### PR TITLE
uber_normal_material lines changes

### DIFF
--- a/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
@@ -424,7 +424,8 @@ void MaterialAdapter::PoulateUsdPreviewSurface(const MaterialParams & params, co
 		}
 		else if (paramName == HdRprTokens->normal)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_NORMAL, materialTexture });
+			m_texRprx.insert({ RPRX_UBER_MATERIAL_DIFFUSE_NORMAL, materialTexture });
+			m_texRprx.insert({ RPRX_UBER_MATERIAL_REFLECTION_NORMAL, materialTexture });
 		}
 		else if (paramName == HdRprTokens->displacement)
 		{


### PR DESCRIPTION
I changed this line in ~/workspace/pkgs/RadeonProRenderUSD/pxr/imaging/plugin/hdRpr/materialAdapter.cpp :
```
		else if (paramName == HdRprTokens->normal)
		{
			m_texRprx.insert({ RPRX_UBER_MATERIAL_NORMAL, materialTexture });
		}
```
with this:
```
		else if (paramName == HdRprTokens->normal)
		{
			m_texRprx.insert({ RPRX_UBER_MATERIAL_DIFFUSE_NORMAL, materialTexture });
			m_texRprx.insert({ RPRX_UBER_MATERIAL_REFLECTION_NORMAL, materialTexture });
		}
```