### PR TITLE
Add transform to dome light

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This plugin allows fast GPU or CPU accelerated viewport rendering on all OpenCL 
 
 For more details on USD, please visit the web site [here](http://openusd.org).
 
-![Alt Text](https://www.dropbox.com/s/adqexgc78v35417/ezgif-2-5eb2f04c90.gif)
+![](https://www.dropbox.com/s/adqexgc78v35417/ezgif-2-5eb2f04c90.gif?raw=1)
 
 Prerequisites
 -----------------------------

--- a/pxr/imaging/plugin/hdRpr/domeLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/domeLight.cpp
@@ -16,6 +16,7 @@ TF_DEFINE_PRIVATE_TOKENS(
 	HdRprDomeLightTokens,
 	(exposure)                                  \
 	(intensity)                                 \
+	(transform)                                 \
 	(params)                                    \
 	(texturePath)
 );
@@ -61,6 +62,9 @@ void HdRprDomeLight::Sync(HdSceneDelegate *sceneDelegate,
 
 		// Extract the exposure of the light
 		float exposure = sceneDelegate->GetLightParamValue(id, HdRprDomeLightTokens->exposure).Get<float>();
+
+		// Extract the transform of the light
+		GfMatrix4d transform = sceneDelegate->Get(id, HdRprDomeLightTokens->transform).Get<GfMatrix4d>();
 		
 		VtValue texturePathValue = sceneDelegate->GetLightParamValue(id, HdRprDomeLightTokens->texturePath);
 
@@ -72,7 +76,7 @@ void HdRprDomeLight::Sync(HdSceneDelegate *sceneDelegate,
 		}
 		
 		float computed_intensity = computeLightIntensity(intensity, exposure);
-		rprApi->CreateEnvironmentLight(path, computed_intensity);
+		rprApi->CreateEnvironmentLight(path, computed_intensity, transform);
 	}
 
 	*dirtyBits = DirtyBits::Clean;

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -319,7 +319,7 @@ public:
 		//unlock();
 	}
 
-	void CreateEnvironmentLight(const std::string & path, float intensity)
+	void CreateEnvironmentLight(const std::string & path, float intensity, const GfMatrix4f & transform)
 	{	
 		rpr_int status;
 		rpr_image image = nullptr;
@@ -335,6 +335,7 @@ public:
 		status = rprContextCreateEnvironmentLight(context, &light);
 		status = rprEnvironmentLightSetImage(light, image);
 		status = rprEnvironmentLightSetIntensityScale(light, intensity);
+		status = rprLightSetTransform(light, false, transform.GetArray());
 		status = rprSceneAttachLight(scene, light);
 		//unlock();
 		isLightPresent = true;
@@ -971,9 +972,10 @@ HdRprPreferences HdRprApiImpl::s_preferences = HdRprPreferences();
 		m_impl->SetMeshVisibility(prototypeMesh, false);
 	}
 
-	void HdRprApi::CreateEnvironmentLight(const std::string & prthTotexture, float intensity)
+	void HdRprApi::CreateEnvironmentLight(const std::string & prthTotexture, float intensity, const GfMatrix4d & transform)
 	{
-		m_impl->CreateEnvironmentLight(prthTotexture, intensity);
+		GfMatrix4f transformF(transform);
+		m_impl->CreateEnvironmentLight(prthTotexture, intensity, transformF);
 		m_impl->SetFramebufferDirty(true);
 	}
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -64,7 +64,7 @@ public:
 
 	void CreateInstances(RprApiObject prototypeMesh, const VtMatrix4dArray & transforms, VtArray<RprApiObject> & out_instances);
 
-	void CreateEnvironmentLight(const std::string & prthTotexture, float intensity);
+	void CreateEnvironmentLight(const std::string & prthTotexture, float intensity, const GfMatrix4d & transform);
 
 	RprApiObject CreateRectLightMesh(const float & width, const float & height);
 


### PR DESCRIPTION
Hello,

Dome lights currently do not respect the authored transform of the light in the USD stage.

This PR gets the transform from the sceneDelegate and adds it to the rprEnvironmentLight, along with defining a new token for the HDRprDomeLight.

Tested locally against USD 18.09.

Thank you,

-Colin