### PR TITLE
Fix: CMake workaround for monolithic USD build

### DIFF
--- a/cmake/modules/FindRif.cmake
+++ b/cmake/modules/FindRif.cmake
@@ -29,6 +29,10 @@ elseif (UNIX)
     if (NOT RIF_LOCATION_LIB)
         set (RIF_LOCATION_LIB ${RIF_LOCATION}/CentOS7/Bin/Release/x64)
     endif ()
+
+    if (NOT RIF_LOCATION_INCLUDE)
+        set (RIF_LOCATION_INCLUDE ${RIF_LOCATION}/CentOS7/RadeonImageFilters)
+    endif ()
 endif()
 
 find_library(RIF_LIBRARY

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -10,6 +10,16 @@ find_path(USD_LIBRARY_DIR
           PATHS ${USD_ROOT}/lib
                 $ENV{USD_ROOT}/lib
           DOC "USD Libraries directory")
+set(USD_LIBRARY_MONOLITHIC FALSE)
+
+if(NOT DEFINED ${USD_LIBRARY_DIR})
+    find_path(USD_LIBRARY_DIR 
+              NAMES libusd_ms.dylib libusd_ms.dll libusd_ms.so
+              PATHS ${USD_ROOT}/lib
+                    $ENV{USD_ROOT}/lib
+              DOC "USD Libraries directory")
+    set(USD_LIBRARY_MONOLITHIC TRUE)
+endif()
 
 if(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
     foreach(_usd_comp MAJOR MINOR PATCH)

--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -44,12 +44,15 @@ if(PXR_ENABLE_RIF_SUPPORT)
 	
 
 endif(PXR_ENABLE_RIF_SUPPORT)
-		
-pxr_plugin(hdRpr
-   LIBRARIES
-		arch
-		sdf
-		trace
+
+if(${USD_LIBRARY_MONOLITHIC})
+    set(USD_LIBRARIES
+            usd_ms)
+else()
+    set(USD_LIBRARIES
+        arch
+        sdf
+        trace
         plug
         tf
         vt
@@ -60,9 +63,14 @@ pxr_plugin(hdRpr
 		hdSt
         hdx
         usdLux
-		pxOsd
-		Half
-		${RPR_LIBRARY}
+        pxOsd)
+endif()
+        
+pxr_plugin(hdRpr
+   LIBRARIES
+        Half
+        ${USD_LIBRARIES}
+        ${RPR_LIBRARY}
         ${RPR_SUPPORT_LIBRARY}
         ${Boost_LIBRARIES}
         ${TBB_LIBRARIES}


### PR DESCRIPTION
Allow user to use monolithic USD 