### PR TITLE
Fix: Broken render device switching

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/rpr.py
+++ b/pxr/imaging/plugin/hdRpr/python/rpr.py
@@ -28,12 +28,13 @@ def setFilter(filter):
 	   lib.SetRprGlobalFilter(filter)
 	   
 	   
-def setRenderDevice(renderDeviceId):
+def setRenderDevice(usdviewApi, renderDeviceId):
     rprPath = getRprPath()
     if rprPath is not None:
-	   print rprPath
-	   lib = cdll.LoadLibrary(rprPath)
-	   lib.SetRprGlobalRenderDevice(renderDeviceId)
+        lib = cdll.LoadLibrary(rprPath)
+        lib.SetRprGlobalRenderDevice(renderDeviceId)
+        usdviewApi._UsdviewApi__appController._reopenStage()
+        usdviewApi._UsdviewApi__appController._rendererPluginChanged('HdRprPlugin')
 	   
 	
 def ColorAov(usdviewApi):
@@ -60,12 +61,12 @@ def EawFilter(usdviewApi):
 	
 	
 def renderDeviceCPU(usdviewApi):
-    setRenderDevice(0)
-	
+    setRenderDevice(usdviewApi, 0)
+
 def renderDeviceGPU(usdviewApi):
-    setRenderDevice(1)
-	
-	
+    setRenderDevice(usdviewApi, 1)
+
+
 class RprPluginContainer(PluginContainer):
 
     def registerPlugins(self, plugRegistry, usdviewApi):

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1498,9 +1498,9 @@ private:
 		delete m_impl;
 	}
 
-	void HdRprApi::SetRenderDevice(const HdRprRenderDevice & renderMode)
+	void HdRprApi::SetRenderDevice(const HdRprRenderDevice & renderDevice)
 	{
-		HdRprPreferences::GetInstance().SetRenderDevice(renderMode);
+		HdRprPreferences::GetInstance().SetRenderDevice(renderDevice);
 	}
 
 	void HdRprApi::SetFilter(const FilterType & type)


### PR DESCRIPTION
GUI render device switching button actually does not really change device type but simply update HdRprPreferences. To really change render device we should somehow reset current context and refill scene. Unfortunately, USD API does not provide the possibility to do some sort of hot reset of renderer plugin, like usdViewApi.RestartPlugin()

I propose shortest in time workaround for this problem but obviously not the most optimal one.