### PR TITLE
Fix: Dynamically derive if GL interoperability can be used

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -119,6 +119,15 @@ pxr_plugin(hdRpr
         plugInfo.json
 )
 
+# LINUX is not listed in default system variables (https://cmake.org/cmake/help/3.15/manual/cmake-variables.7.html)
+if(NOT DEFINED LINUX)
+	if(UNIX AND NOT APPLE AND NOT CYGWIN)
+		set(LINUX TRUE)
+	else(UNIX AND NOT APPLE AND NOT CYGWIN)
+		SET(LINUX FALSE)
+	endif(UNIX AND NOT APPLE AND NOT CYGWIN)
+endif(NOT DEFINED LINUX)
+
 if(WIN32 OR LINUX)
 	add_definitions(-DUSE_GL_INTEROP)
 endif(WIN32 OR LINUX)

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -74,26 +74,26 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const & renderPassStat
 		rprApi->SetCameraProjectionMatrix(proj);
 	}
 
-#ifdef USE_GL_INTEROP
-	GLuint rprFb = rprApi->GetFramebufferGL();
-	GLint restoreTexture, usdReadFB, usdWriteFB;
-	glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &usdReadFB);
-	glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &usdWriteFB);
+	if (rprApi->IsGlInteropUsed()) {
+		GLuint rprFb = rprApi->GetFramebufferGL();
+		GLint restoreTexture, usdReadFB, usdWriteFB;
+		glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &usdReadFB);
+		glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &usdWriteFB);
 
-	glBindFramebuffer(GL_READ_FRAMEBUFFER, rprFb);
-	rprApi->Render();
+		glBindFramebuffer(GL_READ_FRAMEBUFFER, rprFb);
+		rprApi->Render();
 
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, usdWriteFB);
-	glBlitFramebuffer(0, 0, fbSize[0], fbSize[1],
-		0, 0, fbSize[0], fbSize[1],
-		GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, usdWriteFB);
+		glBlitFramebuffer(0, 0, fbSize[0], fbSize[1],
+						  0, 0, fbSize[0], fbSize[1],
+						  GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
 
-	glBindFramebuffer(GL_READ_FRAMEBUFFER_BINDING, usdReadFB);
-	glBindFramebuffer(GL_DRAW_FRAMEBUFFER_BINDING, usdWriteFB);
-#else
-	rprApi->Render();
-	glDrawPixels(fbSize[0], fbSize[1], GL_RGBA, GL_FLOAT, rprApi->GetFramebufferData());
-#endif
+		glBindFramebuffer(GL_READ_FRAMEBUFFER_BINDING, usdReadFB);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER_BINDING, usdWriteFB);
+	} else {
+		rprApi->Render();
+		glDrawPixels(fbSize[0], fbSize[1], GL_RGBA, GL_FLOAT, rprApi->GetFramebufferData());
+	}
 
 }
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -114,17 +114,15 @@ public:
     
 	void GetFramebufferSize(GfVec2i & resolution) const;
 
-#ifdef USE_GL_INTEROP
 	const GLuint GetFramebufferGL() const;
 
-#else
 	const float * GetFramebufferData() const;
-
-#endif
 
 	void DeleteRprApiObject(RprApiObject object);
 
 	void DeleteMesh(RprApiObject mesh);
+
+	bool IsGlInteropUsed() const;
 
 private:
 	HdRprApiImpl * m_impl = nullptr;


### PR DESCRIPTION
When OpenGL context is not set correctly 'glewInit' eventually will fail with error 'Missing GL version'. In case of that, the fallback path will be used, i.e. without GL interoperability.

The proposed changes make it possible to easily add GL interoperability checkbox to usdview GUI.