### PR TITLE
Resolve RPR library path using USD Plugin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,3 @@ If you want the RPR menu added to USDView (allows selecting device, and view mod
 PXR_PLUGINPATH_NAME=${USD_ROOT}/lib/python/rpr
 ```  
 Where USD_ROOT is your USD install directory.
-
-Install psuit:
-pip install psutil
-

--- a/pxr/imaging/plugin/hdRpr/python/rpr.py
+++ b/pxr/imaging/plugin/hdRpr/python/rpr.py
@@ -1,19 +1,22 @@
 from pxr import Tf
+from pxr.Plug import Registry
 from pxr.Usdviewq.plugin import PluginContainer
 
 from ctypes import cdll, c_char_p
 from ctypes.util import find_library
 
-import psutil, os
+import os
 
-def getRprPath():
-    p = psutil.Process( os.getpid() )
-    for dll in p.memory_maps():
-      if dll.path.find("hdRpr") != -1:
-	   return  dll.path
-    print "hdRpr module not loaded"	   
-    return None
-	   
+def getRprPath(_pathCache=[None]):
+    if _pathCache[0]:
+        return _pathCache[0]
+
+    rprPluginType = Registry.FindTypeByName('HdRprPlugin')
+    plugin = Registry().GetPluginForType(rprPluginType)
+    if plugin and plugin.path:
+        _pathCache[0] = plugin.path
+    return _pathCache[0]
+
 def createRprTmpDirIfNeeded(rprLib):
     rprLib.GetRprTmpDir.restype = c_char_p
     rprTmpDir = rprLib.GetRprTmpDir()


### PR DESCRIPTION
## Prerequisite
'memory_maps' was removed on macOS in psutil v5.6.0

## Solution
Using USD API to resolve RPR library path we can remove psutil from required dependencies and eliminate the problem caused by missing 'memory_maps' on macOS