### PR TITLE
don't explicitly use the pxr:: namespace

### DIFF
--- a/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
@@ -189,7 +189,7 @@ void getTextures(const  HdMaterialNetwork & materialNetwork, MaterialTextures & 
 			{
 				auto& assetPath = param.UncheckedGet<SdfAssetPath>();
 				if (assetPath.GetResolvedPath().empty()) {
-					materialNode.Path = pxr::ArGetResolver().Resolve(assetPath.GetAssetPath());
+					materialNode.Path = ArGetResolver().Resolve(assetPath.GetAssetPath());
 				} else {
 					materialNode.Path = assetPath.GetResolvedPath();
 				}

--- a/pxr/imaging/plugin/hdRpr/materialFactory.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialFactory.cpp
@@ -226,7 +226,7 @@ void RprXMaterialFactory::SetMaterialInputs(RprApiMaterial * material, const Mat
 		rpr_image img = NULL;
 		rpr_material_node materialNode = NULL;
 
-		auto textureData = pxr::GlfUVTextureData::New(texParam.second.Path, INT_MAX, 0, 0, 0, 0);
+		auto textureData = GlfUVTextureData::New(texParam.second.Path, INT_MAX, 0, 0, 0, 0);
 		if (!textureData || !textureData->Read(0, false)) {
 			TF_CODING_ERROR("Failed to read image %s", texParam.second.Path.c_str());
 			continue;


### PR DESCRIPTION
...because this may be configured to be something other than default. either
rely on PXR_NAMESPACE_OPEN_SCOPE, or use PXR_NS::