### PR TITLE
Support for per-face-vertex UVs, missing UVs, and explicit normals

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -63,6 +63,7 @@ else()
 		hdSt
         hdx
         usdLux
+        usdUtils
         pxOsd)
 endif()
         

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -56,6 +56,15 @@ enum class FilterType
 	LAST = EawDenoise
 };
 
+enum class InterpolationType
+{
+	NONE = -1,
+	Vertex = 0,
+	FaceVarying,
+	FIRST = Vertex,
+	LAST = FaceVarying
+};
+
 class HdRprApi final
 {
 public:
@@ -75,6 +84,8 @@ public:
 	void Deinit();
 
 	RprApiObject CreateMesh(const VtVec3fArray & points, const VtVec3fArray & normals, const VtVec2fArray & uv, const VtIntArray & indexes, const VtIntArray & vpf);
+
+	RprApiObject CreateMesh(const VtVec3fArray & points, const VtVec3fArray & normals, const InterpolationType normalsInterpolation, const VtVec2fArray & uv, const InterpolationType uvInterpolation, const VtIntArray & indexes, const VtIntArray & vpf);
 
 	RprApiObject CreateCurve(const VtVec3fArray & points, const VtIntArray & indexes, const float & width);
 


### PR DESCRIPTION
Title pretty much says it all - previously, UVs would only work if they were per-vertex, which is a minority of UVs.  It would also raise an error if there were no UVs.

I also added support for explicitly-authored normals to be read from USD.  This should work with per-vertex or per-face-vertex normals.