### PR TITLE
Change usage of RprTools

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -5,8 +5,8 @@
 #include "RadeonProRender_CL.h"
 #include "RadeonProRender_GL.h"
 
-#include "../RprTools.h"
-#include "../RprTools.cpp"
+#include "RprTools.h"
+#include "RprTools.cpp"
 
 #include "material.h"
 #include "materialFactory.h"


### PR DESCRIPTION
So, this may be to open a dialog... as apparently the old way was working for people, but did not for me.

ie, previously, the code would `include "../RprTools.h"`, even though all other rpr includes didn't have the ".." - and all these files are in the same folder in my rpr install

Perhaps this is a detail which varies by OS? On my install for CentOS, all headers, as well as RprTools.h and RprTools.cpp, are all in the same folder.