### PR TITLE
Refactoring: Use new RPR (1.34.1) material system

### DIFF
--- a/cmake/modules/FindRpr.cmake
+++ b/cmake/modules/FindRpr.cmake
@@ -18,30 +18,23 @@ elseif (UNIX)
     endif ()
 endif()
 
-message("RPR location: ${RPR_LOCATION}")
-
 find_library(RPR_LIBRARY
     NAMES  libRadeonProRender64 RadeonProRender64
-    HINTS
+    PATHS
         "${RPR_LOCATION_LIB}"
     DOC
         "Radeon ProRender library path"
-)
-
-find_library(RPR_SUPPORT_LIBRARY
-    NAMES  libSupport64 RprSupport64
-    HINTS
-        "${RPR_LOCATION_LIB}"
-    DOC
-        "Radeon ProRender Support library path"
+    NO_DEFAULT_PATH
 )
 
 find_library(RPR_TAHOE_LIBRARY
     NAMES libTahoe64 Tahoe64
-    HINTS
+    PATHS
         "${RPR_LOCATION_LIB}"
     DOC
-        "Radeon ProRender tahoe library path")
+        "Radeon ProRender tahoe library path"
+    NO_DEFAULT_PATH
+)
 
 include(FindPackageHandleStandardArgs)
 
@@ -49,6 +42,5 @@ find_package_handle_standard_args(Rpr
     REQUIRED_VARS
         RPR_LOCATION_INCLUDE
         RPR_LIBRARY
-        RPR_SUPPORT_LIBRARY
         RPR_TAHOE_LIBRARY
 )

--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -2,16 +2,6 @@ set(PXR_PREFIX pxr/imaging)
 set(PXR_PACKAGE hdRpr)
 add_custom_target(shared_libs)
 
-include(FindPackageHandleStandardArgs)
-
-find_package_handle_standard_args(Rpr
-    REQUIRED_VARS
-        RPR_LOCATION_INCLUDE
-		RPR_LIBRARY
-		RPR_SUPPORT_LIBRARY
-)
-
-
 set(OptLibs ${ARGN})
 set(OptIncludeDir ${ARGN})
 set(OptClass${ARGN})
@@ -70,7 +60,6 @@ pxr_plugin(hdRpr
    LIBRARIES
         ${USD_LIBRARIES}
         ${RPR_LIBRARY}
-        ${RPR_SUPPORT_LIBRARY}
         ${Boost_LIBRARIES}
         ${TBB_LIBRARIES}
         ${GLEW_LIBRARY}
@@ -139,14 +128,6 @@ if (APPLE)
     add_custom_command(TARGET hdRpr
         POST_BUILD COMMAND
         ${CMAKE_INSTALL_NAME_TOOL} -change @loader_path/libRadeonProRender64.dylib ${RPR_LIBRARY} $<TARGET_FILE:hdRpr> )
-
-    add_custom_command(TARGET hdRpr
-        POST_BUILD COMMAND
-        ${CMAKE_INSTALL_NAME_TOOL} -id @rpath/libRprSupport64.dylib  ${RPR_SUPPORT_LIBRARY})
-
-    add_custom_command(TARGET hdRpr
-        POST_BUILD COMMAND
-        ${CMAKE_INSTALL_NAME_TOOL} -change @rpath/libRprSupport64.dylib ${RPR_SUPPORT_LIBRARY} $<TARGET_FILE:hdRpr> )
 endif(APPLE)
 
  _get_install_dir(lib/python/rpr installPrefix)
@@ -172,6 +153,6 @@ install(
     \")")
 
 install(
-    FILES ${RPR_LIBRARY} ${RPR_SUPPORT_LIBRARY} ${RPR_TAHOE_LIBRARY} ${OptLibs}
+    FILES ${RPR_LIBRARY} ${RPR_TAHOE_LIBRARY} ${OptLibs}
     DESTINATION lib
     )

--- a/pxr/imaging/plugin/hdRpr/basisCurves.h
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.h
@@ -30,8 +30,9 @@ protected:
 		HdDirtyBits *dirtyBits) override;
 
 private:
-	HdRprApiWeakPtr m_rprApiWeakPrt;
+	HdRprApiWeakPtr m_rprApiWeakPtr;
 	RprApiObject m_rprCurve = nullptr;
+	std::vector<RprApiMaterial*> m_rprMaterials;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/domeLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/domeLight.cpp
@@ -42,7 +42,7 @@ void HdRprDomeLight::Sync(HdSceneDelegate *sceneDelegate,
 {
 	SdfPath const & id = GetId();
 
-	HdRprApiSharedPtr rprApi = m_rprApiWeakPrt.lock();
+	HdRprApiSharedPtr rprApi = m_rprApiWeakPtr.lock();
 	if (!rprApi)
 	{
 		TF_CODING_ERROR("RprApi is expired");

--- a/pxr/imaging/plugin/hdRpr/domeLight.h
+++ b/pxr/imaging/plugin/hdRpr/domeLight.h
@@ -16,7 +16,7 @@ class HdRprDomeLight : public HdSprim {
 public:
 	HdRprDomeLight(SdfPath const & id, HdRprApiSharedPtr rprApi)
 		: HdSprim(id)
-		, m_rprApiWeakPrt(rprApi) {}
+		, m_rprApiWeakPtr(rprApi) {}
 
 	// change tracking for HdStLight
 	enum DirtyBits : HdDirtyBits {
@@ -44,7 +44,7 @@ public:
 	virtual HdDirtyBits GetInitialDirtyBitsMask() const override;
 
 protected:
-	HdRprApiWeakPtr m_rprApiWeakPrt;
+	HdRprApiWeakPtr m_rprApiWeakPtr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/field.cpp
+++ b/pxr/imaging/plugin/hdRpr/field.cpp
@@ -6,7 +6,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 HdRprField::HdRprField(SdfPath const& id, HdRprApiSharedPtr rprApi) : HdField(id)
 {
-	m_rprApiWeakPrt = rprApi;
+	m_rprApiWeakPtr = rprApi;
 }
 
 HdRprField::~HdRprField()

--- a/pxr/imaging/plugin/hdRpr/field.h
+++ b/pxr/imaging/plugin/hdRpr/field.h
@@ -23,7 +23,7 @@ public:
 protected:
 	virtual HdDirtyBits GetInitialDirtyBitsMask() const override;
 
-	HdRprApiWeakPtr m_rprApiWeakPrt;
+	HdRprApiWeakPtr m_rprApiWeakPtr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/lightBase.cpp
+++ b/pxr/imaging/plugin/hdRpr/lightBase.cpp
@@ -33,10 +33,9 @@ static float computeLightIntensity(float intensity, float exposure)
 }
 
 HdRprLightBase::~HdRprLightBase() {
-	HdRprApiSharedPtr rprApi = m_rprApiWeakPrt.lock();
-	if (m_lightMesh)
-	{
-		rprApi->DeleteMesh(m_lightMesh);
+	if (auto rprApi = m_rprApiWeakPtr.lock()) {
+        rprApi->DeleteMesh(m_lightMesh);
+        rprApi->DeleteMaterial(m_lightMaterial);
 	}
 }
 
@@ -49,7 +48,7 @@ bool HdRprLightBase::IsDirtyMaterial(const GfVec3f & emissionColor)
 
 RprApiMaterial * HdRprLightBase::CreateLightMaterial(const GfVec3f & illumColor)
 {
-	HdRprApiSharedPtr rprApi = m_rprApiWeakPrt.lock();
+	HdRprApiSharedPtr rprApi = m_rprApiWeakPtr.lock();
 	if (!rprApi)
 	{
 		TF_CODING_ERROR("RprApi is expired");
@@ -68,7 +67,7 @@ void HdRprLightBase::Sync(HdSceneDelegate *sceneDelegate,
 {
 	SdfPath const & id = GetId();
 	
-	HdRprApiSharedPtr rprApi = m_rprApiWeakPrt.lock();
+	HdRprApiSharedPtr rprApi = m_rprApiWeakPtr.lock();
 	if (!rprApi)
 	{
 		TF_CODING_ERROR("RprApi is expired");

--- a/pxr/imaging/plugin/hdRpr/lightBase.h
+++ b/pxr/imaging/plugin/hdRpr/lightBase.h
@@ -16,7 +16,7 @@ class HdRprLightBase : public HdLight {
 public:
 	HdRprLightBase(SdfPath const & id, HdRprApiSharedPtr rprApi)
 		: HdLight(id)
-		, m_rprApiWeakPrt(rprApi) {}
+		, m_rprApiWeakPtr(rprApi) {}
 
 	~HdRprLightBase();
 
@@ -62,7 +62,7 @@ protected:
 	// Normalize Light Color with surface area
 	virtual GfVec3f NormalizeLightColor(const GfMatrix4d & transform, std::map<TfToken, float> & params, const GfVec3f & emmisionColor) = 0;
 
-	HdRprApiWeakPtr m_rprApiWeakPrt;
+	HdRprApiWeakPtr m_rprApiWeakPtr;
 
 	// Mesh with emmisive material
 	RprApiObject m_lightMesh = nullptr;

--- a/pxr/imaging/plugin/hdRpr/material.cpp
+++ b/pxr/imaging/plugin/hdRpr/material.cpp
@@ -47,18 +47,21 @@ static const bool getMaterial(const HdMaterialNetworkMap & networkMap, EMaterial
 
 HdRprMaterial::HdRprMaterial(SdfPath const & id, HdRprApiSharedPtr rprApi) : HdMaterial(id) 
 {
-	m_rprApiWeakPrt = rprApi;
+	m_rprApiWeakPtr = rprApi;
 }
 
 HdRprMaterial::~HdRprMaterial()
 {
+    if (auto rprApi = m_rprApiWeakPtr.lock()) {
+        rprApi->DeleteMaterial(m_rprMaterial);
+    }
 }
 
 void HdRprMaterial::Sync(HdSceneDelegate *sceneDelegate,
 	HdRenderParam   *renderParam,
 	HdDirtyBits     *dirtyBits)
 {
-	HdRprApiSharedPtr rprApi = m_rprApiWeakPrt.lock();
+	HdRprApiSharedPtr rprApi = m_rprApiWeakPtr.lock();
 	if (!rprApi)
 	{
 		TF_CODING_ERROR("RprApi is expired");

--- a/pxr/imaging/plugin/hdRpr/material.h
+++ b/pxr/imaging/plugin/hdRpr/material.h
@@ -40,7 +40,7 @@ public:
 	const RprApiMaterial * GetRprMaterialObject() const;
 
 private:
-	HdRprApiWeakPtr m_rprApiWeakPrt;
+	HdRprApiWeakPtr m_rprApiWeakPtr;
 
 	RprApiMaterial * m_rprMaterial = nullptr;
 };

--- a/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
@@ -225,7 +225,7 @@ void getTextures(const  HdMaterialNetwork & materialNetwork, MaterialTextures & 
 			getParam(HdRprTokens->scale, node, param);
 			if (param.IsHolding<GfVec4f>())
 			{
-				materialNode.IsScaleEmable = true;
+				materialNode.IsScaleEnabled = true;
 				materialNode.Scale = param.Get<GfVec4f>();
 			}
 
@@ -233,7 +233,7 @@ void getTextures(const  HdMaterialNetwork & materialNetwork, MaterialTextures & 
 			getParam(HdRprTokens->bias, node, param);
 			if (param.IsHolding<GfVec4f>())
 			{
-				materialNode.IsBiasEmable = true;
+				materialNode.IsBiasEnabled = true;
 				materialNode.Bias = param.Get<GfVec4f>();
 			}
 
@@ -335,8 +335,8 @@ void MaterialAdapter::PoulateTransparent(const MaterialParams & params)
 void MaterialAdapter::PoulateUsdPreviewSurface(const MaterialParams & params, const MaterialTextures & textures)
 {
 	// initial params
-	m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_DIFFUSE_WEIGHT , GfVec4f(1.0f) });
-	m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_REFLECTION_WEIGHT , GfVec4f(1.0f) });
+	m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_DIFFUSE_WEIGHT , GfVec4f(1.0f) });
+	m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_WEIGHT , GfVec4f(1.0f) });
 	
 	int useSpecular = 0;
 	GfVec4f albedoColor = GfVec4f(1.0f);
@@ -355,15 +355,15 @@ void MaterialAdapter::PoulateUsdPreviewSurface(const MaterialParams & params, co
 		if (paramName == HdRprTokens->diffuseColor)
 		{
 			albedoColor = VtValToVec4f(paramValue);
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_DIFFUSE_COLOR , albedoColor });
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_DIFFUSE_COLOR , albedoColor });
 		}
 		else if (paramName == HdRprTokens->emissiveColor)
 		{
 			GfVec4f emmisionColor = VtValToVec4f(paramValue);
 			if (!isColorBlack(emmisionColor))
 			{
-				m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_EMISSION_WEIGHT , GfVec4f(1.0f) });
-				m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_EMISSION_COLOR , emmisionColor });
+				m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_EMISSION_WEIGHT , GfVec4f(1.0f) });
+				m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_EMISSION_COLOR , emmisionColor });
 			}
 		}
 		else if (paramName == HdRprTokens->useSpecularWorkflow)
@@ -376,27 +376,27 @@ void MaterialAdapter::PoulateUsdPreviewSurface(const MaterialParams & params, co
 		}
 		else if (paramName == HdRprTokens->metallic)
 		{
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_REFLECTION_METALNESS, VtValToVec4f(paramValue)});
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_METALNESS, VtValToVec4f(paramValue)});
 		}
 		else if (paramName == HdRprTokens->roughness)
 		{
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_REFLECTION_ROUGHNESS, VtValToVec4f(paramValue)});
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_ROUGHNESS, VtValToVec4f(paramValue)});
 		}
 		else if (paramName == HdRprTokens->clearcoat)
 		{
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_COATING_WEIGHT, VtValToVec4f(paramValue)});
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_COATING_WEIGHT, VtValToVec4f(paramValue)});
 		}
 		else if (paramName == HdRprTokens->clearcoatRoughness)
 		{
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_COATING_ROUGHNESS, VtValToVec4f(paramValue)});
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_COATING_ROUGHNESS, VtValToVec4f(paramValue)});
 		}
 		else if (paramName == HdRprTokens->ior)
 		{
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_REFRACTION_IOR, VtValToVec4f(paramValue)});
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_REFRACTION_IOR, VtValToVec4f(paramValue)});
 		}
 		else if (paramName == HdRprTokens->opacity)
 		{
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_REFRACTION_WEIGHT, GfVec4f(1.0f) - VtValToVec4f(paramValue)});
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_REFRACTION_WEIGHT, GfVec4f(1.0f) - VtValToVec4f(paramValue)});
 		}
 
 	}
@@ -409,12 +409,12 @@ void MaterialAdapter::PoulateUsdPreviewSurface(const MaterialParams & params, co
 		{
 			isAlbedoTexture = true;
 			albedoTex = materialTexture;
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_DIFFUSE_COLOR, materialTexture });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_DIFFUSE_COLOR, materialTexture });
 		}
 		else if (paramName == HdRprTokens->emissiveColor)
 		{
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_EMISSION_WEIGHT , GfVec4f(1.0f) });
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_EMISSION_COLOR, materialTexture });
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_EMISSION_WEIGHT , GfVec4f(1.0f) });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_EMISSION_COLOR, materialTexture });
 		}
 		else if (paramName == HdRprTokens->specularColor)
 		{
@@ -423,63 +423,63 @@ void MaterialAdapter::PoulateUsdPreviewSurface(const MaterialParams & params, co
 		}
 		else if (paramName == HdRprTokens->metallic)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_REFLECTION_METALNESS, materialTexture });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_METALNESS, materialTexture });
 		}
 		else if (paramName == HdRprTokens->roughness)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_REFLECTION_ROUGHNESS, materialTexture });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_ROUGHNESS, materialTexture });
 		}
 		else if (paramName == HdRprTokens->clearcoat)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_COATING_WEIGHT, materialTexture });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_COATING_WEIGHT, materialTexture });
 		}
 		else if (paramName == HdRprTokens->clearcoatRoughness)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_COATING_ROUGHNESS, materialTexture });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_COATING_ROUGHNESS, materialTexture });
 		}
 		else if (paramName == HdRprTokens->ior)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_REFRACTION_IOR, materialTexture });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_REFRACTION_IOR, materialTexture });
 		}
 		else if (paramName == HdRprTokens->opacity)
 		{
 			//materialTexture.IsOneMinusSrcColor = true;
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_REFRACTION_WEIGHT, materialTexture });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_REFRACTION_WEIGHT, materialTexture });
 		}
 		else if (paramName == HdRprTokens->normal)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_DIFFUSE_NORMAL, materialTexture });
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_REFLECTION_NORMAL, materialTexture });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_DIFFUSE_NORMAL, materialTexture });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_NORMAL, materialTexture });
 		}
 		else if (paramName == HdRprTokens->displacement)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_DISPLACEMENT, materialTexture });
+            m_displacementTexture = materialTexture;
 		}
 
 	}
 
 	if(useSpecular) {
-		m_uRprxParams.insert({ RPRX_UBER_MATERIAL_REFLECTION_MODE , RPRX_UBER_MATERIAL_REFLECTION_MODE_PBR});
+		m_uRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_MODE , RPRX_UBER_MATERIAL_REFLECTION_MODE_PBR});
 
 		if (isReflectionTexture)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_REFLECTION_COLOR, reflectionTex });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_COLOR, reflectionTex });
 		}
 		else
 		{
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_REFLECTION_COLOR , reflectionColor });
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_COLOR , reflectionColor });
 		}
 		
 	} else {
-		m_uRprxParams.insert({ RPRX_UBER_MATERIAL_REFLECTION_MODE , RPRX_UBER_MATERIAL_REFLECTION_MODE_METALNESS});
+		m_uRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_MODE , RPRX_UBER_MATERIAL_REFLECTION_MODE_METALNESS});
 
 		if (isAlbedoTexture)
 		{
-			m_texRprx.insert({ RPRX_UBER_MATERIAL_REFLECTION_COLOR, albedoTex });
+			m_texRprx.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_COLOR, albedoTex });
 		}
 		else
 		{
-			m_vec4fRprxParams.insert({ RPRX_UBER_MATERIAL_REFLECTION_COLOR , albedoColor });
+			m_vec4fRprxParams.insert({ RPR_UBER_MATERIAL_INPUT_REFLECTION_COLOR , albedoColor });
 		}
 	}
 

--- a/pxr/imaging/plugin/hdRpr/materialAdapter.h
+++ b/pxr/imaging/plugin/hdRpr/materialAdapter.h
@@ -42,10 +42,10 @@ struct MaterialTexture
 	EWrapMode WrapS = EWrapMode::NONE;
 	EWrapMode WrapT = EWrapMode::NONE;
 
-	bool IsScaleEmable = false;
+	bool IsScaleEnabled = false;
 	GfVec4f Scale;
 
-	bool IsBiasEmable = false;
+	bool IsBiasEnabled = false;
 	GfVec4f Bias;
 };
 
@@ -102,6 +102,11 @@ public:
 		return m_texRprx;
 	}
 
+	const MaterialTexture& GetDisplacementTexture() const
+	{
+	    return m_displacementTexture;
+	}
+
 private:
 	void PoulateRprxColor(const MaterialParams & params);
 	void PoulateRprColor(const MaterialParams & params);
@@ -115,6 +120,8 @@ private:
 	MaterialRprxParamsVec4f m_vec4fRprxParams;
 	MaterialRprxParamsU	m_uRprxParams;
 	MaterialRprxParamsTexture m_texRprx;
+
+    MaterialTexture m_displacementTexture;
 };
 
 

--- a/pxr/imaging/plugin/hdRpr/materialFactory.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialFactory.cpp
@@ -6,7 +6,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 #define SAFE_DELETE_RPR_OBJECT(x) if(x) {rprObjectDelete( x ); x = nullptr;}
 
- bool getWrapType(const EWrapMode & wrapMode, rpr_image_wrap_type & rprWrapType)
+bool getWrapType(const EWrapMode & wrapMode, rpr_image_wrap_type & rprWrapType)
 {
 	switch (wrapMode)
 	{
@@ -50,327 +50,247 @@ bool getSelectedChanel(const EColorChanel & colorChanel, rpr_int & out_selectedC
 	return false;
 }
 
-class RprMaterial : public RprApiMaterial
-{
-public:
-	~RprMaterial() {
-	}
-
-	const rpr_material_node & GetRootRprMaterialNode() const { return m_material; }
-
-	rpr_material_node & GetRootRprMaterialNode() { return m_material; }
-
-private:
-	rpr_material_node m_material;
-};
-
-class RprxMaterial : public RprApiMaterial
-{
-public:
-	~RprxMaterial() {}
-
-	const rprx_material & GetRprxMaterial() const { return m_material; }
-
-	rprx_material & GetRprxMaterial() { return m_material; }
-private:
-	rprx_material m_material;
-};
-
-
-RprMaterialFactory::RprMaterialFactory(rpr_material_system matSys) : m_matSys(matSys)
+RprMaterialFactory::RprMaterialFactory(rpr_material_system matSys, rpr_context rprContext) : m_matSys(matSys), m_context(rprContext)
 {
 }
 
-RprApiMaterial * RprMaterialFactory::CreateMaterial(const EMaterialType type)
+RprApiMaterial* RprMaterialFactory::CreateMaterial(EMaterialType type, const MaterialAdapter & materialAdapter)
 {
-	rpr_material_node_type materialType = 0;
+    rpr_material_node_type materialType = 0;
+
+    switch (type) {
+        case EMaterialType::COLOR:
+            materialType = RPR_MATERIAL_NODE_DIFFUSE;
+            break;
+        case EMaterialType::EMISSIVE:
+            materialType = RPR_MATERIAL_NODE_EMISSIVE;
+            break;
+        case EMaterialType::TRANSPERENT:
+            materialType = RPR_MATERIAL_NODE_TRANSPARENT;
+            break;
+        case EMaterialType::USD_PREVIEW_SURFACE:
+            materialType = RPR_MATERIAL_NODE_UBERV2;
+            break;
+        default:
+            return nullptr;
+    }
+
+    auto material = new RprApiMaterial;
+    rprMaterialSystemCreateNode(m_matSys, materialType, &material->rootMaterial);
+
+    for (auto const& param : materialAdapter.GetVec4fRprParams())
+    {
+        const TfToken & paramName = param.first;
+        const GfVec4f & paramValue = param.second;
+
+        rprMaterialNodeSetInputF(material->rootMaterial, paramName.data(), paramValue[0], paramValue[1], paramValue[2], paramValue[3]);
+    }
+
+    for (auto const& param : materialAdapter.GetVec4fRprxParams())
+    {
+        const uint32_t & paramId = param.first;
+        const GfVec4f & paramValue = param.second;
+
+        rprMaterialNodeSetInputFByKey(material->rootMaterial, paramId, paramValue[0], paramValue[1], paramValue[2], paramValue[3]);
+    }
+
+    for (auto param : materialAdapter.GetURprxParams())
+    {
+        const uint32_t & paramId = param.first;
+        const uint32_t & paramValue = param.second;
+
+        rprMaterialNodeSetInputUByKey(material->rootMaterial, paramId, paramValue);
+    }
+
+    auto getTextureMaterialNode = [](rpr_context rprContext, rpr_material_system matSys, MaterialTexture const& matTex) -> rpr_material_node {
+        if (matTex.Path.empty()) {
+            return nullptr;
+        }
+
+        rpr_image_wrap_type rprWrapSType;
+        rpr_image_wrap_type rprWrapTType;
+
+        rpr_int status = RPR_SUCCESS;
+        rpr_image img = nullptr;
+        rpr_material_node materialNode = nullptr;
+
+        auto textureData = GlfUVTextureData::New(matTex.Path, INT_MAX, 0, 0, 0, 0);
+        if (!textureData || !textureData->Read(0, false)) {
+            TF_CODING_ERROR("Failed to read image %s", matTex.Path.c_str());
+            return nullptr;
+        }
+
+        rpr_image_format format = {};
+        int bytesPerChannel = 0;
+        switch (textureData->GLType()) {
+            case GL_UNSIGNED_BYTE:
+                format.type = RPR_COMPONENT_TYPE_UINT8;
+                bytesPerChannel = 1;
+                break;
+            case GL_HALF_FLOAT:
+                format.type = RPR_COMPONENT_TYPE_FLOAT16;
+                bytesPerChannel = 2;
+                break;
+            case GL_FLOAT:
+                format.type = RPR_COMPONENT_TYPE_FLOAT32;
+                bytesPerChannel = 4;
+                break;
+            default:
+                TF_CODING_ERROR("Failed to create image %s. Unsupported pixel data GLtype: %#x", matTex.Path.c_str(), textureData->GLType());
+                return nullptr;
+        }
+
+        switch (textureData->GLFormat()) {
+            case GL_RED:
+                format.num_components = 1;
+                break;
+            case GL_RG:
+                format.num_components = 2;
+                break;
+            case GL_RGB:
+                format.num_components = 3;
+                break;
+            case GL_RGBA:
+                format.num_components = 4;
+                break;
+            default:
+                TF_CODING_ERROR("Failed to create image %s. Unsupported pixel data GLformat: %#x", matTex.Path.c_str(), textureData->GLFormat());
+                return nullptr;
+        }
+        int bytesPerPixel = bytesPerChannel * format.num_components;
+
+        rpr_image_desc desc = {};
+        desc.image_width = textureData->ResizedWidth();
+        desc.image_height = textureData->ResizedHeight();
+        desc.image_depth = 1;
+        desc.image_row_pitch = bytesPerPixel * desc.image_width;
+        desc.image_slice_pitch = desc.image_row_pitch * desc.image_height;
+        status = rprContextCreateImage(rprContext, format, &desc, textureData->GetRawBuffer(), &img);
+        if (status != RPR_SUCCESS) {
+            TF_CODING_ERROR("Failed to create image %s  Error code %d", matTex.Path.c_str(), status);
+            return nullptr;
+        }
+
+        if (getWrapType(matTex.WrapS, rprWrapSType) && getWrapType(matTex.WrapT, rprWrapTType))
+        {
+            if (rprWrapSType != rprWrapTType)
+            {
+                TF_CODING_WARNING("RPR renderer does not support different WrapS and WrapT modes");
+            }
+            rprImageSetWrap(img, rprWrapSType);
+        }
 
 
-	if (type == EMaterialType::COLOR)
-	{
-		materialType = RPR_MATERIAL_NODE_DIFFUSE;
-	}
+        rprMaterialSystemCreateNode(matSys, RPR_MATERIAL_NODE_IMAGE_TEXTURE, &materialNode);
+        rprMaterialNodeSetInputImageData(materialNode, "data", img);
 
-	if (type == EMaterialType::EMISSIVE)
-	{
-		materialType = RPR_MATERIAL_NODE_EMISSIVE;
-	}
+        // TODO: one minus src color
 
-	if (type == EMaterialType::TRANSPERENT)
-	{
-		materialType = RPR_MATERIAL_NODE_TRANSPARENT;
-	}
+        if (matTex.IsScaleEnabled || matTex.IsBiasEnabled)
+        {
+            rpr_material_node uv_node = nullptr;
+            status = rprMaterialSystemCreateNode(matSys, RPR_MATERIAL_NODE_INPUT_LOOKUP, &uv_node);
+            status = rprMaterialNodeSetInputU(uv_node, "value", RPR_MATERIAL_NODE_LOOKUP_UV);
 
-	if (!materialType)
-	{
-		return nullptr;
-	}
+            rpr_material_node uv_scaled_node;
+            rpr_material_node uv_bias_node;
 
-	RprMaterial * material = new RprMaterial();
-	material->SetType(type);
 
-	rpr_material_node & rootMaterialNode = material->GetRootRprMaterialNode();
+            if (matTex.IsScaleEnabled)
+            {
+                const GfVec4f & scale = matTex.Scale;
+                status = rprMaterialSystemCreateNode(matSys, RPR_MATERIAL_NODE_ARITHMETIC, &uv_scaled_node);
 
-	rprMaterialSystemCreateNode(m_matSys, materialType, &rootMaterialNode);
-	return material;
+                status = rprMaterialNodeSetInputU(uv_scaled_node, "op", RPR_MATERIAL_NODE_OP_MUL);
+                status = rprMaterialNodeSetInputN(uv_scaled_node, "color0", uv_node);
+                status = rprMaterialNodeSetInputF(uv_scaled_node, "color1", scale[0], scale[1], scale[2], 0);
+            }
 
+            if (matTex.IsBiasEnabled)
+            {
+                const GfVec4f & bias = matTex.Bias;
+                rpr_material_node & color0Input = (matTex.IsScaleEnabled) ? uv_scaled_node : uv_node;
+
+                status = rprMaterialSystemCreateNode(matSys, RPR_MATERIAL_NODE_ARITHMETIC, &uv_bias_node);
+
+                status = rprMaterialNodeSetInputU(uv_bias_node, "op", RPR_MATERIAL_NODE_OP_ADD);
+                status = rprMaterialNodeSetInputN(uv_bias_node, "color0", color0Input);
+                status = rprMaterialNodeSetInputF(uv_bias_node, "color1", bias[0], bias[1], bias[2], 0);
+            }
+
+            rpr_material_node & uvIn = (matTex.IsBiasEnabled) ? uv_bias_node : uv_scaled_node;
+            rprMaterialNodeSetInputN(materialNode, "uv", uvIn);
+
+        }
+
+        rpr_material_node outTexture = nullptr;
+        if (matTex.Chanel != EColorChanel::NONE)
+        {
+            rpr_int selectedChanel = 0;
+
+            if (getSelectedChanel(matTex.Chanel, selectedChanel))
+            {
+                rpr_material_node arithmetic = nullptr;
+                status = rprMaterialSystemCreateNode(matSys, RPR_MATERIAL_NODE_ARITHMETIC, &arithmetic);
+                status = rprMaterialNodeSetInputN(arithmetic, "color0", materialNode);
+                status = rprMaterialNodeSetInputF(arithmetic, "color1", 0.0, 0.0, 0.0, 0.0);
+                status = rprMaterialNodeSetInputU(arithmetic, "op", selectedChanel);
+
+                outTexture = arithmetic;
+            }
+            else
+            {
+                outTexture = materialNode;
+            }
+        }
+        else
+        {
+            outTexture = materialNode;
+        }
+
+        return outTexture;
+    };
+
+    for (auto const& texParam : materialAdapter.GetTexRprxParams())
+    {
+        const uint32_t & paramId = texParam.first;
+        const MaterialTexture & matTex = texParam.second;
+
+        rpr_material_node outTexture = getTextureMaterialNode(m_context, m_matSys, matTex);
+        if (!outTexture) {
+            continue;
+        }
+
+        rprMaterialNodeSetInputNByKey(material->rootMaterial, paramId, outTexture);
+    }
+
+    material->displacementMaterial = getTextureMaterialNode(m_context, m_matSys, materialAdapter.GetDisplacementTexture());
+
+    return material;
+}
+
+void RprMaterialFactory::DeleteMaterial(RprApiMaterial* material)
+{
+    if (!material) {
+        return;
+    }
+
+    SAFE_DELETE_RPR_OBJECT(material->rootMaterial);
+    SAFE_DELETE_RPR_OBJECT(material->displacementMaterial);
+    delete material;
 }
 
 void RprMaterialFactory::AttachMaterialToShape(rpr_shape mesh, const RprApiMaterial * material)
 {
-	const RprMaterial * rprMaterial = static_cast<const RprMaterial *>(material);
-	rprShapeSetMaterial(mesh, rprMaterial->GetRootRprMaterialNode());
+	rprShapeSetMaterial(mesh, material->rootMaterial);
+	if (material->displacementMaterial) {
+	    rprShapeSetDisplacementMaterial(mesh, material->displacementMaterial);
+	}
 }
 
 void RprMaterialFactory::AttachCurveToShape(rpr_shape curve, const RprApiMaterial * material)
 {
-	const RprMaterial * rprMaterial = static_cast<const RprMaterial *>(material);
-	rprCurveSetMaterial(curve, rprMaterial->GetRootRprMaterialNode());
+	rprCurveSetMaterial(curve, material->rootMaterial);
 }
-
-void RprMaterialFactory::SetMaterialInputs(RprApiMaterial * material, const MaterialAdapter & materialAdapter)
-{
-	RprMaterial * rprMaterial = static_cast<RprMaterial *>(material);
-
-	for (auto param : materialAdapter.GetVec4fRprParams())
-	{
-		const TfToken & paramName = param.first;
-		const GfVec4f & paramValue = param.second;
-
-		rprMaterialNodeSetInputF(rprMaterial->GetRootRprMaterialNode(), paramName.data(), paramValue[0], paramValue[1], paramValue[2], paramValue[3]);
-	}
-}
-
-void RprMaterialFactory::DeleteMaterial(RprApiMaterial * rprmaterial)
-{
-	RprMaterial * rprMaterial = static_cast<RprMaterial *>(rprmaterial);
-	SAFE_DELETE_RPR_OBJECT(rprMaterial->GetRootRprMaterialNode());
-}
-
-
-
-
-RprXMaterialFactory::RprXMaterialFactory(rpr_material_system matSys, rpr_context rprContext) : m_matSys(matSys), m_context(rprContext){
-	rprxCreateContext(m_matSys, 0, &m_contextX);
-}
-
-RprXMaterialFactory::~RprXMaterialFactory()
-{
-	rprxDeleteContext(m_contextX);
-}
-
-RprApiMaterial * RprXMaterialFactory::CreateMaterial(const EMaterialType type)
-{
-	rpr_material_node_type materialType = 0;
-
-	materialType = RPRX_MATERIAL_UBER;
-
-	if (!materialType)
-	{
-		return nullptr;
-	}
-
-	RprxMaterial * material = new RprxMaterial();
-	material->SetType(type);
-
-	rprx_material & rprxMaterial = material->GetRprxMaterial();
-
-	rprxCreateMaterial(m_contextX, materialType, &rprxMaterial);
-
-	return material;
-}
-
-void RprXMaterialFactory::AttachMaterialToShape(rpr_shape mesh, const RprApiMaterial * material)
-{
-	const RprxMaterial * rprxMaterial = static_cast<const RprxMaterial *>(material);
-	rprxShapeAttachMaterial(m_contextX, mesh, rprxMaterial->GetRprxMaterial());
-
-	rprxMaterialCommit(m_contextX, rprxMaterial->GetRprxMaterial());
-
-}
-
-void RprXMaterialFactory::AttachCurveToShape(rpr_shape mesh, const RprApiMaterial * material)
-{
-	// No-op
-}
-
-void RprXMaterialFactory::SetMaterialInputs(RprApiMaterial * material, const MaterialAdapter & materialAdapter)
-{
-	RprxMaterial * rprxMaterial = static_cast<RprxMaterial *>(material);
-
-	for (auto param : materialAdapter.GetVec4fRprxParams())
-	{
-		const uint32_t & paramId = param.first;
-		const GfVec4f & paramValue = param.second;
-
-		rprxMaterialSetParameterF(m_contextX, rprxMaterial->GetRprxMaterial(), paramId, paramValue[0], paramValue[1], paramValue[2], paramValue[3]);
-	}
-
-	for (auto param : materialAdapter.GetURprxParams())
-	{
-		const uint32_t & paramId = param.first;
-		const uint32_t & paramValue = param.second;
-
-		rprxMaterialSetParameterU(m_contextX, rprxMaterial->GetRprxMaterial(), paramId, paramValue);
-	}
-
-	for (auto const& texParam : materialAdapter.GetTexRprxParams())
-	{
-		rpr_int status;
-		const uint32_t & paramId = texParam.first;
-		const MaterialTexture & matTex = texParam.second;
-
-		rpr_image_wrap_type rprWrapSType;
-		rpr_image_wrap_type rprWrapTType;
-
-		rpr_image img = NULL;
-		rpr_material_node materialNode = NULL;
-
-		auto textureData = GlfUVTextureData::New(texParam.second.Path, INT_MAX, 0, 0, 0, 0);
-		if (!textureData || !textureData->Read(0, false)) {
-			TF_CODING_ERROR("Failed to read image %s", texParam.second.Path.c_str());
-			continue;
-		}
-
-		rpr_image_format format = {};
-		int bytesPerChannel = 0;
-		switch (textureData->GLType()) {
-			case GL_UNSIGNED_BYTE:
-				format.type = RPR_COMPONENT_TYPE_UINT8;
-				bytesPerChannel = 1;
-				break;
-			case GL_HALF_FLOAT:
-				format.type = RPR_COMPONENT_TYPE_FLOAT16;
-				bytesPerChannel = 2;
-				break;
-			case GL_FLOAT:
-				format.type = RPR_COMPONENT_TYPE_FLOAT32;
-				bytesPerChannel = 4;
-				break;
-			default:
-				TF_CODING_ERROR("Failed to create image %s. Unsupported pixel data GLtype: %#x", texParam.second.Path.c_str(), textureData->GLType());
-				continue;
-		}
-
-		switch (textureData->GLFormat()) {
-			case GL_RED:
-				format.num_components = 1;
-				break;
-			case GL_RG:
-				format.num_components = 2;
-				break;
-			case GL_RGB:
-				format.num_components = 3;
-				break;
-			case GL_RGBA:
-				format.num_components = 4;
-				break;
-			default:
-				TF_CODING_ERROR("Failed to create image %s. Unsupported pixel data GLformat: %#x", texParam.second.Path.c_str(), textureData->GLFormat());
-				continue;
-		}
-		int bytesPerPixel = bytesPerChannel * format.num_components;
-
-		rpr_image_desc desc = {};
-		desc.image_width = textureData->ResizedWidth();
-		desc.image_height = textureData->ResizedHeight();
-		desc.image_depth = 1;
-		desc.image_row_pitch = bytesPerPixel * desc.image_width;
-		desc.image_slice_pitch = desc.image_row_pitch * desc.image_height;
-		status = rprContextCreateImage(m_context, format, &desc, textureData->GetRawBuffer(), &img);
-		if (status != RPR_SUCCESS) {
-			TF_CODING_ERROR("Failed to create image %s  Error code %d", texParam.second.Path.c_str(), status);
-			continue;
-		}
-
-		if (getWrapType(matTex.WrapS, rprWrapSType) && getWrapType(matTex.WrapT, rprWrapTType))
-		{
-			if (rprWrapSType != rprWrapTType)
-			{
-				TF_CODING_WARNING("RPR renderer does not support different WrapS and WrapT modes");
-			}
-			rprImageSetWrap(img, rprWrapSType);
-		}
-
-		
-		rprMaterialSystemCreateNode(m_matSys, RPR_MATERIAL_NODE_IMAGE_TEXTURE, &materialNode);
-		rprMaterialNodeSetInputImageData(materialNode, "data", img);
-
-		// TODO: one minus src color
-
-
-		if (matTex.IsScaleEmable || matTex.IsBiasEmable)
-		{
-			rpr_material_node uv_node = NULL;
-			status = rprMaterialSystemCreateNode(m_matSys, RPR_MATERIAL_NODE_INPUT_LOOKUP, &uv_node);
-			status = rprMaterialNodeSetInputU(uv_node, "value", RPR_MATERIAL_NODE_LOOKUP_UV);
-
-			rpr_material_node uv_scaled_node;
-			rpr_material_node uv_bias_node;
-
-			
-			if (matTex.IsScaleEmable)
-			{
-				const GfVec4f & scale = matTex.Scale;
-				status = rprMaterialSystemCreateNode(m_matSys, RPR_MATERIAL_NODE_ARITHMETIC, &uv_scaled_node);
-
-				status = rprMaterialNodeSetInputU(uv_scaled_node, "op", RPR_MATERIAL_NODE_OP_MUL);
-				status = rprMaterialNodeSetInputN(uv_scaled_node, "color0", uv_node);
-				status = rprMaterialNodeSetInputF(uv_scaled_node, "color1", scale[0], scale[1], scale[2], 0);
-			}
-
-			if (matTex.IsBiasEmable)
-			{
-				const GfVec4f & bias = matTex.Bias;
-				rpr_material_node & color0Input = (matTex.IsScaleEmable) ? uv_scaled_node : uv_node;
-				
-				status = rprMaterialSystemCreateNode(m_matSys, RPR_MATERIAL_NODE_ARITHMETIC, &uv_bias_node);
-				
-				status = rprMaterialNodeSetInputU(uv_bias_node, "op", RPR_MATERIAL_NODE_OP_ADD);
-				status = rprMaterialNodeSetInputN(uv_bias_node, "color0", color0Input);
-				status = rprMaterialNodeSetInputF(uv_bias_node, "color1", bias[0], bias[1], bias[2], 0);
-			}
-
-			rpr_material_node & uvIn = (matTex.IsBiasEmable) ? uv_bias_node : uv_scaled_node;
-			rprMaterialNodeSetInputN(materialNode, "uv", uvIn);
-		
-		}
-
-		rpr_material_node outTexture = NULL;
-		if (matTex.Chanel != EColorChanel::NONE)
-		{
-			rpr_int selectedChanel = NULL;
-			
-			if (getSelectedChanel(matTex.Chanel, selectedChanel))
-			{
-				rpr_material_node arithmetic = NULL;
-				status = rprMaterialSystemCreateNode(m_matSys, RPR_MATERIAL_NODE_ARITHMETIC, &arithmetic);
-				status = rprMaterialNodeSetInputN(arithmetic, "color0", materialNode);
-				status = rprMaterialNodeSetInputF(arithmetic, "color1", 0.0, 0.0, 0.0, 0.0);
-				status = rprMaterialNodeSetInputU(arithmetic, "op", selectedChanel);
-
-				outTexture = arithmetic;
-			}
-			else
-			{
-				outTexture = materialNode;
-			}
-		}
-		else
-		{
-			outTexture = materialNode;
-		}
-
-		rprxMaterialSetParameterN(m_contextX, rprxMaterial->GetRprxMaterial(), paramId, outTexture);
-	}
-}
-
-void RprXMaterialFactory::DeleteMaterial(RprApiMaterial * material)
-{
-	RprxMaterial * rprxMaterial = static_cast<RprxMaterial *>(material);
-	rprxMaterialDelete(m_contextX, rprxMaterial->GetRprxMaterial());
-	delete rprxMaterial;
-}
-
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/materialFactory.h
+++ b/pxr/imaging/plugin/hdRpr/materialFactory.h
@@ -4,91 +4,33 @@
 #include "pxr/pxr.h"
 
 #include "RadeonProRender.h"
-#include "RprSupport.h"
 
 #include "materialAdapter.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class RprApiMaterial
-{
-public:
-	void SetType(EMaterialType type)
-	{
-		m_type = type;
-	}
-	EMaterialType GetType() const
-	{
-		return m_type;
-	}
-
-
-protected:
-	virtual ~RprApiMaterial() {}
-	EMaterialType m_type;
+struct RprApiMaterial {
+    rpr_material_node rootMaterial;
+    rpr_material_node displacementMaterial;
 };
 
-class MaterialFactory
+class RprMaterialFactory
 {
 public:
-	virtual ~MaterialFactory() {}
+    RprMaterialFactory(rpr_material_system matSys, rpr_context rprContext);
 
-	virtual RprApiMaterial * CreateMaterial(const EMaterialType type) = 0;
+	RprApiMaterial* CreateMaterial(EMaterialType type, const MaterialAdapter & materialAdapter);
 
-	virtual void DeleteMaterial(RprApiMaterial * rprmaterial) = 0;
+	void DeleteMaterial(RprApiMaterial * rprmaterial);
 
-	virtual void AttachMaterialToShape(rpr_shape mesh, const RprApiMaterial * material) = 0;
+	void AttachMaterialToShape(rpr_shape mesh, const RprApiMaterial* material);
 
-	virtual void AttachCurveToShape(rpr_shape mesh, const RprApiMaterial * material) = 0;
-
-	virtual void SetMaterialInputs(RprApiMaterial * material, const MaterialAdapter & materialAdapter) = 0;
-};
-
-class RprMaterialFactory : public MaterialFactory
-{
-public:
-	RprMaterialFactory(rpr_material_system matSys);
-
-	virtual RprApiMaterial * CreateMaterial(const EMaterialType type) override;
-
-	virtual void AttachMaterialToShape(rpr_shape mesh, const RprApiMaterial * material) override;
-
-	virtual void AttachCurveToShape(rpr_shape mesh, const RprApiMaterial * material) override;
-
-	virtual void SetMaterialInputs(RprApiMaterial * material, const MaterialAdapter & materialAdapter) override;
-
-	virtual void DeleteMaterial(RprApiMaterial * rprmaterial) override;
+	void AttachCurveToShape(rpr_shape mesh, const RprApiMaterial* material);
 
 private:
-	rpr_material_system m_matSys;
+    rpr_material_system m_matSys;
+    rpr_context m_context;
 };
-
-
-class RprXMaterialFactory : public MaterialFactory
-{
-public:
-	RprXMaterialFactory(rpr_material_system matSys, rpr_context rprContext);
-
-	~RprXMaterialFactory();
-
-	virtual RprApiMaterial * CreateMaterial(const EMaterialType type) override;
-
-	virtual void AttachMaterialToShape(rpr_shape mesh, const RprApiMaterial * material) override;
-
-	virtual void AttachCurveToShape(rpr_shape mesh, const RprApiMaterial * material) override;
-
-	virtual void SetMaterialInputs(RprApiMaterial * material, const MaterialAdapter & materialAdapter) override;
-
-	virtual void DeleteMaterial(RprApiMaterial * material) override;
-
-private:
-	const rpr_material_system m_matSys;
-
-	const rpr_context m_context;
-
-	rprx_context m_contextX = nullptr;
-};
-
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -17,6 +17,7 @@ public:
 	HF_MALLOC_TAG_NEW("new HdRprMesh");
 
 	HdRprMesh(SdfPath const& id, HdRprApiSharedPtr rprApi, SdfPath const& instancerId = SdfPath());
+	~HdRprMesh() override;
 
 	virtual void Sync(
 		HdSceneDelegate* sceneDelegate,
@@ -61,9 +62,10 @@ protected:
 		
 private:
 
-	HdRprApiWeakPtr m_rprApiWeakPrt;
+	HdRprApiWeakPtr m_rprApiWeakPtr;
 	RprApiObject m_rprMesh = nullptr;
 	VtArray<RprApiObject> m_rprMeshInstances;
+	RprApiMaterial* m_fallbackMaterial = nullptr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rectLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/rectLight.cpp
@@ -44,7 +44,7 @@ const TfTokenVector & HdRprRectLight::FetchLightGeometryParamNames() const
 RprApiObject HdRprRectLight::CreateLightMesh(std::map<TfToken, float> & params)
 {
 	
-	HdRprApiSharedPtr rprApi = m_rprApiWeakPrt.lock();
+	HdRprApiSharedPtr rprApi = m_rprApiWeakPtr.lock();
 	if (!rprApi)
 	{
 		TF_CODING_ERROR("RprApi is expired");

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -22,7 +22,7 @@ HdRprRenderPass::HdRprRenderPass(HdRenderIndex * index
 )
 	: HdRenderPass(index, collection)
 {
-	m_rprApiWeakPrt = rprApiShader;
+	m_rprApiWeakPtr = rprApiShader;
 }
 
 HdRprRenderPass::~HdRprRenderPass()
@@ -39,7 +39,7 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const & renderPassStat
 		return;
 	}
 
-	HdRprApiSharedPtr rprApi = m_rprApiWeakPrt.lock();
+	HdRprApiSharedPtr rprApi = m_rprApiWeakPtr.lock();
 	if (!rprApi)
 	{
 		TF_CODING_ERROR("RprApi is expired");

--- a/pxr/imaging/plugin/hdRpr/renderPass.h
+++ b/pxr/imaging/plugin/hdRpr/renderPass.h
@@ -51,7 +51,7 @@ private:
 	// -----------------------------------------------------------------------
 	// Internal API
 
-	HdRprApiWeakPtr m_rprApiWeakPrt;
+	HdRprApiWeakPtr m_rprApiWeakPtr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1,6 +1,5 @@
 #include "rprApi.h"
 
-#include "RprSupport.h"
 #include "RadeonProRender.h"
 #include "RadeonProRender_CL.h"
 #include "RadeonProRender_GL.h"
@@ -70,7 +69,7 @@ inline bool rprIsErrorCheck(const TfCallContext &context, const rpr_status statu
 		return false;
 	}
 
-	const char * rprErrorString = [](const rpr_status s)-> const char * {
+	std::string rprErrorString = [](const rpr_status s) -> std::string {
 		switch (s)
 		{
 		case RPR_ERROR_INVALID_API_VERSION: return "invalide api version";
@@ -80,13 +79,13 @@ inline bool rprIsErrorCheck(const TfCallContext &context, const rpr_status statu
 			break;
 		}
 
-		return "unknown error";
+		return "error code - " + std::to_string(s);
 	}(status);
 
 	const size_t maxBufferSize = 1024;
 	char buffer[maxBufferSize];
 
-	snprintf(buffer, maxBufferSize, "%s %s: %s", "[RPR ERROR] ", messageOnFail.c_str(), rprErrorString);
+	snprintf(buffer, maxBufferSize, "%s %s: %s", "[RPR ERROR] ", messageOnFail.c_str(), rprErrorString.c_str());
 	Tf_PostErrorHelper(context, TF_DIAGNOSTIC_CODING_ERROR_TYPE, buffer);
 
 	return true;
@@ -359,6 +358,11 @@ public:
 
 	void Deinit()
 	{
+	    for (auto material : m_materialsToRelease) {
+	        DeleteMaterial(material);
+	    }
+	    m_materialsToRelease.clear();
+
 		DeleteFramebuffers();
 
 		SAFE_DELETE_RPR_OBJECT(m_scene);
@@ -471,15 +475,8 @@ public:
 
 	void SetMeshMaterial(rpr_shape mesh, const RprApiMaterial * material)
 	{
-		MaterialFactory * materialFactory = GetMaterialFactory(material->GetType());
-		
-		if (!materialFactory)
-		{
-			return;
-		}
-
 		lock();
-		materialFactory->AttachMaterialToShape(mesh, material);
+		m_rprMaterialFactory->AttachMaterialToShape(mesh, material);
 		unlock();
 	}
 	void SetMeshHeteroVolume(rpr_shape mesh, const RprApiObject heteroVolume)
@@ -489,15 +486,8 @@ public:
 
 	void SetCurveMaterial(rpr_shape curve, const RprApiMaterial * material)
 	{
-		MaterialFactory * materialFactory = GetMaterialFactory(material->GetType());
-
-		if (!materialFactory)
-		{
-			return;
-		}
-		
 		lock();
-		materialFactory->AttachCurveToShape(curve, material);
+		m_rprMaterialFactory->AttachCurveToShape(curve, material);
 		unlock();
 	}
 
@@ -740,23 +730,21 @@ public:
 
 	}
 
-	RprApiMaterial * CreateMaterial(const MaterialAdapter & materialAdapter)
+	RprApiMaterial* CreateMaterial(const MaterialAdapter & materialAdapter)
 	{
-		MaterialFactory * materialFactory = GetMaterialFactory(materialAdapter.GetType());
-
-		if (!materialFactory)
-		{
-			return nullptr;
-		}
-
 		lock();
-		RprApiMaterial * material = materialFactory->CreateMaterial(materialAdapter.GetType());
-
-		materialFactory->SetMaterialInputs(material, materialAdapter);
+		auto material = m_rprMaterialFactory->CreateMaterial(materialAdapter.GetType(), materialAdapter);
 		unlock();
 
 		return material;
 	}
+
+    void DeleteMaterial(RprApiMaterial* material)
+    {
+        lock();
+        m_rprMaterialFactory->DeleteMaterial(material);
+        unlock();
+    }
 
 	void * CreateHeterVolume(const VtArray<float> & gridDencityData, const VtArray<size_t> & indexesDencity, const VtArray<float> & gridAlbedoData, const VtArray<unsigned int> & indexesAlbedo, const GfVec3i & grigSize)
 	{
@@ -827,6 +815,7 @@ public:
 		{
 			return nullptr;
 		}
+        m_materialsToRelease.push_back(transperantMaterial);
 
 		GfMatrix4f meshTransform;
 		GfVec3f volumeSize = GfVec3f(voxelSize[0] * grigSize[0], voxelSize[1] * grigSize[1], voxelSize[2] * grigSize[2]);
@@ -1121,7 +1110,11 @@ public:
 
 	void DeleteMesh(void * mesh)
 	{
-		rpr_int status;
+	    if (!mesh) {
+	        return;
+	    }
+
+	    rpr_int status;
 
 		lock();
 
@@ -1199,8 +1192,7 @@ private:
 
 		if(RPR_ERROR_CHECK(rprContextCreateMaterialSystem(m_context, 0, &m_matsys), "Fail create Material System resolve")) return;
 
-		m_rprMaterialFactory.reset(new RprMaterialFactory(m_matsys));
-		m_rprxMaterialFactory.reset(new RprXMaterialFactory(m_matsys, m_context));
+		m_rprMaterialFactory.reset(new RprMaterialFactory(m_matsys, m_context));
 	}
 
 
@@ -1330,27 +1322,7 @@ private:
 		}
 	}
 
-
-	MaterialFactory * GetMaterialFactory(const EMaterialType type)
-	{
-		switch (type)
-		{
-		case EMaterialType::USD_PREVIEW_SURFACE:
-			return m_rprxMaterialFactory.get();
-
-		case EMaterialType::COLOR:
-		case EMaterialType::EMISSIVE:
-		case EMaterialType::TRANSPERENT:
-			return m_rprMaterialFactory.get();
-		default:
-				break;
-		}
-
-		TF_CODING_WARNING("Unknown material type");
-		return nullptr;
-	}
-
-    const rpr_framebuffer GetTargetFB() const
+	const rpr_framebuffer GetTargetFB() const
     {
 		switch (HdRprPreferences::GetInstance().GetAov())
         {
@@ -1514,7 +1486,6 @@ private:
 
 
 	std::unique_ptr<RprMaterialFactory> m_rprMaterialFactory;
-	std::unique_ptr<RprXMaterialFactory> m_rprxMaterialFactory;
 
 	bool m_isLightPresent = false;
 
@@ -1523,6 +1494,8 @@ private:
     bool m_isRenderModeDirty = true;
 
     HdRprAov m_currentAov = HdRprAov::COLOR;
+
+    std::vector<RprApiMaterial*> m_materialsToRelease;
 
 	// simple spinlock for locking RPR calls
 	std::atomic_flag m_lock = ATOMIC_FLAG_INIT;
@@ -1625,6 +1598,11 @@ private:
 	RprApiMaterial * HdRprApi::CreateMaterial(MaterialAdapter & materialAdapter)
 	{
 		return m_impl->CreateMaterial(materialAdapter);
+	}
+
+	void HdRprApi::DeleteMaterial(RprApiMaterial *rprApiMaterial)
+	{
+	    m_impl->DeleteMaterial(rprApiMaterial);
 	}
 
 	void HdRprApi::ClearFramebuffer()

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -91,6 +91,7 @@ public:
 	void CreateVolume(const VtArray<float> & gridDencityData, const VtArray<size_t> & indexesDencity, const VtArray<float> & gridAlbedoData, const VtArray<unsigned int> & indexesAlbedo, const GfVec3i & grigSize, const GfVec3f & voxelSize, RprApiObject out_mesh, RprApiObject out_heteroVolume);
 
 	RprApiMaterial * CreateMaterial(MaterialAdapter & materialAdapter);
+	void DeleteMaterial(RprApiMaterial* rprApiMaterial);
 
 	void SetMeshTransform(RprApiObject mesh, const GfMatrix4d & transform);
 

--- a/pxr/imaging/plugin/hdRpr/sphereLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/sphereLight.cpp
@@ -41,7 +41,7 @@ const TfTokenVector & HdRprSphereLight::FetchLightGeometryParamNames() const
 RprApiObject HdRprSphereLight::CreateLightMesh(std::map<TfToken, float> & params)
 {
 	
-	HdRprApiSharedPtr rprApi = m_rprApiWeakPrt.lock();
+	HdRprApiSharedPtr rprApi = m_rprApiWeakPtr.lock();
 	if (!rprApi)
 	{
 		TF_CODING_ERROR("RprApi is expired");

--- a/pxr/imaging/plugin/hdRpr/volume.cpp
+++ b/pxr/imaging/plugin/hdRpr/volume.cpp
@@ -167,7 +167,7 @@ void fillGridOnWithDefaultColor(TPtr grid, VtVec4fArray & out_grid, VtArray<size
 
 HdRprVolume::HdRprVolume(SdfPath const& id, HdRprApiSharedPtr rprApi): HdVolume(id)
 {
-	m_rprApiWeakPrt = rprApi;
+	m_rprApiWeakPtr = rprApi;
 }
 
 HdRprVolume::~HdRprVolume()
@@ -364,7 +364,7 @@ void HdRprVolume::Sync(
 
 		file.close();
 
-		HdRprApiSharedPtr rprApi = m_rprApiWeakPrt.lock();
+		HdRprApiSharedPtr rprApi = m_rprApiWeakPtr.lock();
 		if (!rprApi)
 		{
 			TF_CODING_ERROR("RprApi is expired");

--- a/pxr/imaging/plugin/hdRpr/volume.h
+++ b/pxr/imaging/plugin/hdRpr/volume.h
@@ -34,7 +34,7 @@ protected:
 	virtual void _InitRepr(TfToken const &reprName,
 		HdDirtyBits *dirtyBits) override;
 
-	HdRprApiWeakPtr m_rprApiWeakPrt;
+	HdRprApiWeakPtr m_rprApiWeakPtr;
 
 	RprApiObject m_rprCubeMesh = nullptr;
 	RprApiObject m_rprHeteroVolume = nullptr;


### PR DESCRIPTION
- Remove RPRX material system usage, use plain RPR material system instead.
- Fix numerous memory leaks due to missing 'DeleteMaterial' calls.
- Force cmake to search RPR libraries only in RPR_LOCATION_LIB