### PR TITLE
avoid attempting to get primvar indices directly

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -63,6 +63,7 @@ else()
 		hdSt
         hdx
         usdLux
+        usdUtils
         pxOsd)
 endif()
         


### PR DESCRIPTION
While attempts to get, ie, "primvars:st:indices" directly will work (after printing ominous
errors), it should be avoided because the results returned from Get and SamplePrimvar are
already flattened - and re-indexing will give incorrect results.

Also, even if it did work, the fact that indices may be stored at "primvars:st:indices" is
an implementation detail of the UsdImaging scene delegates - other scene delegates could
behave differently.

This resolves the issues discussed here:

https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/34#issuecomment-513005738
