### PR TITLE
Fix GeomSubset mesh splitting

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -302,11 +302,15 @@ void HdRprMesh::Sync(
                             int pointIndex = indexes[faceIndexesOffset + i];
                             subsetPoints.push_back(points[pointIndex]);
 
-                            int normalIndex = normalIndexes.empty() ? pointIndex : normalIndexes[faceIndexesOffset + i];
-                            subsetNormals.push_back(normals[normalIndex]);
+                            if (!normals.empty()) {
+                                int normalIndex = normalIndexes.empty() ? pointIndex : normalIndexes[faceIndexesOffset + i];
+                                subsetNormals.push_back(normals[normalIndex]);
+                            }
 
-                            int stIndex = stIndexes.empty() ? pointIndex : stIndexes[faceIndexesOffset + i];
-                            subsetSt.push_back(st[stIndex]);
+                            if (!st.empty()) {
+                                int stIndex = stIndexes.empty() ? pointIndex : stIndexes[faceIndexesOffset + i];
+                                subsetSt.push_back(st[stIndex]);
+                            }
                         }
                     }
 


### PR DESCRIPTION
When original mesh has no normals or uvs submesh does not have it either