### PR TITLE
Call GlfGlewInit instead of glewInit

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -1,6 +1,5 @@
 #include "renderDelegate.h"
 
-#include "pxr/imaging/glf/glew.h"
 #include "pxr/imaging/hd/camera.h"
 
 #include "renderPass.h"

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -15,8 +15,6 @@
 
 #include <memory>
 
-#include <GL/glew.h>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdRprApiImpl;

--- a/pxr/imaging/plugin/hdRpr/rprcpp/rprContext.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprcpp/rprContext.cpp
@@ -4,9 +4,9 @@
 #include "../RprTools.h"
 #include "../RprTools.cpp"
 
-#include <GL/glew.h>
-#include <pxr/base/arch/env.h>
-#include <pxr/base/tf/diagnostic.h>
+#include "pxr/imaging/glf/glew.h"
+#include "pxr/base/arch/env.h"
+#include "pxr/base/tf/diagnostic.h"
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
@@ -170,11 +170,9 @@ std::unique_ptr<Context> Context::CreateContext(PluginType plugin, RenderDeviceT
         context->m_activePlugin == PluginType::HYBRID)) {
         context->m_useGlInterop = false;
     }
-    if (context->m_useGlInterop) {
-        if (GLenum err = glewInit()) {
-            TF_WARN("Failed to init GLEW. Error code: %s. Disabling GL interop", glewGetErrorString(err));
-            context->m_useGlInterop = false;
-        }
+    if (context->m_useGlInterop && !GlfGlewInit()) {
+        TF_WARN("Failed to init GLEW. Disabling GL interop");
+        context->m_useGlInterop = false;
     }
 
     auto cachePath = GetCachePath();


### PR DESCRIPTION
GlfGlewInit is a thread safe wrapper around glewInit and it guarantees that glewInit will be called once