### PR TITLE
Fix varying instancer and mesh visibility attribute

### DIFF
--- a/pxr/imaging/plugin/hdRpr/instancer.h
+++ b/pxr/imaging/plugin/hdRpr/instancer.h
@@ -3,13 +3,16 @@
 
 #include "pxr/pxr.h"
 
-#include "pxr/imaging/hdSt/instancer.h"
+#include "pxr/imaging/hd/changeTracker.h"
+#include "pxr/imaging/hd/instancer.h"
 
 #include "pxr/base/gf/vec3f.h"
+#include "pxr/base/gf/vec4f.h"
+#include "pxr/base/gf/matrix4d.h"
 #include "pxr/base/gf/rotation.h"
 #include "pxr/base/gf/quaternion.h"
+#include "pxr/base/vt/array.h"
 
-#include <vector>
 #include <mutex>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -17,11 +20,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdSceneDelegate;
 class SdfPath;
 
-class HdRprInstancer : public HdStInstancer {
+class HdRprInstancer : public HdInstancer {
 public:
 	HdRprInstancer(HdSceneDelegate* delegate, SdfPath const &id,
-		SdfPath const &parentInstancerId) : 
-		HdStInstancer(delegate, id, parentInstancerId) {}
+		SdfPath const &parentInstancerId) :
+		HdInstancer(delegate, id, parentInstancerId) {}
 
 	VtMatrix4dArray ComputeTransforms(SdfPath const& prototypeId);
 
@@ -34,7 +37,7 @@ private:
 	VtQuaternionArray m_rotate;
 	VtVec3fArray m_scale;
 
-	std::mutex m_mutex;
+    std::mutex m_syncMutex;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -30,8 +30,12 @@ HdRprMesh::HdRprMesh(SdfPath const & id, HdRprApiSharedPtr rprApiShared, SdfPath
 HdRprMesh::~HdRprMesh() {
     if (auto rprApi = m_rprApiWeakPtr.lock()) {
         rprApi->DeleteMaterial(m_fallbackMaterial);
-        for (auto rprMesh : m_rprMeshes)
-        {
+        for (auto meshInstances : m_rprMeshInstances) {
+            for (auto instance : meshInstances) {
+                rprApi->DeleteInstance(instance);
+            }
+        }
+        for (auto rprMesh : m_rprMeshes) {
             rprApi->DeleteMesh(rprMesh);
         }
     }
@@ -290,19 +294,16 @@ void HdRprMesh::Sync(
         }
     }
 
-    if (!m_rprMeshes.empty())
-    {
-        if (*dirtyBits & HdChangeTracker::DirtyTransform)
-        {
-            GfMatrix4d transform = sceneDelegate->GetTransform(id);
-            for (auto rprMesh : m_rprMeshes)
-            {
-                rprApi->SetMeshTransform(rprMesh, transform);
-            }
+    if (!m_rprMeshes.empty()) {
+        // TODO: Check materialId dirtiness here
+
+        bool updateTransform = false;
+        if (*dirtyBits & HdChangeTracker::DirtyTransform) {
+            m_transform = sceneDelegate->GetTransform(id);
+            updateTransform = true;
         }
 
-        if (*dirtyBits & HdChangeTracker::DirtyDisplayStyle)
-        {
+        if (*dirtyBits & HdChangeTracker::DirtyDisplayStyle) {
             int refineLevel = sceneDelegate->GetDisplayStyle(id).refineLevel;
             auto boundaryInterpolation = refineLevel > 0 ? sceneDelegate->GetSubdivTags(id).GetVertexInterpolationRule() : TfToken();
             for (auto rprMesh : m_rprMeshes)
@@ -311,20 +312,71 @@ void HdRprMesh::Sync(
             }
         }
 
-        if (*dirtyBits & HdChangeTracker::DirtyInstancer)
-        {
-            if (auto instancer = static_cast<HdRprInstancer*>(sceneDelegate->GetRenderIndex().GetInstancer(GetInstancerId())))
-            {
-                VtMatrix4dArray transforms = instancer->ComputeTransforms(_sharedData.rprimID);
-                for (auto rprMesh : m_rprMeshes)
-                {
-                    rprApi->CreateInstances(rprMesh, transforms, m_rprMeshInstances);
+        if (*dirtyBits & HdChangeTracker::DirtyVisibility) {
+            _UpdateVisibility(sceneDelegate, dirtyBits);
+            for (auto mesh : m_rprMeshes) {
+                rprApi->SetMeshVisibility(mesh, _sharedData.visible);
+            }
+        }
+
+        if (*dirtyBits & HdChangeTracker::DirtyInstancer) {
+            if (auto instancer = static_cast<HdRprInstancer*>(sceneDelegate->GetRenderIndex().GetInstancer(GetInstancerId()))) {
+                // XXX: if current number of meshes less than previous we have a memory leak
+                //      but instead of releasing it here we should refactor rprApi to return
+                //      complete object that obeys RAII idiom
+                m_rprMeshInstances.resize(m_rprMeshes.size());
+
+                auto transforms = instancer->ComputeTransforms(_sharedData.rprimID);
+                if (transforms.empty()) {
+                    for (int i = 0; i < m_rprMeshes.size(); ++i) {
+                        rprApi->SetMeshVisibility(m_rprMeshes[i], _sharedData.visible);
+                        for (auto instance : m_rprMeshInstances[i]) {
+                            rprApi->DeleteInstance(instance);
+                        }
+                        m_rprMeshInstances[i].clear();
+                    }
+                } else {
+                    updateTransform = false;
+                    for (auto& instanceTransform : transforms) {
+                        instanceTransform = m_transform * instanceTransform;
+                    }
+
+                    m_rprMeshInstances.resize(m_rprMeshes.size());
+                    for (int i = 0; i < m_rprMeshes.size(); ++i) {
+                        auto& meshInstances = m_rprMeshInstances[i];
+                        if (meshInstances.size() != transforms.size()) {
+                            if (meshInstances.size() > transforms.size()) {
+                                for (int j = transforms.size(); j < meshInstances.size(); ++j) {
+                                    rprApi->DeleteInstance(meshInstances[j]);
+                                }
+                                meshInstances.resize(transforms.size(), nullptr);
+                            }
+                            else {
+                                for (int j = meshInstances.size(); j < transforms.size(); ++j) {
+                                    meshInstances.push_back(rprApi->CreateMeshInstance(m_rprMeshes[i]));
+                                }
+                            }
+                        }
+
+                        for (int j = 0; j < transforms.size(); ++j) {
+                            rprApi->SetMeshTransform(meshInstances[j], transforms[j]);
+                        }
+
+                        // Hide prototype
+                        rprApi->SetMeshVisibility(m_rprMeshes[i], false);
+                    }
                 }
+            }
+        }
+
+        if (updateTransform) {
+            for (auto& rprMesh : m_rprMeshes) {
+                rprApi->SetMeshTransform(rprMesh, m_transform);
             }
         }
     }
 
-	*dirtyBits = HdChangeTracker::Clean;
+    *dirtyBits = HdChangeTracker::Clean;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -19,7 +19,7 @@ public:
 	HdRprMesh(SdfPath const& id, HdRprApiSharedPtr rprApi, SdfPath const& instancerId = SdfPath());
 	~HdRprMesh() override;
 
-	virtual void Sync(
+	void Sync(
 		HdSceneDelegate* sceneDelegate,
 		HdRenderParam*   renderParam,
 		HdDirtyBits*     dirtyBits,
@@ -62,10 +62,11 @@ protected:
 		
 private:
 
-	HdRprApiWeakPtr m_rprApiWeakPtr;
+    HdRprApiWeakPtr m_rprApiWeakPtr;
     std::vector<RprApiObject> m_rprMeshes;
-	VtArray<RprApiObject> m_rprMeshInstances;
-	RprApiMaterial* m_fallbackMaterial = nullptr;
+    std::vector<std::vector<RprApiObject>> m_rprMeshInstances;
+    RprApiMaterial* m_fallbackMaterial = nullptr;
+    GfMatrix4d m_transform;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1160,6 +1160,15 @@ public:
         rprObjectDelete(mesh);
     }
 
+    void DeleteInstance(void* instance) {
+        if (!instance) {
+            return;
+        }
+
+        RecursiveLockGuard rprLock(m_rprAccessMutex);
+        rprObjectDelete(instance);
+    }
+
     TfToken GetActiveAov() const {
         return m_currentAov;
     }
@@ -1438,18 +1447,8 @@ private:
         return m_impl->CreateCurve(points, indexes, width);
     }
 
-    void HdRprApi::CreateInstances(RprApiObject prototypeMesh, const VtMatrix4dArray & transforms, VtArray<RprApiObject>& out_instances) {
-        out_instances.clear();
-        out_instances.reserve(transforms.size());
-        for (const GfMatrix4d & transform : transforms) {
-            if (void* meshInstance = m_impl->CreateMeshInstance(prototypeMesh)) {
-                m_impl->SetMeshTransform(meshInstance, GfMatrix4f(transform));
-                out_instances.push_back(meshInstance);
-            }
-        }
-
-        // Hide prototype
-        m_impl->SetMeshVisibility(prototypeMesh, false);
+    RprApiObject HdRprApi::CreateMeshInstance(RprApiObject prototypeMesh) {
+        return m_impl->CreateMeshInstance(prototypeMesh);
     }
 
     void HdRprApi::CreateEnvironmentLight(const std::string & prthTotexture, float intensity) {
@@ -1491,6 +1490,10 @@ private:
 
     void HdRprApi::SetMeshMaterial(RprApiObject mesh, const RprApiMaterial * material) {
         m_impl->SetMeshMaterial(mesh, material);
+    }
+
+    void HdRprApi::SetMeshVisibility(RprApiObject mesh, bool isVisible) {
+        m_impl->SetMeshVisibility(mesh, isVisible);
     }
 
     void HdRprApi::SetCurveMaterial(RprApiObject curve, const RprApiMaterial * material) {
@@ -1559,6 +1562,10 @@ private:
 
     int HdRprApi::GetPluginType() {
         return int(HdRprPreferences::GetInstance().GetPlugin());
+    }
+
+    void HdRprApi::DeleteInstance(RprApiObject instance) {
+        m_impl->DeleteInstance(instance);
     }
 
     const char* HdRprApi::GetTmpDir() {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -103,11 +103,12 @@ public:
     void SetMeshTransform(RprApiObject mesh, const GfMatrix4d& transform);
     void SetMeshRefineLevel(RprApiObject mesh, int level, TfToken boundaryInterpolation);
     void SetMeshMaterial(RprApiObject mesh, const RprApiMaterial* material);
+    void SetMeshVisibility(RprApiObject mesh, bool isVisible);
 
     RprApiObject CreateCurve(const VtVec3fArray& points, const VtIntArray& indexes, const float& width);
     void SetCurveMaterial(RprApiObject curve, const RprApiMaterial* material);
 
-    void CreateInstances(RprApiObject prototypeMesh, const VtMatrix4dArray& transforms, VtArray<RprApiObject>& out_instances);
+    RprApiObject CreateMeshInstance(RprApiObject prototypeMesh);
 
     RprApiMaterial* CreateMaterial(MaterialAdapter& materialAdapter);
     void DeleteMaterial(RprApiMaterial* rprApiMaterial);
@@ -132,6 +133,7 @@ public:
     void Render();
 
     void DeleteMesh(RprApiObject mesh);
+    void DeleteInstance(RprApiObject instance);
 
     bool IsGlInteropUsed() const;
 


### PR DESCRIPTION
Every time instancer was dirty new instance for each transform was created but previously created instances have been never released

I have fixed it in such a way that HdRprMesh now always store the required number of instances and whenever instancer is dirty it updates transform for each instance, i.e. without instance release

Regarding the visibility attribute - it was not used at all