### PR TITLE
Remove global framebuffer size

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderBuffer.h
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.h
@@ -48,6 +48,8 @@ protected:
 private:
     HdRprApiWeakPtr m_rprApiWeakPrt;
     TfToken m_aovName;
+    uint32_t m_width = 0u;
+    uint32_t m_height = 0u;
     HdFormat m_format = HdFormat::HdFormatInvalid;
 
     std::shared_ptr<char> m_dataCache;

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -87,20 +87,19 @@ public:
 
     const GfMatrix4d& GetCameraViewMatrix() const;
     const GfMatrix4d& GetCameraProjectionMatrix() const;
-
     void SetCameraViewMatrix(const GfMatrix4d& m );
     void SetCameraProjectionMatrix(const GfMatrix4d& m);
 
-    void EnableAov(TfToken const& aovName, HdFormat format = HdFormatCount);
+    bool EnableAov(TfToken const& aovName, int width, int height, HdFormat format = HdFormatCount);
     void DisableAov(TfToken const& aovName);
-    void DisableAovs();
     bool IsAovEnabled(TfToken const& aovName);
-    TfToken GetActiveAov() const;
+    GfVec2i GetAovSize(TfToken const& aovName) const;
+    std::shared_ptr<char> GetAovData(TfToken const& aovName, std::shared_ptr<char> buffer = nullptr, size_t* bufferSize = nullptr);
 
-    void ResizeAovFramebuffers(int width, int height);
-    void GetFramebufferSize(GfVec2i* resolution) const;
-    std::shared_ptr<char> GetFramebufferData(TfToken const& aovName, std::shared_ptr<char> buffer = nullptr, size_t* bufferSize = nullptr);
-    void ClearFramebuffers();
+    // This function exist for only one particular reason:
+    //   for explicit bliting to GL framebuffer when there are no aovBindings in renderPass::_Execute
+    //   we need to know the latest enabled AOV so we can draw it
+    TfToken const& GetActiveAov() const;
 
     void Render();
 


### PR DESCRIPTION
### Description of Problem
When the user allocates HdRenderBuffer of a particular size and his viewport is of another size internal framebuffer that corresponds to HdRenderBuffer would be resized to the viewport size. It's inappropriate hidden behavior.
In perspective of the multithreaded application, it could cause the crash. And I was able to reproduce it.

### Description of Changes
Define the size of each AOV framebuffer separately removing global framebuffer size that existed before

### Fixed issues
#### Crash
In one thread you draw HdRenderBuffer to your viewport:
```
width = renderBuffer->GetWidth();
height = renderBuffer->GetHeight();
renderBuffer->Resolve();
data = renderBuffer->Map();
// Draw data
```
In another thread, you are executing renderPass.
Let's say you stretch the window and viewport size is getting smaller. And here is a key moment: when you draw HdRenderBuffer you query its size. Now imagine that after you did it renderPass was executed and so that you changed viewport size to smaller after that internal framebuffers become smaller. And after that, the first thread calls to Resolve and Map and return you smaller buffer, but you already have width and height that corresponds to the previous state. Boom
That's actually a fix of implementation of Hydra AOV System
