### PR TITLE
Fix linkage against TBB library

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -74,7 +74,7 @@ pxr_plugin(hdRpr
         ${RPR_LIBRARY}
         ${RIF_LIBRARY}
         ${Boost_LIBRARIES}
-        ${TBB_LIBRARIES}
+        ${TBB_tbb_LIBRARY}
         ${GLEW_LIBRARY}
 		${OPENGL_LIBRARIES}
 		${PYTHON_LIBRARIES}


### PR DESCRIPTION
Link only to tbb library instead of linking to all available tbb libraries