### PR TITLE
Fix hdRpr's install name of RPR library

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -138,16 +138,6 @@ if(WIN32 OR LINUX)
 	add_definitions(-DUSE_GL_INTEROP)
 endif(WIN32 OR LINUX)
 
-if (APPLE)
-    add_custom_command(TARGET hdRpr
-        POST_BUILD COMMAND
-        ${CMAKE_INSTALL_NAME_TOOL} -id @loader_path/libRadeonProRender64.dylib  ${RPR_LIBRARY})
-
-    add_custom_command(TARGET hdRpr
-        POST_BUILD COMMAND
-        ${CMAKE_INSTALL_NAME_TOOL} -change @loader_path/libRadeonProRender64.dylib ${RPR_LIBRARY} $<TARGET_FILE:hdRpr> )
-endif(APPLE)
-
 if(RPR_BUILD_AS_HOUDINI_PLUGIN)
     install(
         FILES ${CMAKE_CURRENT_SOURCE_DIR}/houdini/HdRprPlugin_Viewport.ds


### PR DESCRIPTION
It looks like previously RPR library had broken rpath and so was added this workaround. But now it's redundant due to correct rpath in RPR SDK and even more, it does not allow us to distribute build among users due to hardcoded install name of RPR library