### PR TITLE
Remove version suffix from python component in find_package

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -66,7 +66,7 @@ else(RPR_BUILD_AS_HOUDINI_PLUGIN)
 
     find_package(Boost
         COMPONENTS
-            python27
+            python
         REQUIRED
     )
 endif()


### PR DESCRIPTION
USD build has "boost" version lass than 1.65 on every platform.
Accordingly to cmake's FindBoost, the python component requires a Python version suffix only starting from Boost 1.67.

So as my main development machine currently is windows with MSVC 2019, I had to build USD against the latest Boost version that required version suffix for python component. My local change was accidentally leaked to one of PR. We need to rollback it