### PR TITLE
Track RIF filter attach status

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.cpp
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.cpp
@@ -232,6 +232,7 @@ void Filter::Update() {
     if (m_dirtyFlags & DirtyIOImage) {
         DettachFilter();
         AttachFilter();
+        m_isAttached = true;
     }
 
     for (auto& input : m_inputs) {
@@ -244,9 +245,10 @@ void Filter::Update() {
 }
 
 void Filter::DettachFilter() {
-    if (!m_rifContext) {
+    if (!m_rifContext || !m_isAttached) {
         return;
     }
+    m_isAttached = false;
 
     for (const rif_image_filter& auxFilter : m_auxFilters) {
         m_rifContext->DettachFilter(auxFilter);

--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.h
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.h
@@ -92,6 +92,8 @@ protected:
         DirtyParameters = 1 << 2
     };
     uint32_t m_dirtyFlags = DirtyAll;
+
+    bool m_isAttached = false;
 };
 
 } // namespace rif


### PR DESCRIPTION
This allows us to avoid receiving RIF warnings about dettaching of an unattached filter