### PR TITLE
Add sampling controls

### DIFF
--- a/pxr/imaging/plugin/hdRpr/config.cpp
+++ b/pxr/imaging/plugin/hdRpr/config.cpp
@@ -61,6 +61,42 @@ bool HdRprConfig::IsDenoisingEnabled() const {
     return m_prefData.m_enableDenoising;
 }
 
+void HdRprConfig::SetMinSamples(int minSamples) {
+    if (m_prefData.m_minSamples != minSamples) {
+        m_prefData.m_minSamples = minSamples;
+        m_dirtyFlags |= DirtySampling;
+        Save();
+    }
+}
+
+int HdRprConfig::GetMinSamples() const {
+    return m_prefData.m_minSamples;
+}
+
+void HdRprConfig::SetMaxSamples(int maxSamples) {
+    if (m_prefData.m_maxSamples != maxSamples) {
+        m_prefData.m_maxSamples = maxSamples;
+        m_dirtyFlags |= DirtySampling;
+        Save();
+    }
+}
+
+int HdRprConfig::GetMaxSamples() const {
+    return m_prefData.m_maxSamples;
+}
+
+void HdRprConfig::SetVariance(float variance) {
+    if (m_prefData.m_variance != variance) {
+        m_prefData.m_variance = variance;
+        m_dirtyFlags |= DirtySampling;
+        Save();
+    }
+}
+
+int HdRprConfig::GetVariance() const {
+    return m_prefData.m_variance;
+}
+
 bool HdRprConfig::IsDirty(ChangeTracker dirtyFlag) const {
     return m_dirtyFlags & dirtyFlag;
 }

--- a/pxr/imaging/plugin/hdRpr/config.h
+++ b/pxr/imaging/plugin/hdRpr/config.h
@@ -24,7 +24,8 @@ public:
         DirtyRenderDevice = 1 << 0,
         DirtyPlugin = 1 << 1,
         DirtyHybridQuality = 1 << 2,
-        DirtyDenoising = 1 << 3
+        DirtyDenoising = 1 << 3,
+        DirtySampling = 1 << 4
     };
 
     static HdRprConfig& GetInstance();
@@ -40,6 +41,15 @@ public:
 
     void SetDenoising(bool enableDenoising);
     bool IsDenoisingEnabled() const;
+
+    void SetMinSamples(int minSamples);
+    int GetMinSamples() const;
+
+    void SetMaxSamples(int maxSamples);
+    int GetMaxSamples() const;
+
+    void SetVariance(float variance);
+    int GetVariance() const;
 
     bool IsDirty(ChangeTracker dirtyFlag) const;
     void ResetDirty();
@@ -58,6 +68,9 @@ private:
         rpr::PluginType m_plugin;
         HdRprHybridQuality m_hybridQuality;
         bool m_enableDenoising;
+        int m_minSamples;
+        int m_maxSamples;
+        float m_variance;
 
         PrefData();
         void SetDefault();

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
@@ -23,6 +23,7 @@ HdRprRenderBuffer::HdRprRenderBuffer(SdfPath const & id, HdRprApiSharedPtr rprAp
     }
 
     m_rprApiWeakPrt = rprApi;
+    m_isConverged.store(false);
 
     auto& idName = id.GetName();
     if (idName == _tokens->aov_color)
@@ -155,7 +156,11 @@ void HdRprRenderBuffer::Resolve() {
 }
 
 bool HdRprRenderBuffer::IsConverged() const {
-    return false;
+    return m_isConverged.load();
+}
+
+void HdRprRenderBuffer::SetConverged(bool converged) {
+    return m_isConverged.store(converged);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.h
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.h
@@ -42,6 +42,8 @@ public:
 
     virtual bool IsConverged() const override;
 
+    void SetConverged(bool converged);
+
 protected:
     virtual void _Deallocate() override;
 
@@ -55,6 +57,7 @@ private:
     std::shared_ptr<char> m_dataCache;
     size_t m_dataCacheSize = 0;
     std::atomic<int> m_numMappers;
+    std::atomic<bool> m_isConverged;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -62,10 +62,11 @@ HdRprDelegate::HdRprDelegate() {
     m_rprApiSharedPtr = std::shared_ptr<HdRprApi>(new HdRprApi);
 
     auto& config = HdRprConfig::GetInstance();
-    m_settingDescriptors.resize(2);
+    m_settingDescriptors.resize(5);
     m_settingDescriptors[0] = { "Enable Denoising",
         HdRprRenderSettingsTokens->enableDenoising,
         VtValue(config.IsDenoisingEnabled()) };
+    
     auto renderQuality = HdRprRenderQualityTokens->full;
     if (config.GetPlugin() == rpr::PluginType::HYBRID) {
         switch (config.GetHybridQuality()) {
@@ -85,7 +86,22 @@ HdRprDelegate::HdRprDelegate() {
     m_settingDescriptors[1] = { "Render Quality",
         HdRprRenderSettingsTokens->renderQuality,
         VtValue(renderQuality) };
+    
+    m_settingDescriptors[2] = { "Min Samples",
+        HdRprRenderSettingsTokens->minSamples,
+        VtValue(config.GetMinSamples()) };
+
+    m_settingDescriptors[3] = { "Max Samples",
+        HdRprRenderSettingsTokens->maxSamples,
+        VtValue(config.GetMaxSamples()) };
+
+    m_settingDescriptors[4] = { "Variance",
+        HdRprRenderSettingsTokens->variance,
+        VtValue(config.GetVariance()) };
+
     _PopulateDefaultSettings(m_settingDescriptors);
+
+
 }
 
 HdRprDelegate::~HdRprDelegate() {

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -12,7 +12,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 #define HDRPR_RENDER_SETTINGS_TOKENS \
     (enableDenoising)                \
-    (renderQuality)
+    (renderQuality)                  \
+    (maxSamples)                     \
+    (minSamples)                     \
+    (variance)
 
 TF_DECLARE_PUBLIC_TOKENS(HdRprRenderSettingsTokens, HDRPR_RENDER_SETTINGS_TOKENS);
 

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -2,6 +2,7 @@
 #include "renderDelegate.h"
 #include "config.h"
 #include "rprApi.h"
+#include "renderBuffer.h"
 #include "pxr/imaging/hd/renderPassState.h"
 
 #include <GL/glew.h>
@@ -50,6 +51,7 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState
     }
 
     rprApi->Render();
+    bool is_converged = rprApi->IsConverged();
 
     auto& aovBindings = renderPassState->GetAovBindings();
     if (aovBindings.empty()) {
@@ -68,6 +70,20 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState
             glDrawPixels(aovSize[0], aovSize[1], GL_RGBA, GL_FLOAT, colorBuffer.get());
             glPixelZoom(currentZoomX, currentZoomY);
         }
+    }
+    else {
+        // set all RenderBuffers converged
+        if(is_converged) {
+            for (auto& aovBinding : aovBindings) {
+                HdRprRenderBuffer * buff = (HdRprRenderBuffer* ) aovBinding.renderBuffer;
+                buff->SetConverged(true);
+            }
+        }
+    }
+
+    // set render pass converged
+    if(is_converged) {
+        m_isConverged = true;
     }
 }
 

--- a/pxr/imaging/plugin/hdRpr/renderPass.h
+++ b/pxr/imaging/plugin/hdRpr/renderPass.h
@@ -34,7 +34,7 @@ public:
 
 	/// Return false if scene is require to be rendered or true otherwise
 	/// In order to specific RPR api scene always should be rendered
-	virtual bool IsConverged() const override { return false; }
+	virtual bool IsConverged() const override { return m_isConverged; }
 
 	// -----------------------------------------------------------------------
 	// HdRenderPass API
@@ -54,6 +54,7 @@ private:
 	HdRprApiWeakPtr m_rprApiWeakPtr;
 
     int m_lastSettingsVersion;
+    bool m_isConverged = false;
 
 };
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -66,6 +66,9 @@ public:
         CreateCamera();
     }
 
+    int m_iter = 0;
+    int m_maxSamples = 0;
+
     void CreateScene() {
         if (!m_rprContext) {
             return;
@@ -812,6 +815,12 @@ public:
             }
         }
 
+        if (preferences.IsDirty(HdRprConfig::DirtySampling)) {
+            m_maxSamples =  preferences.GetMaxSamples();
+            rprContextSetParameter1f(m_rprContext->GetHandle(), "as.threshold", preferences.GetVariance());
+            rprContextSetParameter1u(m_rprContext->GetHandle(), "as.minspp", preferences.GetMinSamples());
+        }
+
         // In case there is no Lights in scene - create default
         if (!m_isLightPresent) {
             const GfVec3f k_defaultLightColor(0.5f, 0.5f, 0.5f);
@@ -1024,6 +1033,7 @@ public:
 
         Update();
 
+        
         if (RPR_ERROR_CHECK(rprContextRender(m_rprContext->GetHandle()), "Fail contex render framebuffer")) return;
 
         ResolveFramebuffers();
@@ -1032,6 +1042,25 @@ public:
             m_rifContext->ExecuteCommandQueue();
         } catch (std::runtime_error& e) {
             TF_RUNTIME_ERROR("%s", e.what());
+        }
+    }
+
+    bool IsConverged() { 
+        // return Converged if max samples is reached
+        if(m_iter > m_maxSamples) {
+            return true;
+        }
+        else {
+            // if not max samples check if all pixels converged to threshold
+            auto& preferences = HdRprConfig::GetInstance();
+
+            float variance_setting = preferences.GetVariance();
+            if(variance_setting > 0.0f) {
+                int active_pixels = 0;
+                rprContextGetInfo(m_rprContext->GetHandle(), RPR_CONTEXT_ACTIVE_PIXEL_COUNT, sizeof(active_pixels), &active_pixels, NULL);
+                return active_pixels == 0;
+            }
+            return false;
         }
     }
 
@@ -1441,6 +1470,10 @@ std::shared_ptr<char> HdRprApi::GetAovData(TfToken const& aovName, std::shared_p
 
 void HdRprApi::Render() {
     m_impl->Render();
+}
+
+bool HdRprApi::IsConverged() {
+    return m_impl->IsConverged();
 }
 
 bool HdRprApi::IsGlInteropEnabled() const {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -102,6 +102,7 @@ public:
     TfToken const& GetActiveAov() const;
 
     void Render();
+    bool IsConverged();
 
     bool IsGlInteropEnabled() const;
 


### PR DESCRIPTION
This checkin adds some sampling controls.  Namely min samples, max samples, and variance.

We set is_converged on the render buffer and the render pass based on the criteria
 is samples > max samples or are all pixels converged to variance threshold.

Open TODOs:
How do we mark buffers and render pass as not converged and set iterations to 0 when changes happen?
How do we set defaults here?
Expose in Menu?