### PR TITLE
Tweak sampling controls

### DIFF
--- a/pxr/imaging/plugin/hdRpr/config.cpp
+++ b/pxr/imaging/plugin/hdRpr/config.cpp
@@ -3,6 +3,10 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+const int HdRprConfig::kDefaultMaxSamples;
+const int HdRprConfig::kDefaultMinSamples;
+const float HdRprConfig::kDefaultVariance;
+
 HdRprConfig& HdRprConfig::GetInstance() {
     static HdRprConfig instance;
     return instance;
@@ -97,8 +101,24 @@ int HdRprConfig::GetVariance() const {
     return m_prefData.m_variance;
 }
 
+void HdRprConfig::SetAdaptiveSampling(bool enable) {
+    if (m_prefData.m_enableAdaptiveSampling != enable) {
+        m_prefData.m_enableAdaptiveSampling = enable;
+        m_dirtyFlags |= DirtySampling;
+        Save();
+    }
+}
+
+bool HdRprConfig::IsAdaptiveSamplingEnabled() const {
+    return m_prefData.m_enableAdaptiveSampling;
+}
+
 bool HdRprConfig::IsDirty(ChangeTracker dirtyFlag) const {
     return m_dirtyFlags & dirtyFlag;
+}
+
+void HdRprConfig::CleanDirtyFlag(ChangeTracker dirtyFlag) {
+    m_dirtyFlags &= ~dirtyFlag;
 }
 
 void HdRprConfig::ResetDirty() {
@@ -156,6 +176,10 @@ void HdRprConfig::PrefData::SetDefault() {
     m_plugin = rpr::PluginType::TAHOE;
     m_hybridQuality = HdRprHybridQuality::LOW;
     m_enableDenoising = false;
+    m_minSamples = kDefaultMinSamples;
+    m_maxSamples = kDefaultMaxSamples;
+    m_variance = kDefaultVariance;
+    m_enableAdaptiveSampling = false;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/config.cpp
+++ b/pxr/imaging/plugin/hdRpr/config.cpp
@@ -101,18 +101,6 @@ int HdRprConfig::GetVariance() const {
     return m_prefData.m_variance;
 }
 
-void HdRprConfig::SetAdaptiveSampling(bool enable) {
-    if (m_prefData.m_enableAdaptiveSampling != enable) {
-        m_prefData.m_enableAdaptiveSampling = enable;
-        m_dirtyFlags |= DirtySampling;
-        Save();
-    }
-}
-
-bool HdRprConfig::IsAdaptiveSamplingEnabled() const {
-    return m_prefData.m_enableAdaptiveSampling;
-}
-
 bool HdRprConfig::IsDirty(ChangeTracker dirtyFlag) const {
     return m_dirtyFlags & dirtyFlag;
 }
@@ -179,7 +167,6 @@ void HdRprConfig::PrefData::SetDefault() {
     m_minSamples = kDefaultMinSamples;
     m_maxSamples = kDefaultMaxSamples;
     m_variance = kDefaultVariance;
-    m_enableAdaptiveSampling = false;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/config.h
+++ b/pxr/imaging/plugin/hdRpr/config.h
@@ -55,9 +55,6 @@ public:
     void SetVariance(float variance);
     int GetVariance() const;
 
-    void SetAdaptiveSampling(bool enable);
-    bool IsAdaptiveSamplingEnabled() const;
-
     bool IsDirty(ChangeTracker dirtyFlag) const;
     void CleanDirtyFlag(ChangeTracker dirtyFlag);
     void ResetDirty();
@@ -79,7 +76,6 @@ private:
         int m_minSamples;
         int m_maxSamples;
         float m_variance;
-        bool m_enableAdaptiveSampling;
 
         PrefData();
         void SetDefault();

--- a/pxr/imaging/plugin/hdRpr/config.h
+++ b/pxr/imaging/plugin/hdRpr/config.h
@@ -18,6 +18,10 @@ enum class HdRprHybridQuality {
 
 class HdRprConfig {
 public:
+    constexpr static int kDefaultMaxSamples = 128;
+    constexpr static int kDefaultMinSamples = 128;
+    constexpr static float kDefaultVariance = 0.0f;
+
     enum ChangeTracker {
         Clean = 0,
         DirtyAll = ~0u,
@@ -51,7 +55,11 @@ public:
     void SetVariance(float variance);
     int GetVariance() const;
 
+    void SetAdaptiveSampling(bool enable);
+    bool IsAdaptiveSamplingEnabled() const;
+
     bool IsDirty(ChangeTracker dirtyFlag) const;
+    void CleanDirtyFlag(ChangeTracker dirtyFlag);
     void ResetDirty();
 
 private:
@@ -71,6 +79,7 @@ private:
         int m_minSamples;
         int m_maxSamples;
         float m_variance;
+        bool m_enableAdaptiveSampling;
 
         PrefData();
         void SetDefault();

--- a/pxr/imaging/plugin/hdRpr/config.h
+++ b/pxr/imaging/plugin/hdRpr/config.h
@@ -18,8 +18,8 @@ enum class HdRprHybridQuality {
 
 class HdRprConfig {
 public:
-    constexpr static int kDefaultMaxSamples = 128;
-    constexpr static int kDefaultMinSamples = 128;
+    constexpr static int kDefaultMaxSamples = 256;
+    constexpr static int kDefaultMinSamples = 64;
     constexpr static float kDefaultVariance = 0.0f;
 
     enum ChangeTracker {

--- a/pxr/imaging/plugin/hdRpr/houdini/HdRprPlugin_Viewport.ds
+++ b/pxr/imaging/plugin/hdRpr/houdini/HdRprPlugin_Viewport.ds
@@ -35,4 +35,56 @@
         default { 0 }
         parmtag { "uiicon" VIEW_display_denoise }
     }
+
+    parm {
+        name    "maxSamples"
+        label   "Max Pixel Samples"
+        type    int
+        size    1
+        parmtag { "spare_category" "Sampling" }
+        parmtag { "uiscope" "viewport" }
+        parmtag { "usdvaluetype" "int" }
+        default { 128 }
+        range { 1! 1024 }
+        help    "Maximum number of samples to render for each pixel."
+    }
+
+    parm {
+        name    "enableAdaptiveSampling"
+        label   "Enable Adaptive Sampling"
+        type    toggle
+        size    1
+        parmtag { "spare_category" "Rendering" }
+        parmtag { "uiscope" "viewport" }
+        parmtag { "usdvaluetype" "bool" }
+        default { 0 }
+    }
+
+    parm {
+        name    "minSamples"
+        label   "Min Pixel Samples"
+        type    int
+        size    1
+        parmtag { "spare_category" "Sampling" }
+        parmtag { "uiscope" "viewport" }
+        parmtag { "usdvaluetype" "int" }
+        default { 128 }
+        range { 1! 1024 }
+        disablewhen  "{ enableAdaptiveSampling == 0 }"
+        help    "Minimum number of samples to render for each pixel. After this, adaptive sampling will stop sampling pixels where noise is less than 'Variance Threshold'."
+    }
+
+    parm {
+        name    "variance"
+        label   "Variance Threshold"
+        type    float
+        size    1
+        parmtag { "spare_category" "Shading" }
+        parmtag { "uiscope" "viewport" }
+        parmtag { "usdvaluetype" "float" }
+        default { 0.0 }
+        range { 0! 1 }
+        disablewhen  "{ enableAdaptiveSampling == 0 }"
+        help    "Cutoff for adaptive sampling. Once pixels are below this amount of noise, no more samples are added. Set to 0 for no cutoff."
+    }
 }

--- a/pxr/imaging/plugin/hdRpr/houdini/HdRprPlugin_Viewport.ds
+++ b/pxr/imaging/plugin/hdRpr/houdini/HdRprPlugin_Viewport.ds
@@ -44,7 +44,7 @@
         parmtag { "spare_category" "Sampling" }
         parmtag { "uiscope" "viewport" }
         parmtag { "usdvaluetype" "int" }
-        default { 128 }
+        default { 256 }
         range { 1! 1024 }
         help    "Maximum number of samples to render for each pixel."
     }
@@ -68,7 +68,7 @@
         parmtag { "spare_category" "Sampling" }
         parmtag { "uiscope" "viewport" }
         parmtag { "usdvaluetype" "int" }
-        default { 128 }
+        default { 64 }
         range { 1! 1024 }
         disablewhen  "{ enableAdaptiveSampling == 0 }"
         help    "Minimum number of samples to render for each pixel. After this, adaptive sampling will stop sampling pixels where noise is less than 'Variance Threshold'."

--- a/pxr/imaging/plugin/hdRpr/houdini/HdRprPlugin_Viewport.ds
+++ b/pxr/imaging/plugin/hdRpr/houdini/HdRprPlugin_Viewport.ds
@@ -50,17 +50,6 @@
     }
 
     parm {
-        name    "enableAdaptiveSampling"
-        label   "Enable Adaptive Sampling"
-        type    toggle
-        size    1
-        parmtag { "spare_category" "Rendering" }
-        parmtag { "uiscope" "viewport" }
-        parmtag { "usdvaluetype" "bool" }
-        default { 0 }
-    }
-
-    parm {
         name    "minSamples"
         label   "Min Pixel Samples"
         type    int
@@ -70,7 +59,6 @@
         parmtag { "usdvaluetype" "int" }
         default { 64 }
         range { 1! 1024 }
-        disablewhen  "{ enableAdaptiveSampling == 0 }"
         help    "Minimum number of samples to render for each pixel. After this, adaptive sampling will stop sampling pixels where noise is less than 'Variance Threshold'."
     }
 
@@ -84,7 +72,6 @@
         parmtag { "usdvaluetype" "float" }
         default { 0.0 }
         range { 0! 1 }
-        disablewhen  "{ enableAdaptiveSampling == 0 }"
         help    "Cutoff for adaptive sampling. Once pixels are below this amount of noise, no more samples are added. Set to 0 for no cutoff."
     }
 }

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -62,7 +62,7 @@ HdRprDelegate::HdRprDelegate() {
     m_rprApiSharedPtr = std::shared_ptr<HdRprApi>(new HdRprApi);
 
     auto& config = HdRprConfig::GetInstance();
-    m_settingDescriptors.resize(5);
+    m_settingDescriptors.resize(6);
     m_settingDescriptors[0] = { "Enable Denoising",
         HdRprRenderSettingsTokens->enableDenoising,
         VtValue(config.IsDenoisingEnabled()) };
@@ -86,17 +86,21 @@ HdRprDelegate::HdRprDelegate() {
     m_settingDescriptors[1] = { "Render Quality",
         HdRprRenderSettingsTokens->renderQuality,
         VtValue(renderQuality) };
-    
-    m_settingDescriptors[2] = { "Min Samples",
-        HdRprRenderSettingsTokens->minSamples,
-        VtValue(config.GetMinSamples()) };
 
-    m_settingDescriptors[3] = { "Max Samples",
+    m_settingDescriptors[2] = { "Max Samples",
         HdRprRenderSettingsTokens->maxSamples,
         VtValue(config.GetMaxSamples()) };
 
-    m_settingDescriptors[4] = { "Variance",
-        HdRprRenderSettingsTokens->variance,
+    m_settingDescriptors[3] = { "Enable Adaptive Sampling",
+        HdRprRenderSettingsTokens->enableAdaptiveSampling,
+        VtValue(config.IsAdaptiveSamplingEnabled()) };
+
+    m_settingDescriptors[4] = { "Adaptive Sampling: Min Samples",
+        HdRprRenderSettingsTokens->minAdaptiveSamples,
+        VtValue(config.GetMinSamples()) };
+
+    m_settingDescriptors[5] = { "Adaptive Sampling: Variance Threshold",
+        HdRprRenderSettingsTokens->varianceThreshold,
         VtValue(config.GetVariance()) };
 
     _PopulateDefaultSettings(m_settingDescriptors);

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -62,7 +62,7 @@ HdRprDelegate::HdRprDelegate() {
     m_rprApiSharedPtr = std::shared_ptr<HdRprApi>(new HdRprApi);
 
     auto& config = HdRprConfig::GetInstance();
-    m_settingDescriptors.resize(6);
+    m_settingDescriptors.resize(5);
     m_settingDescriptors[0] = { "Enable Denoising",
         HdRprRenderSettingsTokens->enableDenoising,
         VtValue(config.IsDenoisingEnabled()) };
@@ -91,15 +91,11 @@ HdRprDelegate::HdRprDelegate() {
         HdRprRenderSettingsTokens->maxSamples,
         VtValue(config.GetMaxSamples()) };
 
-    m_settingDescriptors[3] = { "Enable Adaptive Sampling",
-        HdRprRenderSettingsTokens->enableAdaptiveSampling,
-        VtValue(config.IsAdaptiveSamplingEnabled()) };
-
-    m_settingDescriptors[4] = { "Adaptive Sampling: Min Samples",
+    m_settingDescriptors[3] = { "Adaptive Sampling: Min Samples",
         HdRprRenderSettingsTokens->minAdaptiveSamples,
         VtValue(config.GetMinSamples()) };
 
-    m_settingDescriptors[5] = { "Adaptive Sampling: Variance Threshold",
+    m_settingDescriptors[4] = { "Adaptive Sampling: Variance Threshold",
         HdRprRenderSettingsTokens->varianceThreshold,
         VtValue(config.GetVariance()) };
 

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -14,8 +14,9 @@ PXR_NAMESPACE_OPEN_SCOPE
     (enableDenoising)                \
     (renderQuality)                  \
     (maxSamples)                     \
-    (minSamples)                     \
-    (variance)
+    (enableAdaptiveSampling)         \
+    (minAdaptiveSamples)             \
+    (varianceThreshold)
 
 TF_DECLARE_PUBLIC_TOKENS(HdRprRenderSettingsTokens, HDRPR_RENDER_SETTINGS_TOKENS);
 

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -14,7 +14,6 @@ PXR_NAMESPACE_OPEN_SCOPE
     (enableDenoising)                \
     (renderQuality)                  \
     (maxSamples)                     \
-    (enableAdaptiveSampling)         \
     (minAdaptiveSamples)             \
     (varianceThreshold)
 

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -44,7 +44,6 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState
 
         config.SetDenoising(getBoolSetting(HdRprRenderSettingsTokens->enableDenoising, false));
         config.SetMaxSamples(renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->maxSamples, HdRprConfig::kDefaultMaxSamples));
-        config.SetAdaptiveSampling(getBoolSetting(HdRprRenderSettingsTokens->enableAdaptiveSampling, false));
         config.SetMinSamples(renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->minAdaptiveSamples, HdRprConfig::kDefaultMinSamples));
         config.SetVariance(renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->varianceThreshold, HdRprConfig::kDefaultVariance));
     }

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -4,6 +4,7 @@
 #include "rprApi.h"
 #include "renderBuffer.h"
 #include "pxr/imaging/hd/renderPassState.h"
+#include "pxr/imaging/hd/renderIndex.h"
 
 #include <GL/glew.h>
 
@@ -30,12 +31,22 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState
     if (m_lastSettingsVersion != currentSettingsVersion) {
         m_lastSettingsVersion = currentSettingsVersion;
 
-        auto enableDenoisingValue = renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->enableDenoising);
-        if (enableDenoisingValue.IsHolding<int64_t>()) {
-            HdRprConfig::GetInstance().SetDenoising(enableDenoisingValue.UncheckedGet<int64_t>());
-        } else if (enableDenoisingValue.IsHolding<bool>()) {
-            HdRprConfig::GetInstance().SetDenoising(enableDenoisingValue.UncheckedGet<bool>());
-        }
+        auto getBoolSetting = [&renderDelegate](TfToken const& token, bool defaultValue) {
+            auto boolValue = renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->enableDenoising);
+            if (boolValue.IsHolding<int64_t>()) {
+                return static_cast<bool>(boolValue.UncheckedGet<int64_t>());
+            } else if (boolValue.IsHolding<bool>()) {
+                return static_cast<bool>(boolValue.UncheckedGet<bool>());
+            }
+            return defaultValue;
+        };
+        auto& config = HdRprConfig::GetInstance();
+
+        config.SetDenoising(getBoolSetting(HdRprRenderSettingsTokens->enableDenoising, false));
+        config.SetMaxSamples(renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->maxSamples, HdRprConfig::kDefaultMaxSamples));
+        config.SetAdaptiveSampling(getBoolSetting(HdRprRenderSettingsTokens->enableAdaptiveSampling, false));
+        config.SetMinSamples(renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->minAdaptiveSamples, HdRprConfig::kDefaultMinSamples));
+        config.SetVariance(renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->varianceThreshold, HdRprConfig::kDefaultVariance));
     }
 
     auto& cameraViewMatrix = rprApi->GetCameraViewMatrix();
@@ -51,7 +62,7 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState
     }
 
     rprApi->Render();
-    bool is_converged = rprApi->IsConverged();
+    m_isConverged = rprApi->IsConverged();
 
     auto& aovBindings = renderPassState->GetAovBindings();
     if (aovBindings.empty()) {
@@ -70,20 +81,16 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState
             glDrawPixels(aovSize[0], aovSize[1], GL_RGBA, GL_FLOAT, colorBuffer.get());
             glPixelZoom(currentZoomX, currentZoomY);
         }
-    }
-    else {
-        // set all RenderBuffers converged
-        if(is_converged) {
-            for (auto& aovBinding : aovBindings) {
-                HdRprRenderBuffer * buff = (HdRprRenderBuffer* ) aovBinding.renderBuffer;
-                buff->SetConverged(true);
+    } else {
+        for (auto& aovBinding : aovBindings) {
+            auto buff = static_cast<HdRprRenderBuffer*>(aovBinding.renderBuffer);
+            if (!buff) {
+                buff = static_cast<HdRprRenderBuffer*>(GetRenderIndex()->GetBprim(HdPrimTypeTokens->renderBuffer, aovBinding.renderBufferId));
+            }
+            if (buff) {
+                buff->SetConverged(m_isConverged);
             }
         }
-    }
-
-    // set render pass converged
-    if(is_converged) {
-        m_isConverged = true;
     }
 }
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -815,12 +815,6 @@ public:
             }
         }
 
-        if (preferences.IsDirty(HdRprConfig::DirtySampling)) {
-            m_maxSamples =  preferences.GetMaxSamples();
-            rprContextSetParameter1f(m_rprContext->GetHandle(), "as.threshold", preferences.GetVariance());
-            rprContextSetParameter1u(m_rprContext->GetHandle(), "as.minspp", preferences.GetMinSamples());
-        }
-
         // In case there is no Lights in scene - create default
         if (!m_isLightPresent) {
             const GfVec3f k_defaultLightColor(0.5f, 0.5f, 0.5f);
@@ -828,6 +822,7 @@ public:
         }
 
         UpdateCamera();
+        UpdateSampling();
         UpdateDenoiseFilter();
 
         for (auto& aovFrameBufferEntry : m_aovFrameBuffers) {
@@ -895,7 +890,10 @@ public:
             }
         }
 
-        if (m_dirtyFlags & ChangeTracker::DirtyScene) {
+        if (m_dirtyFlags & ChangeTracker::DirtyScene ||
+            m_dirtyFlags & ChangeTracker::DirtyAOVFramebuffers ||
+            m_dirtyFlags & ChangeTracker::DirtyCamera) {
+            m_iter = 0;
             for (auto& aovFb : m_aovFrameBuffers) {
                 if (aovFb.second.aov) {
                     aovFb.second.aov->Clear();
@@ -921,11 +919,32 @@ public:
         preferences.ResetDirty();
     }
 
+    void UpdateSampling() {
+        auto& preferences = HdRprConfig::GetInstance();
+        if (preferences.IsDirty(HdRprConfig::DirtySampling)) {
+            preferences.CleanDirtyFlag(HdRprConfig::DirtySampling);
+
+            m_maxSamples = preferences.GetMaxSamples();
+            if (m_maxSamples < m_iter) {
+                // Force framebuffers clear to render required number of samples
+                m_dirtyFlags |= ChangeTracker::DirtyScene;
+            }
+
+            if (preferences.IsAdaptiveSamplingEnabled()) {
+                RPR_ERROR_CHECK(rprContextSetParameter1f(m_rprContext->GetHandle(), "as.threshold", preferences.GetVariance()), "Failed to set as.threshold");
+                RPR_ERROR_CHECK(rprContextSetParameter1u(m_rprContext->GetHandle(), "as.minspp", preferences.GetMinSamples()), "Failed to set as.minspp");
+            } else {
+                // XXX: Maybe there is a better way to disable it?
+                // i.e. never check for variance
+                RPR_ERROR_CHECK(rprContextSetParameter1u(m_rprContext->GetHandle(), "as.minspp", m_maxSamples + 1), "Failed to set as.minspp");
+            }
+        }
+    }
+
     void UpdateCamera() {
         if ((m_dirtyFlags & ChangeTracker::DirtyCamera) == 0) {
             return;
         }
-        m_dirtyFlags |= ChangeTracker::DirtyScene;
 
         auto camera = m_camera->GetHandle();
         auto iwvm = m_cameraViewMatrix.GetInverse();
@@ -1032,8 +1051,10 @@ public:
         RecursiveLockGuard rprLock(g_rprAccessMutex);
 
         Update();
+        if (IsConverged()) {
+            return;
+        }
 
-        
         if (RPR_ERROR_CHECK(rprContextRender(m_rprContext->GetHandle()), "Fail contex render framebuffer")) return;
 
         ResolveFramebuffers();
@@ -1043,22 +1064,25 @@ public:
         } catch (std::runtime_error& e) {
             TF_RUNTIME_ERROR("%s", e.what());
         }
+
+        m_iter++;
     }
 
     bool IsConverged() { 
+        RecursiveLockGuard rprLock(g_rprAccessMutex);
+
         // return Converged if max samples is reached
-        if(m_iter > m_maxSamples) {
+        if (m_iter > m_maxSamples) {
             return true;
-        }
-        else {
+        } else {
             // if not max samples check if all pixels converged to threshold
             auto& preferences = HdRprConfig::GetInstance();
 
-            float variance_setting = preferences.GetVariance();
-            if(variance_setting > 0.0f) {
-                int active_pixels = 0;
-                rprContextGetInfo(m_rprContext->GetHandle(), RPR_CONTEXT_ACTIVE_PIXEL_COUNT, sizeof(active_pixels), &active_pixels, NULL);
-                return active_pixels == 0;
+            float varianceSetting = preferences.GetVariance();
+            if (varianceSetting > 0.0f) {
+                int activePixels = 0;
+                if (RPR_ERROR_CHECK(rprContextGetInfo(m_rprContext->GetHandle(), RPR_CONTEXT_ACTIVE_PIXEL_COUNT, sizeof(activePixels), &activePixels, NULL), "Failed to query active pixels")) return false;
+                return activePixels == 0;
             }
             return false;
         }

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -930,14 +930,8 @@ public:
                 m_dirtyFlags |= ChangeTracker::DirtyScene;
             }
 
-            if (preferences.IsAdaptiveSamplingEnabled()) {
-                RPR_ERROR_CHECK(rprContextSetParameter1f(m_rprContext->GetHandle(), "as.threshold", preferences.GetVariance()), "Failed to set as.threshold");
-                RPR_ERROR_CHECK(rprContextSetParameter1u(m_rprContext->GetHandle(), "as.minspp", preferences.GetMinSamples()), "Failed to set as.minspp");
-            } else {
-                // XXX: Maybe there is a better way to disable it?
-                // i.e. never check for variance
-                RPR_ERROR_CHECK(rprContextSetParameter1u(m_rprContext->GetHandle(), "as.minspp", m_maxSamples + 1), "Failed to set as.minspp");
-            }
+            RPR_ERROR_CHECK(rprContextSetParameter1f(m_rprContext->GetHandle(), "as.threshold", preferences.GetVariance()), "Failed to set as.threshold");
+            RPR_ERROR_CHECK(rprContextSetParameter1u(m_rprContext->GetHandle(), "as.minspp", preferences.GetMinSamples()), "Failed to set as.minspp");
         }
     }
 


### PR DESCRIPTION
* Mark buffers and render pass as not converged every time render pass is executed. We can do it because when render settings are changed HdRenderPass::_Execute is always called
* Set iterations to 0 when we clear our framebuffers
* Add sampling controls to Houdini UI
* Introduce UI toggle to enable or disable adaptive sampling
* Synchronize Hydra Render sampling settings with HdRprConfig