### PR TITLE
Fix color AOV resize

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -628,6 +628,13 @@ public:
         RecursiveLockGuard rprLock(g_rprAccessMutex);
 
         if (IsAovEnabled(aovName)) {
+            if (format != m_aovFrameBuffers[aovName].format) {
+                DisableAov(aovName, true);
+                return EnableAov(aovName, width, height, format);
+            }
+
+            ResizeAov(aovName, width, height);
+
             // While usdview does not have correct AOV system
             // we have ambiguity in currently selected AOV that we can't distinguish
             if (aovName == HdRprAovTokens->depth) {
@@ -1301,6 +1308,25 @@ private:
         VtVec2fArray uv; // empty
 
         return CreateMesh(position, indexes, normals, VtIntArray(), uv, VtIntArray(), vpf);
+    }
+
+    void ResizeAov(TfToken const& aovName, int width, int height) {
+        if (aovName == HdRprAovTokens->depth) {
+            ResizeAov(HdRprAovTokens->worldCoordinate, width, height);
+            return;
+        }
+
+        auto& aovFramebuffer = m_aovFrameBuffers.at(aovName);
+
+        if (aovFramebuffer.aov && aovFramebuffer.aov->Resize(width, height)) {
+            aovFramebuffer.isDirty = true;
+        }
+
+        if (aovFramebuffer.resolved && aovFramebuffer.resolved->Resize(width, height)) {
+            aovFramebuffer.isDirty = true;
+        }
+
+        m_dirtyFlags |= ChangeTracker::DirtyAOVFramebuffers;
     }
 
     enum ChangeTracker : uint32_t {

--- a/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.cpp
@@ -61,9 +61,9 @@ void FrameBuffer::Resolve(FrameBuffer* dstFrameBuffer) {
     RPR_ERROR_CHECK_THROW(rprContextResolveFrameBuffer(m_context, GetHandle(), dstFrameBuffer->m_rprObjectHandle, true), "Failed to resolve framebuffer", m_context);
 }
 
-void FrameBuffer::Resize(rpr_uint width, rpr_uint height) {
+bool FrameBuffer::Resize(rpr_uint width, rpr_uint height) {
     if (m_width == width && m_height == height) {
-        return;
+        return false;
     }
 
     rpr_aov aov = m_aov;
@@ -76,6 +76,8 @@ void FrameBuffer::Resize(rpr_uint width, rpr_uint height) {
     if (aov != kAovNone) {
         AttachAs(aov);
     }
+
+    return true;
 }
 
 std::shared_ptr<char> FrameBuffer::GetData(std::shared_ptr<char> buffer, size_t* bufferSize) {

--- a/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.h
+++ b/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.h
@@ -25,7 +25,8 @@ public:
     void AttachAs(rpr_aov aov);
     void Clear();
     void Resolve(FrameBuffer* dstFrameBuffer);
-    virtual void Resize(rpr_uint width, rpr_uint height);
+    /// Return true if framebuffer was actually resized
+    virtual bool Resize(rpr_uint width, rpr_uint height);
 
     std::shared_ptr<char> GetData(std::shared_ptr<char> buffer = nullptr, size_t* bufferSize = nullptr);
     rpr_uint GetSize() const;

--- a/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebufferGL.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebufferGL.cpp
@@ -27,9 +27,9 @@ FrameBufferGL::~FrameBufferGL() {
     DeleteGL();
 }
 
-void FrameBufferGL::Resize(rpr_uint width, rpr_uint height) {
+bool FrameBufferGL::Resize(rpr_uint width, rpr_uint height) {
     if (m_width == width && m_height == height) {
-        return;
+        return false;
     }
 
     rpr_aov aov = m_aov;
@@ -42,6 +42,8 @@ void FrameBufferGL::Resize(rpr_uint width, rpr_uint height) {
     if (aov != kAovNone) {
         AttachAs(aov);
     }
+
+    return true;
 }
 
 rpr_GLuint FrameBufferGL::GetGL() const {

--- a/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebufferGL.h
+++ b/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebufferGL.h
@@ -18,7 +18,7 @@ public:
 
     FrameBufferGL const& operator=(FrameBufferGL&& fb) noexcept;
 
-    void Resize(rpr_uint width, rpr_uint height) override;
+    bool Resize(rpr_uint width, rpr_uint height) override;
 
     rpr_GLuint GetGL() const;
 


### PR DESCRIPTION
The logic behind `HdRprRenderBuffer` resizes was broken for color AOV. `HdRprRenderBuffer` implements resizing in the manner of consecutive calls to `_Deallocate` and `_Allocate` with a new size, but currently, `_Deallocate` for color AOV does not work due to limitation in RPR API - color AOV must be always enabled

Fixes #94 