### PR TITLE
Fix iteration count initialization

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -929,9 +929,9 @@ public:
         preferences.ResetDirty();
     }
 
-    void UpdateSampling() {
+    void UpdateSampling(bool force = false) {
         auto& preferences = HdRprConfig::GetInstance();
-        if (preferences.IsDirty(HdRprConfig::DirtySampling)) {
+        if (preferences.IsDirty(HdRprConfig::DirtySampling) || force) {
             preferences.CleanDirtyFlag(HdRprConfig::DirtySampling);
 
             m_maxSamples = preferences.GetMaxSamples();
@@ -1076,7 +1076,7 @@ public:
         RecursiveLockGuard rprLock(g_rprAccessMutex);
 
         // return Converged if max samples is reached
-        if (m_iter > m_maxSamples) {
+        if (m_iter >= m_maxSamples) {
             return true;
         } else {
             // if not max samples check if all pixels converged to threshold
@@ -1135,6 +1135,8 @@ private:
         if (m_rprContext->GetActivePluginType() == rpr::PluginType::HYBRID) {
             RPR_ERROR_CHECK(rprContextSetParameterByKey1u(m_rprContext->GetHandle(), RPR_CONTEXT_RENDER_QUALITY, int(HdRprConfig::GetInstance().GetHybridQuality())), "Fail to set context hybrid render quality");
         }
+
+        UpdateSampling(true);
 
         m_imageCache.reset(new ImageCache(m_rprContext.get()));
     }


### PR DESCRIPTION
After the first hdRpr initialization, HdRprConfig's sampling attributes were marked as clean. But when you reinitialize hdRpr, HdRprConfig's sampling is no longer dirty that's why the number of max samples was never queried again until you set a new value for one of the sampling attributes in HdRprConfig. Thus the number of max samples was always 0. This behavior was mentioned in #95