### PR TITLE
Use opacity map to define transparency map

### DIFF
--- a/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
@@ -426,7 +426,7 @@ void MaterialAdapter::PopulateUsdPreviewSurface(const MaterialParams & params, c
 		else if (paramName == HdRprTokens->opacity)
 		{
 			materialTexture.IsOneMinusSrcColor = true;
-			m_texRpr.insert({ RPR_UBER_MATERIAL_INPUT_REFRACTION_WEIGHT, materialTexture });
+			m_texRpr.insert({ RPR_UBER_MATERIAL_INPUT_TRANSPARENCY, materialTexture });
 		}
 		else if (paramName == HdRprTokens->normal)
 		{


### PR DESCRIPTION
Motivated by the [principled node](https://github.com/Radeon-Pro/RadeonProRenderBlenderAddon/blob/master/src/rprblender/nodes/blender_nodes.py#L827) in blender plugin