### PR TITLE
Fix support of half float textures

### DIFF
--- a/pxr/imaging/plugin/hdRpr/imageCache.cpp
+++ b/pxr/imaging/plugin/hdRpr/imageCache.cpp
@@ -34,6 +34,9 @@ std::shared_ptr<rpr::Image> ImageCache::CreateImage(std::string const& path) {
                 case GL_UNSIGNED_BYTE:
                     format.type = RPR_COMPONENT_TYPE_UINT8;
                     break;
+                case GL_HALF_FLOAT:
+                    format.type = RPR_COMPONENT_TYPE_FLOAT16;
+                    break;
                 case GL_FLOAT:
                     format.type = RPR_COMPONENT_TYPE_FLOAT32;
                     break;


### PR DESCRIPTION
This case was previously not added to this switch because of compilation error on macOS, but now this issue is resolved