### PR TITLE
Material fixes

### DIFF
--- a/pxr/imaging/plugin/hdRpr/materialFactory.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialFactory.cpp
@@ -83,6 +83,9 @@ RprApiMaterial* RprMaterialFactory::CreateMaterial(EMaterialType type, const Mat
         const uint32_t & paramId = param.first;
         const GfVec4f & paramValue = param.second;
 
+        if (materialAdapter.GetTexRprParams().count(paramId)) {
+            continue;
+        }
         rprMaterialNodeSetInputFByKey(material->rootMaterial, paramId, paramValue[0], paramValue[1], paramValue[2], paramValue[3]);
     }
 

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -131,9 +131,6 @@ void HdRprMesh::Sync(
         m_adjacencyValid = false;
         m_normalsValid = false;
 
-        // TODO: handle different winding order
-        // m_topology.GetOrientation() == HdTokens->leftHanded
-
         m_enableSubdiv = m_topology.GetScheme() == PxOsdOpenSubdivTokens->catmullClark;
 
         newMesh = true;
@@ -266,7 +263,7 @@ void HdRprMesh::Sync(
         };
 
         if (geomSubsets.empty() || geomSubsets.size() == 1) {
-            if (auto rprMesh = rprApi->CreateMesh(m_points, m_faceVertexIndices, m_normals, m_normalIndices, m_uvs, m_uvIndices, m_faceVertexCounts)) {
+            if (auto rprMesh = rprApi->CreateMesh(m_points, m_faceVertexIndices, m_normals, m_normalIndices, m_uvs, m_uvIndices, m_faceVertexCounts, m_topology.GetOrientation())) {
                 setMeshMaterial(rprMesh, geomSubsets.empty() ? hdMaterialId : geomSubsets[0].materialId);
                 m_rprMeshes.push_back(std::move(rprMesh));
             }
@@ -319,7 +316,7 @@ void HdRprMesh::Sync(
                     }
                 }
 
-                if (auto rprMesh = rprApi->CreateMesh(subsetPoints, subsetIndexes, subsetNormals, VtIntArray(), subsetSt, VtIntArray(), subsetVertexPerFace)) {
+                if (auto rprMesh = rprApi->CreateMesh(subsetPoints, subsetIndexes, subsetNormals, VtIntArray(), subsetSt, VtIntArray(), subsetVertexPerFace, m_topology.GetOrientation())) {
                     setMeshMaterial(rprMesh, subset.materialId);
                     m_rprMeshes.push_back(std::move(rprMesh));
                 }
@@ -353,9 +350,8 @@ void HdRprMesh::Sync(
         }
 
         if (newMesh || (*dirtyBits & HdChangeTracker::DirtyDisplayStyle)) {
-            int refineLevel = sceneDelegate->GetDisplayStyle(id).refineLevel;
             for (auto& rprMesh : m_rprMeshes) {
-                rprApi->SetMeshRefineLevel(rprMesh.get(), refineLevel);
+                rprApi->SetMeshRefineLevel(rprMesh.get(), m_refineLevel);
             }
         }
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1443,6 +1443,7 @@ private:
     void ResizeAov(TfToken const& aovName, int width, int height) {
         if (aovName == HdRprAovTokens->depth) {
             ResizeAov(HdRprAovTokens->worldCoordinate, width, height);
+            m_aovFrameBuffers[aovName].isDirty = true;
             return;
         }
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -78,7 +78,7 @@ public:
 
     RprApiObjectPtr CreateVolume(const VtArray<float>& gridDencityData, const VtArray<size_t>& indexesDencity, const VtArray<float>& gridAlbedoData, const VtArray<unsigned int>& indexesAlbedo, const GfVec3i& grigSize, const GfVec3f& voxelSize);
 
-    RprApiObjectPtr CreateMesh(const VtVec3fArray& points, const VtIntArray& pointIndexes, const VtVec3fArray& normals, const VtIntArray& normalIndexes, const VtVec2fArray& uv, const VtIntArray& uvIndexes, const VtIntArray& vpf);
+    RprApiObjectPtr CreateMesh(const VtVec3fArray& points, const VtIntArray& pointIndexes, const VtVec3fArray& normals, const VtIntArray& normalIndexes, const VtVec2fArray& uv, const VtIntArray& uvIndexes, const VtIntArray& vpf, TfToken const& polygonWinding);
     RprApiObjectPtr CreateMeshInstance(RprApiObject* prototypeMesh);
     void SetMeshTransform(RprApiObject* mesh, const GfMatrix4d& transform);
     void SetMeshRefineLevel(RprApiObject* mesh, int level);


### PR DESCRIPTION
* Fix translucent layer: `diffuse_weight = opacity` and `refraction_weight = 1 - opacity`
* Set fallback values for absent parameters
* Set refraction color to white
* Handle left-hand oriented meshes