### PR TITLE
Fix crash on release of HdRprBasisCurve

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -352,7 +352,7 @@ public:
             }
         });
 
-        return RprApiObject::Wrap(curve);
+        return curveObject;
     }
 
     RprApiObjectPtr CreateEnvironmentLight(std::unique_ptr<rpr::Image>&& image, float intensity) {


### PR DESCRIPTION
`HdRprApi::CreateCurve` was returning wittingly incorrect curve object because it was detached and released in the destructor of previously created RprApiObject from the same curve object rpr handle