### PR TITLE
Implement basis curves visibility support

### DIFF
--- a/pxr/imaging/plugin/hdRpr/basisCurves.h
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.h
@@ -7,6 +7,8 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdRprMaterial;
+
 class HdRprBasisCurves : public HdBasisCurves {
 
 public:
@@ -33,6 +35,8 @@ private:
     HdRprApiWeakPtr m_rprApiWeakPtr;
     RprApiObjectPtr m_rprCurve;
     RprApiObjectPtr m_fallbackMaterial;
+
+    HdRprMaterial const* m_cachedMaterial;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifContext.cpp
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifContext.cpp
@@ -330,14 +330,14 @@ void Context::AttachFilter(rif_image_filter filter, rif_image inputImage, rif_im
     ++m_numAttachedFilters;
 }
 
-void Context::DettachFilter(rif_image_filter filter) {
+void Context::DetachFilter(rif_image_filter filter) {
     auto rifStatus = rifCommandQueueDetachImageFilter(m_commandQueue, filter);
     if (rifStatus == RIF_ERROR_INVALID_PARAMETER) {
         // Ignore if filter was not attached before
         return;
     }
 
-    RIF_ERROR_CHECK_THROW(rifStatus, "Failed to dettach image filter from queue");
+    RIF_ERROR_CHECK_THROW(rifStatus, "Failed to detach image filter from queue");
     --m_numAttachedFilters;
 }
 

--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifContext.h
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifContext.h
@@ -28,7 +28,7 @@ public:
     virtual std::unique_ptr<Image> CreateImage(rpr::FrameBuffer* rprFrameBuffer) = 0;
 
     void AttachFilter(rif_image_filter filter, rif_image inputImage, rif_image outputImage);
-    void DettachFilter(rif_image_filter filter);
+    void DetachFilter(rif_image_filter filter);
 
     virtual void UpdateInputImage(rpr::FrameBuffer* rprFrameBuffer, rif_image image);
 

--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.cpp
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.cpp
@@ -170,7 +170,7 @@ std::unique_ptr<Filter> Filter::CreateCustom(rif_image_filter_type type, Context
 }
 
 Filter::~Filter() {
-    DettachFilter();
+    DetachFilter();
 
     rif_int rifStatus = RIF_SUCCESS;
 
@@ -229,7 +229,7 @@ void Filter::Update() {
         ApplyParameters();
     }
     if (m_dirtyFlags & DirtyIOImage) {
-        DettachFilter();
+        DetachFilter();
         AttachFilter();
         m_isAttached = true;
     }
@@ -243,16 +243,16 @@ void Filter::Update() {
     m_dirtyFlags = Clean;
 }
 
-void Filter::DettachFilter() {
+void Filter::DetachFilter() {
     if (!m_rifContext || !m_isAttached) {
         return;
     }
     m_isAttached = false;
 
     for (const rif_image_filter& auxFilter : m_auxFilters) {
-        m_rifContext->DettachFilter(auxFilter);
+        m_rifContext->DetachFilter(auxFilter);
     }
-    m_rifContext->DettachFilter(m_rifFilter);
+    m_rifContext->DetachFilter(m_rifFilter);
 }
 
 struct ParameterSetter : public BOOST_NS::static_visitor<rif_int> {

--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.h
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.h
@@ -61,7 +61,7 @@ public:
 protected:
     Filter(Context* rifContext) : m_rifContext(rifContext) {}
 
-    void DettachFilter();
+    void DetachFilter();
     virtual void AttachFilter() = 0;
 
     void ApplyParameters();

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -36,7 +36,8 @@ public:
     void AttachDependency(std::unique_ptr<rpr::Object>&& dependencyObject);
 
     void AttachOnReleaseAction(TfToken const& actionName, std::function<void (void*)> action);
-    void DettachOnReleaseAction(TfToken const& actionName);
+    void DetachOnReleaseAction(TfToken const& actionName);
+    bool HasOnReleaseAction(TfToken const& actionName);
 
     void* GetHandle() const;
 
@@ -88,6 +89,7 @@ public:
 
     RprApiObjectPtr CreateCurve(const VtVec3fArray& points, const VtIntArray& indexes, float width);
     void SetCurveMaterial(RprApiObject* curve, RprApiObject const* material);
+    void SetCurveVisibility(RprApiObject* curve, bool isVisible);
 
     RprApiObjectPtr CreateMaterial(MaterialAdapter& materialAdapter);
 


### PR DESCRIPTION
RPR API does not have `rprCurveSetVisibility*` functions like for shapes, that's why visibility on/off emulated using scene attach/detach. It should be fixed in the future when RPR API will be updated.
I have already created an appropriate issue in the backlog - FIR-1575