### PR TITLE
Fix crash on resize of HdRprRenderBuffer

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
@@ -14,10 +14,8 @@ TF_DEFINE_PRIVATE_TOKENS(
     (aov_primvars_st)
 );
 
-HdRprRenderBuffer::HdRprRenderBuffer(SdfPath const & id, HdRprApiSharedPtr rprApi) : HdRenderBuffer(id), m_numMappers(0)
-{
-    if (!rprApi)
-    {
+HdRprRenderBuffer::HdRprRenderBuffer(SdfPath const & id, HdRprApiSharedPtr rprApi) : HdRenderBuffer(id), m_numMappers(0) {
+    if (!rprApi) {
         TF_CODING_ERROR("RprApi is expired");
         return;
     }
@@ -26,35 +24,18 @@ HdRprRenderBuffer::HdRprRenderBuffer(SdfPath const & id, HdRprApiSharedPtr rprAp
     m_isConverged.store(false);
 
     auto& idName = id.GetName();
-    if (idName == _tokens->aov_color)
-    {
+    if (idName == _tokens->aov_color) {
         m_aovName = HdRprAovTokens->color;
-        m_format = HdFormat::HdFormatUNorm8Vec4;
-    }
-    else if (idName == _tokens->aov_normal)
-    {
+    } else if (idName == _tokens->aov_normal) {
         m_aovName = HdRprAovTokens->normal;
-        m_format = HdFormat::HdFormatFloat32Vec3;
-    }
-    else if (idName == _tokens->aov_depth)
-    {
+    } else if (idName == _tokens->aov_depth) {
         m_aovName = HdRprAovTokens->depth;
-        m_format = HdFormat::HdFormatFloat32;
-    }
-    else if (idName == _tokens->aov_linear_depth)
-    {
+    } else if (idName == _tokens->aov_linear_depth) {
         m_aovName = HdRprAovTokens->linearDepth;
-        m_format = HdFormat::HdFormatFloat32;
-    }
-    else if (idName == _tokens->aov_primId)
-    {
+    } else if (idName == _tokens->aov_primId) {
         m_aovName = HdRprAovTokens->primId;
-        m_format = HdFormat::HdFormatUNorm8Vec4;
-    }
-    else if (idName == _tokens->aov_primvars_st)
-    {
+    } else if (idName == _tokens->aov_primvars_st) {
         m_aovName = HdRprAovTokens->primvarsSt;
-        m_format = HdFormat::HdFormatFloat32Vec3;
     }
 }
 
@@ -66,14 +47,35 @@ HdDirtyBits HdRprRenderBuffer::GetInitialDirtyBitsMask() const
 bool HdRprRenderBuffer::Allocate(GfVec3i const& dimensions,
                       HdFormat format,
                       bool multiSampled) {
+    TF_VERIFY(!IsMapped());
+    TF_UNUSED(multiSampled);
+
     if (m_aovName.IsEmpty()) {
         return false;
     }
 
+    _Deallocate();
+
     if (auto rprApi = m_rprApiWeakPrt.lock()) {
-        if (rprApi->EnableAov(m_aovName, dimensions[0], dimensions[1], m_format)) {
+        // XXX: RPR does not support int32 images
+        auto requestedFormat = format;
+        if (requestedFormat == HdFormatInt32) {
+            format = HdFormatUNorm8Vec4;
+        }
+
+        if (rprApi->EnableAov(m_aovName, dimensions[0], dimensions[1], format)) {
             m_width = dimensions[0];
             m_height = dimensions[1];
+            m_format = requestedFormat;
+
+            auto newBufferSize = m_width * m_height * HdDataSizeOfFormat(m_format);
+            // Avoid reallocation if new size a little bit smaller than bufferSize
+            if (newBufferSize < (m_bufferSize * 0.9) ||
+                newBufferSize > m_bufferSize) {
+                m_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[newBufferSize]);
+                m_bufferSize = newBufferSize;
+            }
+
             return true;
         }
     } else {
@@ -108,9 +110,6 @@ unsigned int HdRprRenderBuffer::GetDepth() const {
 }
 
 HdFormat HdRprRenderBuffer::GetFormat() const {
-    if (m_aovName == HdRprAovTokens->primId) {
-        return HdFormatInt32;
-    }
     return m_format;
 }
 
@@ -121,13 +120,11 @@ bool HdRprRenderBuffer::IsMultiSampled() const {
 void* HdRprRenderBuffer::Map() {
     ++m_numMappers;
     // XXX: RPR does not support framebuffer mapping, so here is at least correct mapping for reading
-    return m_dataCache.get();
+    return m_buffer.get();
 }
 
 void HdRprRenderBuffer::Unmap() {
-    if (m_numMappers > 0) {
-        --m_numMappers;
-    }
+    --m_numMappers;
 }
 
 bool HdRprRenderBuffer::IsMapped() const {
@@ -136,19 +133,20 @@ bool HdRprRenderBuffer::IsMapped() const {
 
 void HdRprRenderBuffer::Resolve() {
     if (auto rprApi = m_rprApiWeakPrt.lock()) {
-        m_dataCache = rprApi->GetAovData(m_aovName, m_dataCache, &m_dataCacheSize);
-        if (m_aovName == HdRprAovTokens->primId) {
-            // RPR store integer ID values to RGB images using such formula:
-            // c[i].x = i;
-            // c[i].y = i/256;
-            // c[i].z = i/(256*256);
-            // i.e. saving little endian int24 to uchar3
-            // That's why we interpret the value as int and filling the alpha channel with zeros
-            auto primIdData = reinterpret_cast<int*>(m_dataCache.get());
-            for (uint32_t y = 0; y < m_height; ++y) {
-                uint32_t yOffset = y * m_width;
-                for (uint32_t x = 0; x < m_width; ++x) {
-                    primIdData[x + yOffset] &= 0xFFFFFF;
+        if (rprApi->GetAovData(m_aovName, m_buffer.get(), m_bufferSize)) {
+            if (m_aovName == HdRprAovTokens->primId) {
+                // RPR store integer ID values to RGB images using such formula:
+                // c[i].x = i;
+                // c[i].y = i/256;
+                // c[i].z = i/(256*256);
+                // i.e. saving little endian int24 to uchar3
+                // That's why we interpret the value as int and filling the alpha channel with zeros
+                auto primIdData = reinterpret_cast<int*>(m_buffer.get());
+                for (uint32_t y = 0; y < m_height; ++y) {
+                    uint32_t yOffset = y * m_width;
+                    for (uint32_t x = 0; x < m_width; ++x) {
+                        primIdData[x + yOffset] &= 0xFFFFFF;
+                    }
                 }
             }
         }

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.h
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.h
@@ -54,8 +54,7 @@ private:
     uint32_t m_height = 0u;
     HdFormat m_format = HdFormat::HdFormatInvalid;
 
-    std::unique_ptr<uint8_t[]> m_buffer;
-    size_t m_bufferSize = 0u;
+    std::vector<uint8_t> m_mappedBuffer;
     std::atomic<int> m_numMappers;
     std::atomic<bool> m_isConverged;
 };

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.h
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.h
@@ -54,8 +54,8 @@ private:
     uint32_t m_height = 0u;
     HdFormat m_format = HdFormat::HdFormatInvalid;
 
-    std::shared_ptr<char> m_dataCache;
-    size_t m_dataCacheSize = 0;
+    std::unique_ptr<uint8_t[]> m_buffer;
+    size_t m_bufferSize = 0u;
     std::atomic<int> m_numMappers;
     std::atomic<bool> m_isConverged;
 };

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -975,8 +975,8 @@ public:
             return readRifImage(m_denoiseFilterPtr->GetOutput());
         } else {
             auto& aovFrameBuffer = it->second;
-            if (!aovFrameBuffer.postprocessFilters.empty()) {
-                return readRifImage(aovFrameBuffer.postprocessFilters.back()->GetOutput());
+            if (aovFrameBuffer.postprocessFilter) {
+                return readRifImage(aovFrameBuffer.postprocessFilter->GetOutput());
             } else {
                 auto resolvedFb = aovFrameBuffer.resolved.get();
                 if (!resolvedFb) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -798,9 +798,10 @@ public:
         return m_cameraProjectionMatrix;
     }
 
-    bool EnableAov(TfToken const& aovName, int width, int height, HdFormat format = HdFormatInvalid, bool setAsActive = false) {
+    bool EnableAov(TfToken const& aovName, int width, int height, HdFormat format = HdFormatFloat32Vec4, bool setAsActive = false) {
         if (!m_rprContext ||
-            width < 1 || height < 1) {
+            width < 1 || height < 1 ||
+            format == HdFormatInvalid || HdDataSizeOfFormat(format) == 0) {
             return false;
         }
 
@@ -912,75 +913,82 @@ public:
         }
     }
 
-    GfVec2i GetAovSize(TfToken const& aovName) const {
+    bool GetAovInfo(TfToken const& aovName, int* width, int* height, HdFormat* format) const {
         RecursiveLockGuard rprLock(g_rprAccessMutex);
 
         auto it = m_aovFrameBuffers.find(aovName);
         if (it == m_aovFrameBuffers.end()) {
-            return GfVec2i(-1, -1);
+            return false;
         }
 
-        auto desc = it->second.aov->GetDesc();
-        return GfVec2i(desc.fb_width, desc.fb_height);
+        if (width || height) {
+            auto desc = it->second.aov->GetDesc();
+            if (width) {
+                *width = desc.fb_width;
+            }
+            if (height) {
+                *height = desc.fb_height;
+            }
+        }
+
+        if (format) {
+            *format = it->second.format;
+        }
+
+        return true;
     }
 
-    std::shared_ptr<char> GetAovData(TfToken const& aovName, std::shared_ptr<char> buffer, size_t* bufferSize) {
+    bool GetAovData(TfToken const& aovName, void* dstBuffer, size_t dstBufferSize) {
         RecursiveLockGuard rprLock(g_rprAccessMutex);
 
         auto it = m_aovFrameBuffers.find(aovName);
         if (it == m_aovFrameBuffers.end()) {
-            return nullptr;
+            return false;
         }
 
-        auto readRifImage = [](rif_image image, size_t* bufferSize) -> std::shared_ptr<char> {
+        auto readRifImage = [&dstBuffer, &dstBufferSize](rif_image image) -> bool {
             size_t size;
             size_t dummy;
             auto rifStatus = rifImageGetInfo(image, RIF_IMAGE_DATA_SIZEBYTE, sizeof(size), &size, &dummy);
-            if (rifStatus != RIF_SUCCESS) {
-                return nullptr;
+            if (rifStatus != RIF_SUCCESS || dstBufferSize < size) {
+                return false;
             }
 
             void* data = nullptr;
             rifStatus = rifImageMap(image, RIF_IMAGE_MAP_READ, &data);
             if (rifStatus != RIF_SUCCESS) {
-                return nullptr;
+                return false;
             }
 
             auto buffer = std::shared_ptr<char>(new char[size]);
-            std::memcpy(buffer.get(), data, size);
+            std::memcpy(dstBuffer, data, size);
 
             rifStatus = rifImageUnmap(image, data);
             if (rifStatus != RIF_SUCCESS) {
                 TF_WARN("Failed to unmap rif image");
             }
 
-            if (bufferSize) {
-                *bufferSize = size;
-            }
-            return buffer;
+            return true;
         };
 
         if (aovName == HdRprAovTokens->color && m_denoiseFilterPtr) {
-            buffer = readRifImage(m_denoiseFilterPtr->GetOutput(), bufferSize);
+            return readRifImage(m_denoiseFilterPtr->GetOutput());
         } else {
             auto& aovFrameBuffer = it->second;
-            if (aovFrameBuffer.postprocessFilter) {
-                buffer = readRifImage(aovFrameBuffer.postprocessFilter->GetOutput(), bufferSize);
+            if (!aovFrameBuffer.postprocessFilters.empty()) {
+                return readRifImage(aovFrameBuffer.postprocessFilters.back()->GetOutput());
             } else {
                 auto resolvedFb = aovFrameBuffer.resolved.get();
                 if (!resolvedFb) {
                     resolvedFb = aovFrameBuffer.aov.get();
                 }
                 if (!resolvedFb) {
-                    assert(false);
-                    return nullptr;
+                    return false;
                 }
 
-                buffer = resolvedFb->GetData(buffer, bufferSize);
+                return resolvedFb->GetData(dstBuffer, dstBufferSize);
             }
         }
-
-        return buffer;
     }
 
     rif_image_desc GetRifImageDesc(uint32_t width, uint32_t height, HdFormat format) {
@@ -1806,12 +1814,12 @@ bool HdRprApi::IsAovEnabled(TfToken const& aovName) {
     return m_impl->IsAovEnabled(aovName);
 }
 
-GfVec2i HdRprApi::GetAovSize(TfToken const& aovName) const {
-    return m_impl->GetAovSize(aovName);
+bool HdRprApi::GetAovInfo(TfToken const& aovName, int* width, int* height, HdFormat* format) const {
+    return m_impl->GetAovInfo(aovName, width, height, format);
 }
 
-std::shared_ptr<char> HdRprApi::GetAovData(TfToken const& aovName, std::shared_ptr<char> buffer, size_t* bufferSize) {
-    return m_impl->GetAovData(aovName, buffer, bufferSize);
+bool HdRprApi::GetAovData(TfToken const& aovName, void* dstBuffer, size_t dstBufferSize) {
+    return m_impl->GetAovData(aovName, dstBuffer, dstBufferSize);
 }
 
 void HdRprApi::Render() {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -102,8 +102,8 @@ public:
     bool EnableAov(TfToken const& aovName, int width, int height, HdFormat format = HdFormatCount);
     void DisableAov(TfToken const& aovName);
     bool IsAovEnabled(TfToken const& aovName);
-    GfVec2i GetAovSize(TfToken const& aovName) const;
-    std::shared_ptr<char> GetAovData(TfToken const& aovName, std::shared_ptr<char> buffer = nullptr, size_t* bufferSize = nullptr);
+    bool GetAovInfo(TfToken const& aovName, int* width, int* height, HdFormat* format) const;
+    bool GetAovData(TfToken const& aovName, void* dstBuffer, size_t dstBufferSize);
 
     // This function exist for only one particular reason:
     //   for explicit bliting to GL framebuffer when there are no aovBindings in renderPass::_Execute

--- a/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.cpp
@@ -80,29 +80,17 @@ bool FrameBuffer::Resize(rpr_uint width, rpr_uint height) {
     return true;
 }
 
-std::shared_ptr<char> FrameBuffer::GetData(std::shared_ptr<char> buffer, size_t* bufferSize) {
+bool FrameBuffer::GetData(void* dstBuffer, size_t dstBufferSize) {
     if (m_width == 0 || m_height == 0 || !m_rprObjectHandle) {
-        return nullptr;
+        return false;
     }
 
     auto size = GetSize();
-    if (!buffer) {
-        buffer = std::shared_ptr<char>(new char[size]);
-        if (bufferSize) {
-            *bufferSize = size;
-        }
-    } else if (bufferSize) {
-        if (*bufferSize != size) {
-            buffer = std::shared_ptr<char>(new char[size]);
-            *bufferSize = size;
-        }
+    if (size > dstBufferSize) {
+        return false;
     }
 
-    if (RPR_ERROR_CHECK(rprFrameBufferGetInfo(GetHandle(), RPR_FRAMEBUFFER_DATA, size, buffer.get(), nullptr), "Failed to get framebuffer data", m_context)) {
-        return nullptr;
-    }
-
-    return buffer;
+    return !RPR_ERROR_CHECK(rprFrameBufferGetInfo(GetHandle(), RPR_FRAMEBUFFER_DATA, size, dstBuffer, nullptr), "Failed to get framebuffer data", m_context);
 }
 
 rpr_uint FrameBuffer::GetSize() const {

--- a/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.h
+++ b/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.h
@@ -28,7 +28,7 @@ public:
     /// Return true if framebuffer was actually resized
     virtual bool Resize(rpr_uint width, rpr_uint height);
 
-    std::shared_ptr<char> GetData(std::shared_ptr<char> buffer = nullptr, size_t* bufferSize = nullptr);
+    bool GetData(void* dstBuffer, size_t dstBufferSize);
     rpr_uint GetSize() const;
     rpr_framebuffer_desc GetDesc() const;
 


### PR DESCRIPTION
* Avoid potential crashes due to incorrect usage of HdRenderBuffer API by external code. According to my observations, HdRenderBuffer might be reallocated while in a mapped state. Also, after reallocation HdRprRenderBuffer's internal buffer used to store resolved image has been in an incorrect state - it didn't match new width and height - until first Resolve call.