### PR TITLE
Add "Pause/Resume Render" functionality

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -115,6 +115,7 @@ pxr_plugin(hdRpr
         rendererPlugin
         renderDelegate
         renderPass
+        renderThread
         rprApi
         mesh
         instancer

--- a/pxr/imaging/plugin/hdRpr/basisCurves.cpp
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.cpp
@@ -1,14 +1,15 @@
 #include "basisCurves.h"
 #include "materialFactory.h"
 #include "material.h"
+#include "renderParam.h"
+#include "rprApi.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 HdRprBasisCurves::HdRprBasisCurves(SdfPath const& id,
-                                   HdRprApiSharedPtr rprApi,
                                    SdfPath const& instancerId)
     : HdBasisCurves(id, instancerId) {
-    m_rprApiWeakPtr = rprApi;
+
 }
 
 HdDirtyBits HdRprBasisCurves::_PropagateDirtyBits(HdDirtyBits bits) const {
@@ -29,12 +30,8 @@ void HdRprBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
                             TfToken const& reprSelector) {
     TF_UNUSED(renderParam);
 
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        *dirtyBits = HdChangeTracker::Clean;
-        return;
-    }
+    auto rprRenderParam = static_cast<HdRprRenderParam*>(renderParam);
+    auto rprApi = rprRenderParam->AcquireRprApiForEdit();
 
     SdfPath const& id = GetId();
 

--- a/pxr/imaging/plugin/hdRpr/basisCurves.cpp
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.cpp
@@ -123,4 +123,11 @@ HdDirtyBits HdRprBasisCurves::GetInitialDirtyBitsMask() const {
         | HdChangeTracker::DirtyMaterialId;
 }
 
+void HdRprBasisCurves::Finalize(HdRenderParam* renderParam) {
+    // Stop render thread to safely release resources
+    static_cast<HdRprRenderParam*>(renderParam)->GetRenderThread()->StopRender();
+
+    HdBasisCurves::Finalize(renderParam);
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/basisCurves.h
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.h
@@ -3,17 +3,16 @@
 
 #include "pxr/imaging/hd/basisCurves.h"
 
-#include "rprApi.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdRprMaterial;
+class RprApiObject;
+using RprApiObjectPtr = std::unique_ptr<RprApiObject>;
 
 class HdRprBasisCurves : public HdBasisCurves {
 
 public:
     HdRprBasisCurves(SdfPath const& id,
-                     HdRprApiSharedPtr rprApi,
                      SdfPath const& instancerId);
 
     ~HdRprBasisCurves() override = default;
@@ -33,7 +32,6 @@ protected:
                    HdDirtyBits* dirtyBits) override;
 
 private:
-    HdRprApiWeakPtr m_rprApiWeakPtr;
     RprApiObjectPtr m_rprCurve;
     RprApiObjectPtr m_fallbackMaterial;
     HdRprMaterial const* m_cachedMaterial;

--- a/pxr/imaging/plugin/hdRpr/basisCurves.h
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.h
@@ -22,6 +22,8 @@ public:
               HdDirtyBits* dirtyBits,
               TfToken const& reprSelector) override;
 
+    void Finalize(HdRenderParam* renderParam) override;
+
 protected:
 
     HdDirtyBits GetInitialDirtyBitsMask() const override;

--- a/pxr/imaging/plugin/hdRpr/cylinderLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/cylinderLight.cpp
@@ -1,4 +1,5 @@
 #include "cylinderLight.h"
+#include "rprApi.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
 
 #include <cmath>
@@ -17,17 +18,11 @@ bool HdRprCylinderLight::SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath 
     return isDirty;
 }
 
-RprApiObjectPtr HdRprCylinderLight::CreateLightMesh() {
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        return nullptr;
-    }
-
+RprApiObjectPtr HdRprCylinderLight::CreateLightMesh(HdRprApi* rprApi) {
     return rprApi->CreateCylinderLightMesh(m_radius, m_length);
 }
 
-GfVec3f HdRprCylinderLight::NormalizeLightColor(const GfMatrix4d& transform, const GfVec3f& inColor) {
+GfVec3f HdRprCylinderLight::NormalizeLightColor(const GfMatrix4f& transform, const GfVec3f& inColor) {
     const double sx = GfVec3d(transform[0][0], transform[1][0], transform[2][0]).GetLength() * m_radius;
     const double sy = GfVec3d(transform[0][1], transform[1][1], transform[2][1]).GetLength() * m_radius;
     const double sz = GfVec3d(transform[0][2], transform[1][2], transform[2][2]).GetLength() * m_length;

--- a/pxr/imaging/plugin/hdRpr/cylinderLight.h
+++ b/pxr/imaging/plugin/hdRpr/cylinderLight.h
@@ -8,8 +8,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdRprCylinderLight : public HdRprLightBase {
 
 public:
-    HdRprCylinderLight(SdfPath const& id, HdRprApiSharedPtr rprApi)
-        : HdRprLightBase(id, rprApi) {
+    HdRprCylinderLight(SdfPath const& id)
+        : HdRprLightBase(id) {
     }
 
 protected:
@@ -17,10 +17,10 @@ protected:
     bool SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath const& id) override;
 
     // Create mesh with emmisive material
-    RprApiObjectPtr CreateLightMesh() override;
+    RprApiObjectPtr CreateLightMesh(HdRprApi* rprApi) override;
 
     // Normalize Light Color with surface area
-    GfVec3f NormalizeLightColor(const GfMatrix4d& transform, const GfVec3f& emmisionColor) override;
+    GfVec3f NormalizeLightColor(const GfMatrix4f& transform, const GfVec3f& emmisionColor) override;
 
 private:
     float m_radius = std::numeric_limits<float>::quiet_NaN();

--- a/pxr/imaging/plugin/hdRpr/diskLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/diskLight.cpp
@@ -1,4 +1,5 @@
 #include "diskLight.h"
+#include "rprApi.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
 
 #include <cmath>
@@ -19,17 +20,11 @@ bool HdRprDiskLight::SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath cons
     return isDirty;
 }
 
-RprApiObjectPtr HdRprDiskLight::CreateLightMesh() {
-    HdRprApiSharedPtr rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        return nullptr;
-    }
-
+RprApiObjectPtr HdRprDiskLight::CreateLightMesh(HdRprApi* rprApi) {
     return rprApi->CreateDiskLightMesh(m_radius);
 }
 
-GfVec3f HdRprDiskLight::NormalizeLightColor(const GfMatrix4d& transform, const GfVec3f& inColor) {
+GfVec3f HdRprDiskLight::NormalizeLightColor(const GfMatrix4f& transform, const GfVec3f& inColor) {
     const double sx = GfVec3d(transform[0][0], transform[1][0], transform[2][0]).GetLength() * m_radius;
     const double sy = GfVec3d(transform[0][1], transform[1][1], transform[2][1]).GetLength() * m_radius;
 

--- a/pxr/imaging/plugin/hdRpr/diskLight.h
+++ b/pxr/imaging/plugin/hdRpr/diskLight.h
@@ -8,18 +8,18 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdRprDiskLight : public HdRprLightBase {
     
 public:
-    HdRprDiskLight(SdfPath const & id, HdRprApiSharedPtr rprApi)
-        : HdRprLightBase(id, rprApi) {}
+    HdRprDiskLight(SdfPath const & id)
+        : HdRprLightBase(id) {}
 
 protected:
 
     bool SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath const& id) override;
 
     // Create mesh with emmisive material
-    RprApiObjectPtr CreateLightMesh() override;
+    RprApiObjectPtr CreateLightMesh(HdRprApi* rprApi) override;
 
     // Normalize Light Color with surface area
-    GfVec3f NormalizeLightColor(const GfMatrix4d & transform, const GfVec3f & emmisionColor) override;
+    GfVec3f NormalizeLightColor(const GfMatrix4f& transform, const GfVec3f& emmisionColor) override;
 
 private:
     float m_radius = std::numeric_limits<float>::quiet_NaN();

--- a/pxr/imaging/plugin/hdRpr/distantLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/distantLight.cpp
@@ -1,4 +1,5 @@
 #include "distantLight.h"
+#include "renderParam.h"
 
 #include "pxr/imaging/hd/light.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
@@ -15,11 +16,8 @@ void HdRprDistantLight::Sync(HdSceneDelegate* sceneDelegate,
                              HdRenderParam* renderParam,
                              HdDirtyBits* dirtyBits) {
 
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        return;
-    }
+    auto rprRenderParam = static_cast<HdRprRenderParam*>(renderParam);
+    auto rprApi = rprRenderParam->AcquireRprApiForEdit();
 
     HdDirtyBits bits = *dirtyBits;
     auto& id = GetId();

--- a/pxr/imaging/plugin/hdRpr/distantLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/distantLight.cpp
@@ -66,4 +66,11 @@ HdDirtyBits HdRprDistantLight::GetInitialDirtyBitsMask() const {
     return HdLight::AllDirty;
 }
 
+void HdRprDistantLight::Finalize(HdRenderParam* renderParam) {
+    // Stop render thread to safely release resources
+    static_cast<HdRprRenderParam*>(renderParam)->GetRenderThread()->StopRender();
+
+    HdSprim::Finalize(renderParam);
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/distantLight.h
+++ b/pxr/imaging/plugin/hdRpr/distantLight.h
@@ -14,9 +14,9 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdRprDistantLight : public HdSprim {
 
 public:
-    HdRprDistantLight(SdfPath const& id, HdRprApiSharedPtr rprApi)
-        : HdSprim(id)
-        , m_rprApiWeakPtr(rprApi) {
+    HdRprDistantLight(SdfPath const& id)
+        : HdSprim(id) {
+
     }
 
     void Sync(HdSceneDelegate* sceneDelegate,
@@ -26,7 +26,6 @@ public:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
 protected:
-    HdRprApiWeakPtr m_rprApiWeakPtr;
     RprApiObjectPtr m_rprLight;
     GfMatrix4f m_transform;
 };

--- a/pxr/imaging/plugin/hdRpr/distantLight.h
+++ b/pxr/imaging/plugin/hdRpr/distantLight.h
@@ -25,6 +25,8 @@ public:
 
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
+    void Finalize(HdRenderParam* renderParam) override;
+
 protected:
     RprApiObjectPtr m_rprLight;
     GfMatrix4f m_transform;

--- a/pxr/imaging/plugin/hdRpr/domeLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/domeLight.cpp
@@ -93,4 +93,11 @@ HdDirtyBits HdRprDomeLight::GetInitialDirtyBitsMask() const {
     return HdLight::AllDirty;
 }
 
+void HdRprDomeLight::Finalize(HdRenderParam* renderParam) {
+    // Stop render thread to safely release resources
+    static_cast<HdRprRenderParam*>(renderParam)->GetRenderThread()->StopRender();
+
+    HdSprim::Finalize(renderParam);
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/domeLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/domeLight.cpp
@@ -1,4 +1,6 @@
 #include "domeLight.h"
+#include "renderParam.h"
+#include "rprApi.h"
 
 #include "pxr/usd/ar/resolver.h"
 #include "pxr/imaging/hd/light.h"
@@ -25,12 +27,8 @@ void HdRprDomeLight::Sync(HdSceneDelegate* sceneDelegate,
                           HdRenderParam* renderParam,
                           HdDirtyBits* dirtyBits) {
 
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        *dirtyBits = HdLight::Clean;
-        return;
-    }
+    auto rprRenderParam = static_cast<HdRprRenderParam*>(renderParam);
+    auto rprApi = rprRenderParam->AcquireRprApiForEdit();
 
     SdfPath const& id = GetId();
     HdDirtyBits bits = *dirtyBits;

--- a/pxr/imaging/plugin/hdRpr/domeLight.h
+++ b/pxr/imaging/plugin/hdRpr/domeLight.h
@@ -25,6 +25,8 @@ public:
 
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
+    void Finalize(HdRenderParam* renderParam) override;
+
 protected:
     RprApiObjectPtr m_rprLight;
     GfMatrix4f m_transform;

--- a/pxr/imaging/plugin/hdRpr/domeLight.h
+++ b/pxr/imaging/plugin/hdRpr/domeLight.h
@@ -5,16 +5,18 @@
 #include "pxr/imaging/hd/sprim.h"
 #include "pxr/usd/sdf/path.h"
 
-#include "rprApi.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
+
+class HdRprApi;
+class RprApiObject;
+using RprApiObjectPtr = std::unique_ptr<RprApiObject>;
 
 class HdRprDomeLight : public HdSprim {
 
 public:
-    HdRprDomeLight(SdfPath const& id, HdRprApiSharedPtr rprApi)
-        : HdSprim(id)
-        , m_rprApiWeakPtr(rprApi) {
+    HdRprDomeLight(SdfPath const& id)
+        : HdSprim(id) {
+
     }
 
     void Sync(HdSceneDelegate* sceneDelegate,
@@ -24,7 +26,6 @@ public:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
 protected:
-    HdRprApiWeakPtr m_rprApiWeakPtr;
     RprApiObjectPtr m_rprLight;
     GfMatrix4f m_transform;
 };

--- a/pxr/imaging/plugin/hdRpr/field.cpp
+++ b/pxr/imaging/plugin/hdRpr/field.cpp
@@ -2,8 +2,8 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-HdRprField::HdRprField(SdfPath const& id, HdRprApiSharedPtr rprApi) : HdField(id) {
-    m_rprApiWeakPtr = rprApi;
+HdRprField::HdRprField(SdfPath const& id) : HdField(id) {
+
 }
 
 void HdRprField::Sync(HdSceneDelegate* sceneDelegate,

--- a/pxr/imaging/plugin/hdRpr/field.h
+++ b/pxr/imaging/plugin/hdRpr/field.h
@@ -3,13 +3,11 @@
 
 #include "pxr/imaging/hd/field.h"
 
-#include "rprApi.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdRprField : public HdField {
 public:
-    HdRprField(SdfPath const& id, HdRprApiSharedPtr rprApi);
+    HdRprField(SdfPath const& id);
     ~HdRprField() override = default;
 
     void Sync(HdSceneDelegate* sceneDelegate,
@@ -18,9 +16,6 @@ public:
 
 protected:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
-
-private:
-    HdRprApiWeakPtr m_rprApiWeakPtr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/lightBase.cpp
+++ b/pxr/imaging/plugin/hdRpr/lightBase.cpp
@@ -97,4 +97,11 @@ HdDirtyBits HdRprLightBase::GetInitialDirtyBitsMask() const {
         | DirtyBits::DirtyParams;
 }
 
+void HdRprLightBase::Finalize(HdRenderParam* renderParam) {
+    // Stop render thread to safely release resources
+    static_cast<HdRprRenderParam*>(renderParam)->GetRenderThread()->StopRender();
+
+    HdLight::Finalize(renderParam);
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/lightBase.cpp
+++ b/pxr/imaging/plugin/hdRpr/lightBase.cpp
@@ -1,6 +1,8 @@
 #include "lightBase.h"
+#include "renderParam.h"
 #include "material.h"
 #include "materialFactory.h"
+#include "rprApi.h"
 
 #include "pxr/imaging/hd/sceneDelegate.h"
 #include "pxr/usd/usdLux/blackbody.h"
@@ -17,32 +19,18 @@ bool HdRprLightBase::IsDirtyMaterial(const GfVec3f& emissionColor) {
     return isDirty;
 }
 
-RprApiObjectPtr HdRprLightBase::CreateLightMaterial(const GfVec3f& illumColor) {
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        return nullptr;
-    }
-
-    MaterialAdapter matAdapter(EMaterialType::EMISSIVE, MaterialParams{{HdLightTokens->color, VtValue(illumColor)}});
-    return rprApi->CreateMaterial(matAdapter);
-}
-
 void HdRprLightBase::Sync(HdSceneDelegate* sceneDelegate,
                           HdRenderParam* renderParam,
                           HdDirtyBits* dirtyBits) {
 
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        return;
-    }
+    auto rprRenderParam = static_cast<HdRprRenderParam*>(renderParam);
+    auto rprApi = rprRenderParam->AcquireRprApiForEdit();
 
     SdfPath const& id = GetId();
     HdDirtyBits bits = *dirtyBits;
 
     if (bits & DirtyBits::DirtyTransform) {
-        m_transform = sceneDelegate->GetLightParamValue(id, HdLightTokens->transform).Get<GfMatrix4d>();
+        m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdLightTokens->transform).Get<GfMatrix4d>());
     }
 
     bool newLight = false;
@@ -68,7 +56,7 @@ void HdRprLightBase::Sync(HdSceneDelegate* sceneDelegate,
         const float illuminationIntensity = computeLightIntensity(intensity, exposure);
 
         if (SyncGeomParams(sceneDelegate, id) || !m_lightMesh) {
-            m_lightMesh = CreateLightMesh();
+            m_lightMesh = CreateLightMesh(rprApi);
         }
 
         if (!m_lightMesh) {
@@ -82,7 +70,8 @@ void HdRprLightBase::Sync(HdSceneDelegate* sceneDelegate,
         const GfVec3f emissionColor = (isNormalize) ? NormalizeLightColor(m_transform, illumColor) : illumColor;
 
         if (!m_lightMaterial || IsDirtyMaterial(emissionColor)) {
-            m_lightMaterial = CreateLightMaterial(emissionColor);
+            MaterialAdapter matAdapter(EMaterialType::EMISSIVE, MaterialParams{{HdLightTokens->color, VtValue(emissionColor)}});
+            m_lightMaterial = rprApi->CreateMaterial(matAdapter);
         }
 
         if (!m_lightMaterial) {

--- a/pxr/imaging/plugin/hdRpr/lightBase.h
+++ b/pxr/imaging/plugin/hdRpr/lightBase.h
@@ -1,19 +1,23 @@
 #ifndef HDRPR_LIGHT_BASE_H
 #define HDRPR_LIGHT_BASE_H
 
+#include "pxr/base/gf/vec3f.h"
+#include "pxr/base/gf/matrix4f.h"
 #include "pxr/imaging/hd/sprim.h"
 #include "pxr/imaging/hd/light.h"
 #include "pxr/usd/sdf/path.h"
 
-#include "rprApi.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
+
+class HdRprApi;
+class RprApiObject;
+using RprApiObjectPtr = std::unique_ptr<RprApiObject>;
 
 class HdRprLightBase : public HdLight {
 public:
-    HdRprLightBase(SdfPath const& id, HdRprApiSharedPtr rprApi)
-        : HdLight(id)
-        , m_rprApiWeakPtr(rprApi) {
+    HdRprLightBase(SdfPath const& id)
+        : HdLight(id) {
+
     }
 
     ~HdRprLightBase() override = default;
@@ -27,23 +31,19 @@ public:
 protected:
     virtual bool SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath const& id) = 0;
 
-    virtual RprApiObjectPtr CreateLightMesh() = 0;
+    virtual RprApiObjectPtr CreateLightMesh(HdRprApi* rprApi) = 0;
 
     // Normalize Light Color with surface area
-    virtual GfVec3f NormalizeLightColor(const GfMatrix4d& transform, const GfVec3f& emmisionColor) = 0;
-
-protected:
-    HdRprApiWeakPtr m_rprApiWeakPtr;
+    virtual GfVec3f NormalizeLightColor(const GfMatrix4f& transform, const GfVec3f& emmisionColor) = 0;
 
 private:
     bool IsDirtyMaterial(const GfVec3f& emmisionColor);
-    RprApiObjectPtr CreateLightMaterial(const GfVec3f& illumColor);
 
 private:
     RprApiObjectPtr m_lightMesh;
     RprApiObjectPtr m_lightMaterial;
     GfVec3f m_emmisionColor = GfVec3f(0.0f);
-    GfMatrix4d m_transform;
+    GfMatrix4f m_transform;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/lightBase.h
+++ b/pxr/imaging/plugin/hdRpr/lightBase.h
@@ -28,6 +28,8 @@ public:
 
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
+    void Finalize(HdRenderParam* renderParam) override;
+
 protected:
     virtual bool SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath const& id) = 0;
 

--- a/pxr/imaging/plugin/hdRpr/material.cpp
+++ b/pxr/imaging/plugin/hdRpr/material.cpp
@@ -2,6 +2,9 @@
 #include "materialFactory.h"
 #include "materialAdapter.h"
 
+#include "renderParam.h"
+#include "rprApi.h"
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_PRIVATE_TOKENS(
@@ -32,20 +35,16 @@ static const bool GetMaterial(const HdMaterialNetworkMap& networkMap, EMaterialT
     return false;
 }
 
-HdRprMaterial::HdRprMaterial(SdfPath const& id, HdRprApiSharedPtr rprApi) : HdMaterial(id) {
-    m_rprApiWeakPtr = rprApi;
+HdRprMaterial::HdRprMaterial(SdfPath const& id) : HdMaterial(id) {
+
 }
 
 void HdRprMaterial::Sync(HdSceneDelegate* sceneDelegate,
                          HdRenderParam* renderParam,
                          HdDirtyBits* dirtyBits) {
 
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        *dirtyBits = Clean;
-        return;
-    }
+    auto rprRenderParam = static_cast<HdRprRenderParam*>(renderParam);
+    auto rprApi = rprRenderParam->AcquireRprApiForEdit();
 
     if (*dirtyBits & HdMaterial::DirtyResource) {
         VtValue vtMat = sceneDelegate->GetMaterialResource(GetId());

--- a/pxr/imaging/plugin/hdRpr/material.cpp
+++ b/pxr/imaging/plugin/hdRpr/material.cpp
@@ -75,6 +75,13 @@ void HdRprMaterial::Reload() {
     // no-op
 }
 
+void HdRprMaterial::Finalize(HdRenderParam* renderParam) {
+    // Stop render thread to safely release resources
+    static_cast<HdRprRenderParam*>(renderParam)->GetRenderThread()->StopRender();
+
+    HdMaterial::Finalize(renderParam);
+}
+
 RprApiObject const* HdRprMaterial::GetRprMaterialObject() const {
     return m_rprMaterial.get();
 }

--- a/pxr/imaging/plugin/hdRpr/material.h
+++ b/pxr/imaging/plugin/hdRpr/material.h
@@ -21,6 +21,7 @@ public:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
     void Reload() override;
+    void Finalize(HdRenderParam* renderParam) override;
 
     /// Get pointer to RPR material
     /// In case material сreation failure return nullptr

--- a/pxr/imaging/plugin/hdRpr/material.h
+++ b/pxr/imaging/plugin/hdRpr/material.h
@@ -3,13 +3,14 @@
 
 #include "pxr/imaging/hd/material.h"
 
-#include "rprApi.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
+
+class RprApiObject;
+using RprApiObjectPtr = std::unique_ptr<RprApiObject>;
 
 class HdRprMaterial final : public HdMaterial {
 public:
-    HdRprMaterial(SdfPath const& id, HdRprApiSharedPtr rprApi);
+    HdRprMaterial(SdfPath const& id);
 
     ~HdRprMaterial() override = default;
 
@@ -26,7 +27,6 @@ public:
     const RprApiObject* GetRprMaterialObject() const;
 
 private:
-    HdRprApiWeakPtr m_rprApiWeakPtr;
     RprApiObjectPtr m_rprMaterial;
 };
 

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -143,15 +143,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
-        m_cachedMaterial = nullptr;
-
-        auto materialId = sceneDelegate->GetMaterialId(id);
-        if (!materialId.IsEmpty()) {
-            auto hdMaterial = sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, materialId);
-            if (hdMaterial) {
-                m_cachedMaterial = static_cast<const HdRprMaterial*>(hdMaterial)->GetRprMaterialObject();
-            }
-        }
+        m_cachedMaterialId = sceneDelegate->GetMaterialId(id);
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -194,7 +186,6 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
     if (newMesh) {
         auto numFaces = m_faceVertexCounts.size();
-        auto hdMaterialId = sceneDelegate->GetMaterialId(id);
 
         auto geomSubsets = m_topology.GetGeomSubsets();
         // If the geometry has been partitioned into subsets, add an
@@ -217,7 +208,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                 HdGeomSubset& unusedSubset = geomSubsets.back();
                 unusedSubset.type = HdGeomSubset::TypeFaceSet;
                 unusedSubset.id = id;
-                unusedSubset.materialId = hdMaterialId;
+                unusedSubset.materialId = m_cachedMaterialId;
                 unusedSubset.indices.resize(numUnusedFaces);
                 size_t count = 0;
                 for (size_t i = 0; i < faceIsUnused.size() && count < numUnusedFaces; ++i) {
@@ -262,7 +253,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
         if (geomSubsets.empty() || geomSubsets.size() == 1) {
             if (auto rprMesh = rprApi->CreateMesh(m_points, m_faceVertexIndices, m_normals, m_normalIndices, m_uvs, m_uvIndices, m_faceVertexCounts, m_topology.GetOrientation())) {
-                setMeshMaterial(rprMesh, geomSubsets.empty() ? hdMaterialId : geomSubsets[0].materialId);
+                setMeshMaterial(rprMesh, geomSubsets.empty() ? m_cachedMaterialId : geomSubsets[0].materialId);
                 m_rprMeshes.push_back(std::move(rprMesh));
             }
         } else {
@@ -410,14 +401,26 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         if (!newMesh && (*dirtyBits & HdChangeTracker::DirtyMaterialId)) {
             // when geometry subsetting enabled, the material comes from each particular HdGeomSubset
             if (m_topology.GetGeomSubsets().empty()) {
+                RprApiObject const* rprMaterial = nullptr;
+                auto hdMaterial = sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, m_cachedMaterialId);
+                if (hdMaterial) {
+                    rprMaterial = static_cast<HdRprMaterial const*>(hdMaterial)->GetRprMaterialObject();
+                }
                 for (auto& mesh : m_rprMeshes) {
-                    rprApi->SetMeshMaterial(mesh.get(), m_cachedMaterial);
+                    rprApi->SetMeshMaterial(mesh.get(), rprMaterial);
                 }
             }
         }
     }
 
     *dirtyBits = HdChangeTracker::Clean;
+}
+
+void HdRprMesh::Finalize(HdRenderParam* renderParam) {
+    // Stop render thread to safely release resources
+    static_cast<HdRprRenderParam*>(renderParam)->GetRenderThread()->StopRender();
+
+    HdMesh::Finalize(renderParam);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -5,18 +5,19 @@
 #include "pxr/imaging/hd/vertexAdjacency.h"
 #include "pxr/base/vt/array.h"
 #include "pxr/base/gf/vec2f.h"
-
-#include "rprApi.h"
+#include "pxr/base/gf/matrix4f.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdRprParam;
+class RprApiObject;
+using RprApiObjectPtr = std::unique_ptr<RprApiObject>;
 
 class HdRprMesh final : public HdMesh {
 public:
     HF_MALLOC_TAG_NEW("new HdRprMesh");
 
-    HdRprMesh(SdfPath const& id, HdRprApiSharedPtr rprApi, SdfPath const& instancerId = SdfPath());
+    HdRprMesh(SdfPath const& id, SdfPath const& instancerId = SdfPath());
     ~HdRprMesh() override = default;
 
     void Sync(HdSceneDelegate* sceneDelegate,
@@ -40,12 +41,11 @@ private:
                         VtIntArray& out_indices);
 
 private:
-    HdRprApiWeakPtr m_rprApiWeakPtr;
     std::vector<RprApiObjectPtr> m_rprMeshes;
     std::vector<std::vector<RprApiObjectPtr>> m_rprMeshInstances;
     RprApiObjectPtr m_fallbackMaterial;
     RprApiObject const* m_cachedMaterial;
-    GfMatrix4d m_transform;
+    GfMatrix4f m_transform;
 
     HdMeshTopology m_topology;
     VtVec3fArray m_points;

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -25,6 +25,8 @@ public:
               HdDirtyBits* dirtyBits,
               TfToken const& reprName) override;
 
+    void Finalize(HdRenderParam* renderParam) override;
+
 protected:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
@@ -44,7 +46,7 @@ private:
     std::vector<RprApiObjectPtr> m_rprMeshes;
     std::vector<std::vector<RprApiObjectPtr>> m_rprMeshInstances;
     RprApiObjectPtr m_fallbackMaterial;
-    RprApiObject const* m_cachedMaterial;
+    SdfPath m_cachedMaterialId;
     GfMatrix4f m_transform;
 
     HdMeshTopology m_topology;

--- a/pxr/imaging/plugin/hdRpr/rectLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/rectLight.cpp
@@ -1,4 +1,5 @@
 #include "rectLight.h"
+#include "rprApi.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -15,21 +16,16 @@ bool HdRprRectLight::SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath cons
     return isDirty;
 }
 
-RprApiObjectPtr HdRprRectLight::CreateLightMesh() {
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        return nullptr;
-    }
+RprApiObjectPtr HdRprRectLight::CreateLightMesh(HdRprApi* rprApi) {
     return rprApi->CreateRectLightMesh(m_width, m_height);
 }
 
-GfVec3f HdRprRectLight::NormalizeLightColor(const GfMatrix4d& transform, const GfVec3f& inColor) {
-    const GfVec4d ox(m_width, 0., 0., 0.);
-    const GfVec4d oy(0., m_height, 0., 0.);
+GfVec3f HdRprRectLight::NormalizeLightColor(const GfMatrix4f& transform, const GfVec3f& inColor) {
+    const GfVec4f ox(m_width, 0., 0., 0.);
+    const GfVec4f oy(0., m_height, 0., 0.);
 
-    const GfVec4d oxTrans = ox * transform;
-    const GfVec4d oyTrans = oy * transform;
+    const GfVec4f oxTrans = ox * transform;
+    const GfVec4f oyTrans = oy * transform;
 
     return static_cast<float>(1. / (oxTrans.GetLength() * oyTrans.GetLength())) * inColor;
 }

--- a/pxr/imaging/plugin/hdRpr/rectLight.h
+++ b/pxr/imaging/plugin/hdRpr/rectLight.h
@@ -8,8 +8,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdRprRectLight : public HdRprLightBase {
 
 public:
-    HdRprRectLight(SdfPath const& id, HdRprApiSharedPtr rprApi)
-        : HdRprLightBase(id, rprApi) {
+    HdRprRectLight(SdfPath const& id)
+        : HdRprLightBase(id) {
     }
 
 protected:
@@ -17,10 +17,10 @@ protected:
     bool SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath const& id) override;
 
     // Create light mesh which is required to be set emmisive material 
-    RprApiObjectPtr CreateLightMesh() override;
+    RprApiObjectPtr CreateLightMesh(HdRprApi* rprApi) override;
 
     // Normalize Light Color with surface area
-    GfVec3f NormalizeLightColor(const GfMatrix4d& transform, const GfVec3f& emmisionColor) override;
+    GfVec3f NormalizeLightColor(const GfMatrix4f& transform, const GfVec3f& emmisionColor) override;
 
 private:
     float m_width = std::numeric_limits<float>::quiet_NaN();

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.h
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.h
@@ -3,15 +3,14 @@
 
 #include "pxr/imaging/hd/renderBuffer.h"
 
-#include "rprApi.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
+
+class HdRprApi;
 
 class HdRprRenderBuffer final : public HdRenderBuffer {
 public:
-    HdRprRenderBuffer(SdfPath const& id, HdRprApiSharedPtr rprApi);
-
-    virtual HdDirtyBits GetInitialDirtyBitsMask() const override;
+    HdRprRenderBuffer(SdfPath const& id, HdRprApi* rprApi);
+    ~HdRprRenderBuffer() override = default;
 
     bool Allocate(GfVec3i const& dimensions,
                   HdFormat format,
@@ -40,10 +39,10 @@ public:
     void SetConverged(bool converged);
 
 protected:
-    virtual void _Deallocate() override;
+    void _Deallocate() override;
 
 private:
-    HdRprApiWeakPtr m_rprApiWeakPrt;
+    HdRprApi* m_rprApi;
     TfToken m_aovName;
     uint32_t m_width = 0u;
     uint32_t m_height = 0u;

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.h
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.h
@@ -5,12 +5,16 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class HdRprApi;
-
 class HdRprRenderBuffer final : public HdRenderBuffer {
 public:
-    HdRprRenderBuffer(SdfPath const& id, HdRprApi* rprApi);
+    HdRprRenderBuffer(SdfPath const& id);
     ~HdRprRenderBuffer() override = default;
+
+    void Sync(HdSceneDelegate* sceneDelegate,
+              HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits) override;
+
+    void Finalize(HdRenderParam* renderParam) override;
 
     bool Allocate(GfVec3i const& dimensions,
                   HdFormat format,
@@ -42,8 +46,6 @@ protected:
     void _Deallocate() override;
 
 private:
-    HdRprApi* m_rprApi;
-    TfToken m_aovName;
     uint32_t m_width = 0u;
     uint32_t m_height = 0u;
     HdFormat m_format = HdFormat::HdFormatInvalid;

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -67,6 +67,9 @@ HdRprDelegate::HdRprDelegate() {
     m_renderThread.SetRenderCallback([this]() {
         m_rprApi->Render(&m_renderThread);
     });
+    m_renderThread.SetStopCallback([this]() {
+        m_rprApi->AbortRender();
+    });
     m_renderThread.StartThread();
 }
 

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -4,6 +4,7 @@
 
 #include "config.h"
 #include "renderPass.h"
+#include "renderParam.h"
 #include "mesh.h"
 #include "instancer.h"
 #include "domeLight.h"
@@ -57,20 +58,15 @@ const TfTokenVector HdRprDelegate::SUPPORTED_BPRIM_TYPES = {
 };
 
 HdRprDelegate::HdRprDelegate() {
-    m_rprApiSharedPtr = std::shared_ptr<HdRprApi>(new HdRprApi);
+    m_rprApi.reset(new HdRprApi);
+    m_renderParam.reset(new HdRprRenderParam(m_rprApi.get()));
 
     m_settingDescriptors = HdRprConfig::GetRenderSettingDescriptors();
     _PopulateDefaultSettings(m_settingDescriptors);
 }
 
-HdRprDelegate::~HdRprDelegate() {
-    if (m_rprApiSharedPtr.use_count() > 1) {
-        TF_CODING_ERROR("Leaked rprApi reference");
-    }
-}
-
 HdRenderParam* HdRprDelegate::GetRenderParam() const {
-    return nullptr;
+    return m_renderParam.get();
 }
 
 void HdRprDelegate::CommitResources(HdChangeTracker* tracker) {
@@ -101,7 +97,7 @@ HdResourceRegistrySharedPtr HdRprDelegate::GetResourceRegistry() const {
 
 HdRenderPassSharedPtr HdRprDelegate::CreateRenderPass(HdRenderIndex* index,
                                                       HdRprimCollection const& collection) {
-    return HdRenderPassSharedPtr(new HdRprRenderPass(index, collection, m_rprApiSharedPtr));
+    return HdRenderPassSharedPtr(new HdRprRenderPass(index, collection, m_renderParam.get()));
 }
 
 HdInstancer* HdRprDelegate::CreateInstancer(HdSceneDelegate* delegate,
@@ -118,13 +114,13 @@ HdRprim* HdRprDelegate::CreateRprim(TfToken const& typeId,
                                     SdfPath const& rprimId,
                                     SdfPath const& instancerId) {
     if (typeId == HdPrimTypeTokens->mesh) {
-        return new HdRprMesh(rprimId, m_rprApiSharedPtr, instancerId);
+        return new HdRprMesh(rprimId, instancerId);
     } else if (typeId == HdPrimTypeTokens->basisCurves) {
-        return new HdRprBasisCurves(rprimId, m_rprApiSharedPtr, instancerId);
+        return new HdRprBasisCurves(rprimId, instancerId);
     }
 #ifdef USE_VOLUME
     else if (typeId == HdPrimTypeTokens->volume) {
-        return new HdRprVolume(rprimId, m_rprApiSharedPtr);
+        return new HdRprVolume(rprimId);
     }
 #endif
 
@@ -141,19 +137,19 @@ HdSprim* HdRprDelegate::CreateSprim(TfToken const& typeId,
     if (typeId == HdPrimTypeTokens->camera) {
         return new HdCamera(sprimId);
     } else if (typeId == HdPrimTypeTokens->domeLight) {
-        return new HdRprDomeLight(sprimId, m_rprApiSharedPtr);
+        return new HdRprDomeLight(sprimId);
     } else if (typeId == HdPrimTypeTokens->rectLight) {
-        return new HdRprRectLight(sprimId, m_rprApiSharedPtr);
+        return new HdRprRectLight(sprimId);
     } else if (typeId == HdPrimTypeTokens->sphereLight) {
-        return new HdRprSphereLight(sprimId, m_rprApiSharedPtr);
+        return new HdRprSphereLight(sprimId);
     } else if (typeId == HdPrimTypeTokens->cylinderLight) {
-        return new HdRprCylinderLight(sprimId, m_rprApiSharedPtr);
+        return new HdRprCylinderLight(sprimId);
     } else if (typeId == HdPrimTypeTokens->distantLight) {
-        return new HdRprDistantLight(sprimId, m_rprApiSharedPtr);
+        return new HdRprDistantLight(sprimId);
     } else if (typeId == HdPrimTypeTokens->diskLight) {
-        return new HdRprDiskLight(sprimId, m_rprApiSharedPtr);
+        return new HdRprDiskLight(sprimId);
     } else if (typeId == HdPrimTypeTokens->material) {
-        return new HdRprMaterial(sprimId, m_rprApiSharedPtr);
+        return new HdRprMaterial(sprimId);
     }
 
     TF_CODING_ERROR("Unknown Sprim Type %s", typeId.GetText());
@@ -166,19 +162,19 @@ HdSprim* HdRprDelegate::CreateFallbackSprim(TfToken const& typeId) {
     if (typeId == HdPrimTypeTokens->camera) {
         return new HdCamera(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->domeLight) {
-        return new HdRprDomeLight(SdfPath::EmptyPath(), m_rprApiSharedPtr);
+        return new HdRprDomeLight(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->rectLight) {
-        return new HdRprRectLight(SdfPath::EmptyPath(), m_rprApiSharedPtr);
+        return new HdRprRectLight(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->sphereLight) {
-        return new HdRprSphereLight(SdfPath::EmptyPath(), m_rprApiSharedPtr);
+        return new HdRprSphereLight(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->cylinderLight) {
-        return new HdRprCylinderLight(SdfPath::EmptyPath(), m_rprApiSharedPtr);
+        return new HdRprCylinderLight(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->diskLight) {
-        return new HdRprDiskLight(SdfPath::EmptyPath(), m_rprApiSharedPtr);
+        return new HdRprDiskLight(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->distantLight) {
-        return new HdRprDistantLight(SdfPath::EmptyPath(), m_rprApiSharedPtr);
+        return new HdRprDistantLight(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->material) {
-        return new HdRprMaterial(SdfPath::EmptyPath(), m_rprApiSharedPtr);
+        return new HdRprMaterial(SdfPath::EmptyPath());
     }
 
     TF_CODING_ERROR("Unknown Sprim Type %s", typeId.GetText());
@@ -192,11 +188,11 @@ void HdRprDelegate::DestroySprim(HdSprim* sPrim) {
 HdBprim* HdRprDelegate::CreateBprim(TfToken const& typeId,
                                     SdfPath const& bprimId) {
     if (typeId == HdPrimTypeTokens->renderBuffer) {
-        return new HdRprRenderBuffer(bprimId, m_rprApiSharedPtr);
+        return new HdRprRenderBuffer(bprimId, m_rprApi.get());
     }
 #ifdef USE_VOLUME
     else if (typeId == _tokens->openvdbAsset) {
-        return new HdRprField(bprimId, m_rprApiSharedPtr);
+        return new HdRprField(bprimId);
     }
 #endif
 
@@ -248,14 +244,14 @@ HdRenderSettingDescriptorList HdRprDelegate::GetRenderSettingDescriptors() const
 
 VtDictionary HdRprDelegate::GetRenderStats() const {
     VtDictionary stats;
-    int numCompletedSamples = m_rprApiSharedPtr->GetNumCompletedSamples();
+    int numCompletedSamples = m_rprApi->GetNumCompletedSamples();
     stats[HdPerfTokens->numCompletedSamples.GetString()] = numCompletedSamples;
 
     double percentDone = double(numCompletedSamples) / HdRprConfig::GetInstance().GetMaxSamples();
-    int numActivePixels = m_rprApiSharedPtr->GetNumActivePixels();
+    int numActivePixels = m_rprApi->GetNumActivePixels();
     if (numActivePixels != -1) {
         int width, height;
-        if (m_rprApiSharedPtr->GetAovInfo(m_rprApiSharedPtr->GetActiveAov(), &width, &height, nullptr)) {
+        if (m_rprApi->GetAovInfo(m_rprApi->GetActiveAov(), &width, &height, nullptr)) {
             int numPixels = width * height;
             percentDone = std::max(percentDone, double(numPixels - numActivePixels) / numPixels);
         }

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -2,6 +2,7 @@
 #define HDRPR_RENDER_DELEGATE_H
 
 #include "pxr/imaging/hd/renderDelegate.h"
+#include "pxr/imaging/hd/renderThread.h"
 
 #include "api.h"
 
@@ -58,10 +59,11 @@ public:
 
     HdRenderSettingDescriptorList GetRenderSettingDescriptors() const override;
 
-    ///
-    /// Returns an open-format dictionary of render statistics
-    ///
     VtDictionary GetRenderStats() const override;
+
+    bool IsPauseSupported() const override;
+    bool Pause() override;
+    bool Resume() override;
 private:
     static const TfTokenVector SUPPORTED_RPRIM_TYPES;
     static const TfTokenVector SUPPORTED_SPRIM_TYPES;
@@ -70,6 +72,7 @@ private:
     std::unique_ptr<HdRprApi> m_rprApi;
     std::unique_ptr<HdRprRenderParam> m_renderParam;
     HdRenderSettingDescriptorList m_settingDescriptors;
+    HdRenderThread m_renderThread;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -1,10 +1,10 @@
 #ifndef HDRPR_RENDER_DELEGATE_H
 #define HDRPR_RENDER_DELEGATE_H
 
-#include "pxr/imaging/hd/renderDelegate.h"
-#include "pxr/imaging/hd/renderThread.h"
-
 #include "api.h"
+#include "renderThread.h"
+
+#include "pxr/imaging/hd/renderDelegate.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -72,7 +72,7 @@ private:
     std::unique_ptr<HdRprApi> m_rprApi;
     std::unique_ptr<HdRprRenderParam> m_renderParam;
     HdRenderSettingDescriptorList m_settingDescriptors;
-    HdRenderThread m_renderThread;
+    HdRprRenderThread m_renderThread;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -1,19 +1,20 @@
 #ifndef HDRPR_RENDER_DELEGATE_H
 #define HDRPR_RENDER_DELEGATE_H
 
-#include "pxr/pxr.h"
 #include "pxr/imaging/hd/renderDelegate.h"
 
 #include "api.h"
-#include "rprApi.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+class HdRprRenderParam;
+class HdRprApi;
 
 class HdRprDelegate final : public HdRenderDelegate {
 public:
 
     HdRprDelegate();
-    ~HdRprDelegate() override;
+    ~HdRprDelegate() override = default;
 
     HdRprDelegate(const HdRprDelegate&) = delete;
     HdRprDelegate& operator =(const HdRprDelegate&) = delete;
@@ -66,7 +67,8 @@ private:
     static const TfTokenVector SUPPORTED_SPRIM_TYPES;
     static const TfTokenVector SUPPORTED_BPRIM_TYPES;
 
-    HdRprApiSharedPtr m_rprApiSharedPtr;
+    std::unique_ptr<HdRprApi> m_rprApi;
+    std::unique_ptr<HdRprRenderParam> m_renderParam;
     HdRenderSettingDescriptorList m_settingDescriptors;
 };
 

--- a/pxr/imaging/plugin/hdRpr/renderParam.h
+++ b/pxr/imaging/plugin/hdRpr/renderParam.h
@@ -2,6 +2,7 @@
 #define HDRPR_RENDER_PARAM_H
 
 #include "pxr/imaging/hd/renderDelegate.h"
+#include "pxr/imaging/hd/renderThread.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -9,24 +10,24 @@ class HdRprApi;
 
 class HdRprRenderParam final : public HdRenderParam {
 public:
-    HdRprRenderParam(HdRprApi* rprApi)
-        : m_rprApi(rprApi) {
+    HdRprRenderParam(HdRprApi* rprApi, HdRenderThread* renderThread)
+        : m_rprApi(rprApi)
+        , m_renderThread(renderThread) {
 
     }
     ~HdRprRenderParam() override = default;
 
     HdRprApi const* GetRprApi() const { return m_rprApi; }
     HdRprApi* AcquireRprApiForEdit() {
-        m_sceneEdited.store(true);
+        m_renderThread->StopRender();
         return m_rprApi;
     }
 
-    bool IsSceneEdited() const { return m_sceneEdited.load(); }
-    void ResetSceneEdited() { m_sceneEdited.store(false); }
+    HdRenderThread* GetRenderThread() { return m_renderThread;  }
 
 private:
     HdRprApi* m_rprApi;
-    std::atomic<bool> m_sceneEdited;
+    HdRenderThread* m_renderThread;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderParam.h
+++ b/pxr/imaging/plugin/hdRpr/renderParam.h
@@ -1,0 +1,34 @@
+#ifndef HDRPR_RENDER_PARAM_H
+#define HDRPR_RENDER_PARAM_H
+
+#include "pxr/imaging/hd/renderDelegate.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdRprApi;
+
+class HdRprRenderParam final : public HdRenderParam {
+public:
+    HdRprRenderParam(HdRprApi* rprApi)
+        : m_rprApi(rprApi) {
+
+    }
+    ~HdRprRenderParam() override = default;
+
+    HdRprApi const* GetRprApi() const { return m_rprApi; }
+    HdRprApi* AcquireRprApiForEdit() {
+        m_sceneEdited.store(true);
+        return m_rprApi;
+    }
+
+    bool IsSceneEdited() const { return m_sceneEdited.load(); }
+    void ResetSceneEdited() { m_sceneEdited.store(false); }
+
+private:
+    HdRprApi* m_rprApi;
+    std::atomic<bool> m_sceneEdited;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDRPR_RENDER_PARAM_H

--- a/pxr/imaging/plugin/hdRpr/renderParam.h
+++ b/pxr/imaging/plugin/hdRpr/renderParam.h
@@ -1,8 +1,9 @@
 #ifndef HDRPR_RENDER_PARAM_H
 #define HDRPR_RENDER_PARAM_H
 
+#include "renderThread.h"
+
 #include "pxr/imaging/hd/renderDelegate.h"
-#include "pxr/imaging/hd/renderThread.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -10,7 +11,7 @@ class HdRprApi;
 
 class HdRprRenderParam final : public HdRenderParam {
 public:
-    HdRprRenderParam(HdRprApi* rprApi, HdRenderThread* renderThread)
+    HdRprRenderParam(HdRprApi* rprApi, HdRprRenderThread* renderThread)
         : m_rprApi(rprApi)
         , m_renderThread(renderThread) {
 
@@ -23,11 +24,11 @@ public:
         return m_rprApi;
     }
 
-    HdRenderThread* GetRenderThread() { return m_renderThread;  }
+    HdRprRenderThread* GetRenderThread() { return m_renderThread;  }
 
 private:
     HdRprApi* m_rprApi;
-    HdRenderThread* m_renderThread;
+    HdRprRenderThread* m_renderThread;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -3,6 +3,8 @@
 #include "config.h"
 #include "rprApi.h"
 #include "renderBuffer.h"
+#include "renderParam.h"
+
 #include "pxr/imaging/hd/renderPassState.h"
 #include "pxr/imaging/hd/renderIndex.h"
 
@@ -12,20 +14,17 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 HdRprRenderPass::HdRprRenderPass(HdRenderIndex* index,
                                  HdRprimCollection const& collection,
-                                 HdRprApiSharedPtr rprApi)
+                                 HdRprRenderParam* renderParam)
     : HdRenderPass(index, collection)
-    , m_lastSettingsVersion(0) {
-    m_rprApiWeakPtr = rprApi;
+    , m_lastSettingsVersion(0)
+    , m_renderParam(renderParam) {
+
 }
 
 void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState, TfTokenVector const& renderTags) {
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        return;
-    }
-
     HdRprConfig::GetInstance().Sync(GetRenderIndex()->GetRenderDelegate());
+
+    auto rprApi = m_renderParam->AcquireRprApiForEdit();
 
     auto& cameraViewMatrix = rprApi->GetCameraViewMatrix();
     auto& wvm = renderPassState->GetWorldToViewMatrix();

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -21,7 +21,11 @@ HdRprRenderPass::HdRprRenderPass(HdRenderIndex* index,
 }
 
 void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState, TfTokenVector const& renderTags) {
-    HdRprConfig::GetInstance().Sync(GetRenderIndex()->GetRenderDelegate());
+    auto& config = HdRprConfig::GetInstance();
+    config.Sync(GetRenderIndex()->GetRenderDelegate());
+    if (config.IsDirty(HdRprConfig::DirtyAll)) {
+        m_renderParam->GetRenderThread()->StopRender();
+    }
 
     auto rprApiConst = m_renderParam->GetRprApi();
 

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -16,7 +16,6 @@ HdRprRenderPass::HdRprRenderPass(HdRenderIndex* index,
                                  HdRprimCollection const& collection,
                                  HdRprRenderParam* renderParam)
     : HdRenderPass(index, collection)
-    , m_lastSettingsVersion(0)
     , m_renderParam(renderParam) {
 
 }
@@ -24,90 +23,50 @@ HdRprRenderPass::HdRprRenderPass(HdRenderIndex* index,
 void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState, TfTokenVector const& renderTags) {
     HdRprConfig::GetInstance().Sync(GetRenderIndex()->GetRenderDelegate());
 
-    auto rprApi = m_renderParam->AcquireRprApiForEdit();
+    auto rprApiConst = m_renderParam->GetRprApi();
 
-    auto& cameraViewMatrix = rprApi->GetCameraViewMatrix();
+    auto& vp = renderPassState->GetViewport();
+    GfVec2i newViewportSize(static_cast<int>(vp[2]), static_cast<int>(vp[3]));
+    auto oldViewportSize = rprApiConst->GetViewportSize();
+    if (oldViewportSize != newViewportSize) {
+        m_renderParam->AcquireRprApiForEdit()->SetViewportSize(newViewportSize);
+    }
+
+    if (rprApiConst->GetAovBindings() != renderPassState->GetAovBindings()) {
+        m_renderParam->AcquireRprApiForEdit()->SetAovBindings(renderPassState->GetAovBindings());
+    }
+
+    auto& cameraViewMatrix = rprApiConst->GetCameraViewMatrix();
     auto& wvm = renderPassState->GetWorldToViewMatrix();
     if (cameraViewMatrix != wvm) {
-        rprApi->SetCameraViewMatrix(wvm);
+        m_renderParam->AcquireRprApiForEdit()->SetCameraViewMatrix(wvm);
     }
 
-    auto& cameraProjMatrix = rprApi->GetCameraProjectionMatrix();
+    auto& cameraProjMatrix = rprApiConst->GetCameraProjectionMatrix();
     auto proj = renderPassState->GetProjectionMatrix();
     if (cameraProjMatrix != proj) {
-        rprApi->SetCameraProjectionMatrix(proj);
+        m_renderParam->AcquireRprApiForEdit()->SetCameraProjectionMatrix(proj);
     }
 
-    auto& aovBindings = renderPassState->GetAovBindings();
-    if (aovBindings.empty() &&
-        (rprApi->GetActiveAov().IsEmpty() || !rprApi->GetAovInfo(rprApi->GetActiveAov(), nullptr, nullptr, nullptr))) {
-
-        auto& vp = renderPassState->GetViewport();
-        auto& aovToEnable = rprApi->GetActiveAov().IsEmpty() ? HdRprAovTokens->color : rprApi->GetActiveAov();
-        rprApi->EnableAov(aovToEnable, vp[2], vp[3], HdFormatFloat32Vec4);
-    }
-
-    rprApi->Render();
-    m_isConverged = rprApi->IsConverged();
-
-    if (aovBindings.empty()) {
-        auto& activeAov = rprApi->GetActiveAov();
-        int aovWidth;
-        int aovHeight;
-        HdFormat aovFormat;
-        if (rprApi->GetAovInfo(activeAov, &aovWidth, &aovHeight, &aovFormat)) {
-            std::vector<uint8_t> buffer;
-            buffer.reserve(aovWidth * aovHeight * HdDataSizeOfFormat(aovFormat));
-            if (rprApi->GetAovData(activeAov, buffer.data(), buffer.capacity())) {
-                float currentZoomX;
-                float currentZoomY;
-                glGetFloatv(GL_ZOOM_X, &currentZoomX);
-                glGetFloatv(GL_ZOOM_Y, &currentZoomY);
-
-                if (aovFormat == HdFormatInt32) {
-                    aovFormat = HdFormatUNorm8Vec4;
-                }
-                auto componentFormat = HdGetComponentFormat(aovFormat);
-                auto componentCount = HdGetComponentCount(aovFormat);
-
-                GLenum format;
-                if (componentCount == 4) {
-                    format = GL_RGBA;
-                } else if (componentCount == 3) {
-                    format = GL_RGB;
-                } else if (componentCount == 2) {
-                    format = GL_RG;
-                } else {
-                    format = GL_R;
-                }
-
-                GLenum type;
-                if (componentFormat == HdFormatUNorm8) {
-                    type = GL_UNSIGNED_BYTE;
-                } else if (componentFormat == HdFormatFloat16) {
-                    type = GL_HALF_FLOAT;
-                } else if (componentFormat == HdFormatFloat32) {
-                    type = GL_FLOAT;
-                }
-
-                // Viewport size is not required to be of the same size as AOV framebuffer
-                auto& vp = renderPassState->GetViewport();
-                glPixelZoom(float(vp[2]) / aovWidth, float(vp[3]) / aovHeight);
-                glDrawPixels(aovWidth, aovHeight, format, type, buffer.data());
-                glPixelZoom(currentZoomX, currentZoomY);
+    if (rprApiConst->IsChanged()) {
+        for (auto& aovBinding : renderPassState->GetAovBindings()) {
+            if (aovBinding.renderBuffer) {
+                auto rprRenderBuffer = static_cast<HdRprRenderBuffer*>(aovBinding.renderBuffer);
+                rprRenderBuffer->SetConverged(false);
             }
         }
-    } else {
-        for (auto& aovBinding : aovBindings) {
-            auto buff = static_cast<HdRprRenderBuffer*>(aovBinding.renderBuffer);
-            if (!buff) {
-                buff = static_cast<HdRprRenderBuffer*>(GetRenderIndex()->GetBprim(HdPrimTypeTokens->renderBuffer, aovBinding.renderBufferId));
-            }
-            if (buff) {
-                buff->SetConverged(m_isConverged);
-            }
+        m_renderParam->GetRenderThread()->StartRender();
+    }
+}
+
+bool HdRprRenderPass::IsConverged() const {
+    for (auto& aovBinding : m_renderParam->GetRprApi()->GetAovBindings()) {
+        if (aovBinding.renderBuffer &&
+            !aovBinding.renderBuffer->IsConverged()) {
+            return false;
         }
     }
+    return true;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderPass.h
+++ b/pxr/imaging/plugin/hdRpr/renderPass.h
@@ -17,16 +17,13 @@ public:
 
     ~HdRprRenderPass() override = default;
 
-    bool IsConverged() const override { return m_isConverged; }
+    bool IsConverged() const override;
 
     void _Execute(HdRenderPassStateSharedPtr const& renderPassState,
                   TfTokenVector const& renderTags) override;
 
 private:
     HdRprRenderParam* m_renderParam;
-
-    int m_lastSettingsVersion;
-    bool m_isConverged = false;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderPass.h
+++ b/pxr/imaging/plugin/hdRpr/renderPass.h
@@ -7,11 +7,13 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdRprRenderParam;
+
 class HdRprRenderPass final : public HdRenderPass {
 public:
     HdRprRenderPass(HdRenderIndex* index,
                     HdRprimCollection const& collection,
-                    HdRprApiSharedPtr rprApiShader);
+                    HdRprRenderParam* renderParam);
 
     ~HdRprRenderPass() override = default;
 
@@ -21,7 +23,7 @@ public:
                   TfTokenVector const& renderTags) override;
 
 private:
-    HdRprApiWeakPtr m_rprApiWeakPtr;
+    HdRprRenderParam* m_renderParam;
 
     int m_lastSettingsVersion;
     bool m_isConverged = false;

--- a/pxr/imaging/plugin/hdRpr/renderThread.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderThread.cpp
@@ -1,0 +1,141 @@
+#include "renderThread.h"
+
+#include "pxr/base/tf/diagnostic.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdRprRenderThread::HdRprRenderThread()
+    : m_stopCallback([]() {})
+    , m_renderCallback([]() { TF_CODING_ERROR("StartThread() called without a render callback set"); })
+    , m_shutdownCallback([]() {})
+    , m_requestedState(StateInitial)
+    , m_stopRequested(false)
+    , m_pauseRender(false)
+    , m_rendering(false) {
+
+}
+
+HdRprRenderThread::~HdRprRenderThread() {
+    StopThread();
+}
+
+void HdRprRenderThread::SetRenderCallback(std::function<void()> renderCallback) {
+    if (renderCallback) {
+        m_renderCallback = renderCallback;
+    }
+}
+
+void HdRprRenderThread::SetStopCallback(std::function<void()> stopCallback) {
+    if (stopCallback) {
+        m_stopCallback = stopCallback;
+    }
+}
+
+void HdRprRenderThread::SetShutdownCallback(std::function<void()> shutdownCallback) {
+    if (shutdownCallback) {
+        m_shutdownCallback = shutdownCallback;
+    }
+}
+
+void HdRprRenderThread::StartThread() {
+    if (m_renderThread.joinable()) {
+        TF_CODING_ERROR("StartThread() called while render thread is already running");
+        return;
+    }
+
+    m_requestedState = StateIdle;
+    m_renderThread = std::thread(&HdRprRenderThread::RenderLoop, this);
+}
+
+void HdRprRenderThread::StopThread() {
+    if (!m_renderThread.joinable()) {
+        return;
+    }
+
+    {
+        m_enableRender.clear();
+        std::unique_lock<std::mutex> lock(m_requestedStateMutex);
+        m_requestedState = StateTerminated;
+        m_requestedStateCV.notify_one();
+    }
+    m_renderThread.join();
+}
+
+bool HdRprRenderThread::IsThreadRunning() {
+    return m_renderThread.joinable();
+}
+
+void HdRprRenderThread::StartRender() {
+    if (!IsRendering()) {
+        std::unique_lock<std::mutex> lock(m_requestedStateMutex);
+        m_enableRender.test_and_set();
+        m_requestedState = StateRendering;
+        m_rendering.store(true);
+        m_requestedStateCV.notify_one();
+    }
+}
+
+void HdRprRenderThread::StopRender() {
+    if (IsRendering()) {
+        m_enableRender.clear();
+        if (m_pauseRender) {
+            // In case rendering thread was blocked by WaitUntilPaused, notify that stop is requested
+            m_pauseWaitCV.notify_one();
+        }
+        // In case rendering thread currently inside of some sort of rendering task that could be stopped call stopCallback to speed up return from renderCallback
+        m_stopCallback();
+        std::unique_lock<std::mutex> lock(m_requestedStateMutex);
+        m_requestedState = StateIdle;
+        m_rendering.store(false);
+    }
+}
+
+bool HdRprRenderThread::IsRendering() {
+    return m_rendering.load();
+}
+
+bool HdRprRenderThread::IsStopRequested() {
+    if (!m_enableRender.test_and_set()) {
+        m_stopRequested = true;
+    }
+
+    return m_stopRequested;
+}
+
+void HdRprRenderThread::PauseRender() {
+    std::unique_lock<std::mutex> lock(m_pauseWaitMutex);
+    m_pauseRender = true;
+}
+
+void HdRprRenderThread::ResumeRender() {
+    std::unique_lock<std::mutex> lock(m_pauseWaitMutex);
+    m_pauseRender = false;
+    m_pauseWaitCV.notify_one();
+}
+
+void HdRprRenderThread::WaitUntilPaused() {
+    std::unique_lock<std::mutex> lock(m_pauseWaitMutex);
+    while (m_pauseRender && !IsStopRequested()) {
+        m_pauseWaitCV.wait(lock);
+    }
+}
+
+void HdRprRenderThread::RenderLoop() {
+    while (1) {
+        std::unique_lock<std::mutex> lock(m_requestedStateMutex);
+        m_requestedStateCV.wait(lock, [this]() {
+            return m_requestedState != StateIdle;
+        });
+        if (m_requestedState == StateRendering) {
+            m_renderCallback();
+            m_stopRequested = false;
+            m_rendering.store(false);
+            m_requestedState = StateIdle;
+        } else if (m_requestedState == StateTerminated) {
+            break;
+        }
+    }
+    m_shutdownCallback();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderThread.h
+++ b/pxr/imaging/plugin/hdRpr/renderThread.h
@@ -1,0 +1,66 @@
+#ifndef HDRPR_RENDER_THREAD_H
+#define HDRPR_RENDER_THREAD_H
+
+#include "pxr/pxr.h"
+
+#include <atomic>
+#include <thread>
+#include <mutex>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdRprRenderThread {
+public:
+    HdRprRenderThread();
+    ~HdRprRenderThread();
+
+    void SetStopCallback(std::function<void()> stopCallback);
+    void SetRenderCallback(std::function<void()> renderCallback);
+    void SetShutdownCallback(std::function<void()> shutdownCallback);
+
+    void StartThread();
+    void StopThread();
+    bool IsThreadRunning();
+
+    void StartRender();
+    void StopRender();
+    bool IsStopRequested();
+    bool IsRendering();
+
+    void PauseRender();
+    void ResumeRender();
+
+    void WaitUntilPaused();
+
+private:
+    void RenderLoop();
+
+    std::function<void()> m_stopCallback;
+    std::function<void()> m_renderCallback;
+    std::function<void()> m_shutdownCallback;
+
+    enum State {
+        StateInitial,
+        StateIdle,
+        StateRendering,
+        StateTerminated,
+    };
+
+    State m_requestedState;
+    std::mutex m_requestedStateMutex;
+    std::condition_variable m_requestedStateCV;
+
+    std::mutex m_pauseWaitMutex;
+    std::condition_variable m_pauseWaitCV;
+    bool m_pauseRender;
+
+    std::atomic_flag m_enableRender;
+    bool m_stopRequested;
+
+    std::atomic<bool> m_rendering;
+    std::thread m_renderThread;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDRPR_RENDER_THREAD_H

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1362,7 +1362,7 @@ public:
     }
 
     bool IsChanged() const {
-        return m_dirtyFlags != ChangeTracker::Clean;
+        return m_dirtyFlags != ChangeTracker::Clean || HdRprConfig::GetInstance().IsDirty(HdRprConfig::DirtyAll);
     }
 
     bool IsConverged() const {

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1348,9 +1348,10 @@ public:
     }
 
     void AbortRender() {
-        if (m_rprContext && m_rendering) {
+        // XXX: disable until FIR-1588 resolved
+        /*if (m_rprContext && m_rendering) {
             RPR_ERROR_CHECK(rprContextAbortRender(m_rprContext->GetHandle()), "Failed to abort render");
-        }
+        }*/
     }
 
     int GetNumCompletedSamples() const {

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1819,9 +1819,8 @@ RprApiObjectPtr HdRprApi::CreateMaterial(MaterialAdapter& materialAdapter) {
     return m_impl->CreateMaterial(materialAdapter);
 }
 
-void HdRprApi::SetMeshTransform(RprApiObject* mesh, const GfMatrix4d& transform) {
-    GfMatrix4f transformF(transform);
-    m_impl->SetMeshTransform(mesh->GetHandle(), transformF);
+void HdRprApi::SetMeshTransform(RprApiObject* mesh, const GfMatrix4f& transform) {
+    m_impl->SetMeshTransform(mesh->GetHandle(), transform);
 }
 
 void HdRprApi::SetMeshRefineLevel(RprApiObject* mesh, int level) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -9,6 +9,8 @@
 #include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/gf/quaternion.h"
 #include "pxr/imaging/hd/types.h"
+#include "pxr/imaging/hd/renderThread.h"
+#include "pxr/imaging/hd/renderPassState.h"
 #include "pxr/base/tf/staticTokens.h"
 
 #include "rprcpp/rprObject.h"
@@ -103,26 +105,21 @@ public:
 
     const GfMatrix4d& GetCameraViewMatrix() const;
     const GfMatrix4d& GetCameraProjectionMatrix() const;
-    void SetCameraViewMatrix(const GfMatrix4d& m );
+    void SetCameraViewMatrix(const GfMatrix4d& m);
     void SetCameraProjectionMatrix(const GfMatrix4d& m);
 
-    bool EnableAov(TfToken const& aovName, int width, int height, HdFormat format = HdFormatCount);
-    void DisableAov(TfToken const& aovName);
-    bool IsAovEnabled(TfToken const& aovName);
-    bool GetAovInfo(TfToken const& aovName, int* width, int* height, HdFormat* format) const;
-    bool GetAovData(TfToken const& aovName, void* dstBuffer, size_t dstBufferSize);
+    GfVec2i GetViewportSize() const;
+    void SetViewportSize(GfVec2i const& size);
 
-    // This function exist for only one particular reason:
-    //   for explicit bliting to GL framebuffer when there are no aovBindings in renderPass::_Execute
-    //   we need to know the latest enabled AOV so we can draw it
-    TfToken const& GetActiveAov() const;
+    void SetAovBindings(HdRenderPassAovBindingVector const& aovBindings);
+    HdRenderPassAovBindingVector GetAovBindings() const;
 
-    void Render();
-    bool IsConverged();
     int GetNumCompletedSamples() const;
     // returns -1 if adaptive sampling is not used
     int GetNumActivePixels() const;
 
+    void Render(HdRenderThread* renderThread);
+    bool IsChanged() const;
     bool IsGlInteropEnabled() const;
 
     static std::string GetAppDataPath();
@@ -131,9 +128,6 @@ public:
 private:
     HdRprApiImpl* m_impl = nullptr;
 };
-
-typedef std::shared_ptr<HdRprApi> HdRprApiSharedPtr;
-typedef std::weak_ptr<HdRprApi> HdRprApiWeakPtr;
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -2,6 +2,8 @@
 #define HDRPR_RPR_API_H
 
 #include "api.h"
+#include "renderThread.h"
+#include "rprcpp/rprObject.h"
 
 #include "pxr/base/gf/vec2i.h"
 #include "pxr/base/gf/vec3f.h"
@@ -9,11 +11,8 @@
 #include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/gf/quaternion.h"
 #include "pxr/imaging/hd/types.h"
-#include "pxr/imaging/hd/renderThread.h"
 #include "pxr/imaging/hd/renderPassState.h"
 #include "pxr/base/tf/staticTokens.h"
-
-#include "rprcpp/rprObject.h"
 
 #include <memory>
 #include <vector>
@@ -118,7 +117,9 @@ public:
     // returns -1 if adaptive sampling is not used
     int GetNumActivePixels() const;
 
-    void Render(HdRenderThread* renderThread);
+    void Render(HdRprRenderThread* renderThread);
+    void AbortRender();
+
     bool IsChanged() const;
     bool IsGlInteropEnabled() const;
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -6,7 +6,7 @@
 #include "pxr/base/gf/vec2i.h"
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/vt/array.h"
-#include "pxr/base/gf/matrix4d.h"
+#include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/gf/quaternion.h"
 #include "pxr/imaging/hd/types.h"
 #include "pxr/base/tf/staticTokens.h"
@@ -89,7 +89,7 @@ public:
 
     RprApiObjectPtr CreateMesh(const VtVec3fArray& points, const VtIntArray& pointIndexes, const VtVec3fArray& normals, const VtIntArray& normalIndexes, const VtVec2fArray& uv, const VtIntArray& uvIndexes, const VtIntArray& vpf, TfToken const& polygonWinding);
     RprApiObjectPtr CreateMeshInstance(RprApiObject* prototypeMesh);
-    void SetMeshTransform(RprApiObject* mesh, const GfMatrix4d& transform);
+    void SetMeshTransform(RprApiObject* mesh, const GfMatrix4f& transform);
     void SetMeshRefineLevel(RprApiObject* mesh, int level);
     void SetMeshVertexInterpolationRule(RprApiObject* mesh, TfToken boundaryInterpolation);
     void SetMeshMaterial(RprApiObject* mesh, RprApiObject const* material);

--- a/pxr/imaging/plugin/hdRpr/sphereLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/sphereLight.cpp
@@ -1,4 +1,5 @@
 #include "sphereLight.h"
+#include "rprApi.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
 
 #include <cmath>
@@ -15,17 +16,11 @@ bool HdRprSphereLight::SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath co
     return isDirty;
 }
 
-RprApiObjectPtr HdRprSphereLight::CreateLightMesh() {
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        return nullptr;
-    }
-
+RprApiObjectPtr HdRprSphereLight::CreateLightMesh(HdRprApi* rprApi) {
     return rprApi->CreateSphereLightMesh(m_radius);
 }
 
-GfVec3f HdRprSphereLight::NormalizeLightColor(const GfMatrix4d& transform, const GfVec3f& inColor) {
+GfVec3f HdRprSphereLight::NormalizeLightColor(const GfMatrix4f& transform, const GfVec3f& inColor) {
     const double sx = GfVec3d(transform[0][0], transform[1][0], transform[2][0]).GetLength() * m_radius;
     const double sy = GfVec3d(transform[0][1], transform[1][1], transform[2][1]).GetLength() * m_radius;
     const double sz = GfVec3d(transform[0][2], transform[1][2], transform[2][2]).GetLength() * m_radius;

--- a/pxr/imaging/plugin/hdRpr/sphereLight.h
+++ b/pxr/imaging/plugin/hdRpr/sphereLight.h
@@ -8,18 +8,18 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdRprSphereLight : public HdRprLightBase {
 
 public:
-    HdRprSphereLight(SdfPath const& id, HdRprApiSharedPtr rprApi)
-        : HdRprLightBase(id, rprApi) {
+    HdRprSphereLight(SdfPath const& id)
+        : HdRprLightBase(id) {
     }
 
 protected:
     bool SyncGeomParams(HdSceneDelegate* sceneDelegate, SdfPath const& id) override;
 
     // Create mesh with emmisive material
-    RprApiObjectPtr CreateLightMesh() override;
+    RprApiObjectPtr CreateLightMesh(HdRprApi* rprApi) override;
 
     // Normalize Light Color with surface area
-    GfVec3f NormalizeLightColor(const GfMatrix4d& transform, const GfVec3f& emmisionColor) override;
+    GfVec3f NormalizeLightColor(const GfMatrix4f& transform, const GfVec3f& emmisionColor) override;
 
 private:
     float m_radius = std::numeric_limits<float>::quiet_NaN();

--- a/pxr/imaging/plugin/hdRpr/volume.cpp
+++ b/pxr/imaging/plugin/hdRpr/volume.cpp
@@ -1,4 +1,6 @@
 #include "volume.h"
+#include "rprApi.h"
+#include "renderParam.h"
 
 #include "houdini/openvdb.h"
 
@@ -71,9 +73,8 @@ struct GridData {
     }
 };
 
-HdRprVolume::HdRprVolume(SdfPath const& id, HdRprApiSharedPtr rprApi)
-    : HdVolume(id)
-    , m_rprApiWeakPtr(rprApi) {
+HdRprVolume::HdRprVolume(SdfPath const& id)
+    : HdVolume(id) {
 
 }
 
@@ -82,12 +83,9 @@ void HdRprVolume::Sync(
     HdRenderParam* renderParam,
     HdDirtyBits* dirtyBits,
     TfToken const& reprName) {
-    auto rprApi = m_rprApiWeakPtr.lock();
-    if (!rprApi) {
-        TF_CODING_ERROR("RprApi is expired");
-        *dirtyBits = HdChangeTracker::Clean;
-        return;
-    }
+
+    auto rprRenderParam = static_cast<HdRprRenderParam*>(renderParam);
+    auto rprApi = rprRenderParam->AcquireRprApiForEdit();
 
     auto& id = GetId();
 

--- a/pxr/imaging/plugin/hdRpr/volume.cpp
+++ b/pxr/imaging/plugin/hdRpr/volume.cpp
@@ -292,13 +292,19 @@ HdDirtyBits HdRprVolume::_PropagateDirtyBits(HdDirtyBits bits) const {
     return bits;
 }
 
-void
-HdRprVolume::_InitRepr(TfToken const& reprName,
+void HdRprVolume::_InitRepr(TfToken const& reprName,
                        HdDirtyBits* dirtyBits) {
     TF_UNUSED(reprName);
     TF_UNUSED(dirtyBits);
 
     // No-op
+}
+
+void HdRprVolume::Finalize(HdRenderParam* renderParam) {
+    // Stop render thread to safely release resources
+    static_cast<HdRprRenderParam*>(renderParam)->GetRenderThread()->StopRender();
+
+    HdVolume::Finalize(renderParam);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/volume.h
+++ b/pxr/imaging/plugin/hdRpr/volume.h
@@ -21,6 +21,8 @@ public:
         TfToken const& reprName
     ) override;
 
+    void Finalize(HdRenderParam* renderParam) override;
+
 protected:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 

--- a/pxr/imaging/plugin/hdRpr/volume.h
+++ b/pxr/imaging/plugin/hdRpr/volume.h
@@ -1,16 +1,17 @@
 #ifndef HDRPR_VOLUME_H
 #define HDRPR_VOLUME_H
 
-#include "rprApi.h"
-
 #include "pxr/imaging/hd/volume.h"
 #include "pxr/base/gf/matrix4f.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class RprApiObject;
+using RprApiObjectPtr = std::unique_ptr<RprApiObject>;
+
 class HdRprVolume : public HdVolume {
 public:
-    HdRprVolume(SdfPath const& id, HdRprApiSharedPtr rprApi);
+    HdRprVolume(SdfPath const& id);
     ~HdRprVolume() override = default;
 
     void Sync(
@@ -29,7 +30,6 @@ protected:
                    HdDirtyBits* dirtyBits) override;
 
 private:
-    HdRprApiWeakPtr m_rprApiWeakPtr;
     RprApiObjectPtr m_rprHeteroVolume;
     GfMatrix4f m_transform;
 };


### PR DESCRIPTION
* Move rendering to separate thread that can be paused/unpaused and stopped when needed.
    HdRprRenderBuffer now is simple proxy primitive that shared between rendering thread and main Hydra thread
* Use HdRenderParam to pass HdRprApi and HdRenderThread objects across primitives
    So instead of storing a weak pointer to HdRprApi in each primitive, HdRprApi queried from HdRenderParam
* Whenever the scene is going to be changed render thread must be stopped


Resolves #74 