### PR TITLE
Avoid false render stops

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -263,7 +263,12 @@ VtDictionary HdRprDelegate::GetRenderStats() const {
     int numCompletedSamples = m_rprApi->GetNumCompletedSamples();
     stats[HdPerfTokens->numCompletedSamples.GetString()] = numCompletedSamples;
 
-    double percentDone = double(numCompletedSamples) / HdRprConfig::GetInstance().GetMaxSamples();
+    double percentDone = 0.0;
+    {
+        HdRprConfig* config;
+        auto configInstanceLock = HdRprConfig::GetInstance(&config);
+        percentDone = double(numCompletedSamples) / config->GetMaxSamples();
+    }
     int numActivePixels = m_rprApi->GetNumActivePixels();
     if (numActivePixels != -1) {
         auto size = m_rprApi->GetViewportSize();
@@ -291,11 +296,15 @@ bool HdRprDelegate::Resume() {
 PXR_NAMESPACE_CLOSE_SCOPE
 
 void SetHdRprRenderDevice(int renderDevice) {
-    PXR_INTERNAL_NS::HdRprConfig::GetInstance().SetRenderDevice(renderDevice);
+    PXR_INTERNAL_NS::HdRprConfig* config;
+    auto configInstanceLock = PXR_INTERNAL_NS::HdRprConfig::GetInstance(&config);
+    config->SetRenderDevice(renderDevice);
 }
 
 void SetHdRprRenderQuality(int quality) {
-    PXR_INTERNAL_NS::HdRprConfig::GetInstance().SetRenderQuality(quality);
+    PXR_INTERNAL_NS::HdRprConfig* config;
+    auto configInstanceLock = PXR_INTERNAL_NS::HdRprConfig::GetInstance(&config);
+    config->SetRenderQuality(quality);
 }
 
 int GetHdRprRenderQuality() {

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -21,10 +21,13 @@ HdRprRenderPass::HdRprRenderPass(HdRenderIndex* index,
 }
 
 void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState, TfTokenVector const& renderTags) {
-    auto& config = HdRprConfig::GetInstance();
-    config.Sync(GetRenderIndex()->GetRenderDelegate());
-    if (config.IsDirty(HdRprConfig::DirtyAll)) {
-        m_renderParam->GetRenderThread()->StopRender();
+    {
+        HdRprConfig* config;
+        auto configInstanceLock = HdRprConfig::GetInstance(&config);
+        config->Sync(GetRenderIndex()->GetRenderDelegate());
+        if (config->IsDirty(HdRprConfig::DirtyAll)) {
+            m_renderParam->GetRenderThread()->StopRender();
+        }
     }
 
     auto rprApiConst = m_renderParam->GetRprApi();


### PR DESCRIPTION
In Houdini, it's possible that `HdRpRenderPass::_Execute` called multiple times while `HdRprApi::Update` was not finished yet, in such case render stop would be called because `HdRprConfig` is still dirty. Lock `HdRprConfig` instance before reading/writing  to avoid it