### PR TITLE
Fix crash caused by over-release of displacement material node

### DIFF
--- a/pxr/imaging/plugin/hdRpr/materialFactory.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialFactory.cpp
@@ -295,7 +295,6 @@ void RprMaterialFactory::DeleteMaterial(RprApiMaterial* material) {
     }
 
     SAFE_DELETE_RPR_OBJECT(material->rootMaterial);
-    SAFE_DELETE_RPR_OBJECT(material->displacementMaterial);
     for (auto node : material->materialNodes) {
         SAFE_DELETE_RPR_OBJECT(node);
     }


### PR DESCRIPTION
The same RPR object of `displacementMaterial` was released twice: explicitly via `SAFE_DELETE_RPR_OBJECT(material->displacementMaterial)` and when all retained material nodes (`RprApiMaterial::materialNodes`) were released later

Resolves #157