### PR TITLE
Fix mesh displacement material setting

### DIFF
--- a/pxr/imaging/plugin/hdRpr/materialFactory.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialFactory.cpp
@@ -304,12 +304,22 @@ void RprMaterialFactory::DeleteMaterial(RprApiMaterial* material) {
 
 void RprMaterialFactory::AttachMaterialToShape(rpr_shape mesh, const RprApiMaterial* material) {
     if (material) {
-        rprShapeSetMaterial(mesh, material->rootMaterial);
-        if (material->displacementMaterial) {
-            rprShapeSetDisplacementMaterial(mesh, material->displacementMaterial);
+        RPR_ERROR_CHECK(rprShapeSetMaterial(mesh, material->rootMaterial), "Failed to set shape material");
+
+        size_t dummy;
+        int subdFactor;
+        if (RPR_ERROR_CHECK(rprShapeGetInfo(mesh, RPR_SHAPE_SUBDIVISION_FACTOR, sizeof(subdFactor), &subdFactor, &dummy), "Failed to query mesh subdivision factor")) {
+            subdFactor = 0;
+        }
+
+        if (material->displacementMaterial && subdFactor > 0) {
+            RPR_ERROR_CHECK(rprShapeSetDisplacementMaterial(mesh, material->displacementMaterial), "Failed to set shape displacement material");
+        } else {
+            RPR_ERROR_CHECK(rprShapeSetDisplacementMaterial(mesh, nullptr), "Failed to unset shape displacement material");
         }
     } else {
-        rprShapeSetMaterial(mesh, nullptr);
+        RPR_ERROR_CHECK(rprShapeSetMaterial(mesh, nullptr), "Failed to unset shape material");
+        RPR_ERROR_CHECK(rprShapeSetDisplacementMaterial(mesh, nullptr), "Failed to unset shape displacement material");
     }
 }
 

--- a/pxr/imaging/plugin/hdRpr/materialFactory.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialFactory.cpp
@@ -312,6 +312,13 @@ void RprMaterialFactory::AttachMaterialToShape(rpr_shape mesh, const RprApiMater
             subdFactor = 0;
         }
 
+        if (subdFactor == 0) {
+            TF_WARN("Displacement material requires subdivision to be enabled. The subdivision will be enabled with refine level of 1");
+            if (!RPR_ERROR_CHECK(rprShapeSetSubdivisionFactor(mesh, 1), "Failed to set mesh subdividion")) {
+                subdFactor = 1;
+            }
+        }
+
         if (material->displacementMaterial && subdFactor > 0) {
             RPR_ERROR_CHECK(rprShapeSetDisplacementMaterial(mesh, material->displacementMaterial), "Failed to set shape displacement material");
         } else {

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -9,6 +9,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdRprApi;
 class HdRprParam;
 class RprApiObject;
 using RprApiObjectPtr = std::unique_ptr<RprApiObject>;
@@ -42,6 +43,8 @@ private:
                         VtArray<T>& out_data,
                         VtIntArray& out_indices);
 
+    RprApiObject const* GetFallbackMaterial(HdSceneDelegate* sceneDelegate, HdRprApi* rprApi, HdDirtyBits dirtyBits);
+
 private:
     std::vector<RprApiObjectPtr> m_rprMeshes;
     std::vector<std::vector<RprApiObjectPtr>> m_rprMeshInstances;
@@ -50,6 +53,7 @@ private:
     GfMatrix4f m_transform;
 
     HdMeshTopology m_topology;
+    HdGeomSubsets m_geomSubsets;
     VtVec3fArray m_points;
     VtIntArray m_faceVertexCounts;
     VtIntArray m_faceVertexIndices;


### PR DESCRIPTION
Displacement material relies on the mesh subdivision factor. Whenever the subdivision factor is 0 we need to unset displacement material and vice versa if the subdivision factor is greater than 0 we should set displacement material.