### PR TITLE
Fix RIF image creation

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifContext.cpp
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifContext.cpp
@@ -70,12 +70,12 @@ std::vector<rpr_char> GetRprCachePath(rpr_context rprContext) {
 rif_image_desc GetRifImageDesc(rpr::FrameBuffer* rprFrameBuffer) {
     auto rprDesc = rprFrameBuffer->GetDesc();
 
-    rif_image_desc imageDesc;
+    rif_image_desc imageDesc = {};
     imageDesc.image_width = rprDesc.fb_width;
     imageDesc.image_height = rprDesc.fb_height;
     imageDesc.image_depth = 1;
-    imageDesc.image_row_pitch = imageDesc.image_width;
-    imageDesc.image_slice_pitch = imageDesc.image_width * imageDesc.image_height;
+    imageDesc.image_row_pitch = 0;
+    imageDesc.image_slice_pitch = 0;
     imageDesc.num_components = 4;
     imageDesc.type = RIF_COMPONENT_TYPE_FLOAT32;
 

--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.cpp
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.cpp
@@ -80,7 +80,7 @@ FilterAIDenoise::FilterAIDenoise(Context* rifContext, std::uint32_t width, std::
     RIF_ERROR_CHECK_THROW(rifImageFilterSetParameter1f(m_auxFilters[RemapDepthFilter], "dstHi", 1.0f), "Failed to set filter parameter");
 
     // auxillary rif images
-    rif_image_desc desc = {width, height, 1, width, width * height, 4, RIF_COMPONENT_TYPE_FLOAT32};
+    auto desc = Image::GetDesc(width, height, HdFormatFloat32Vec4);
 
     m_auxImages.resize(AuxImageMax);
     m_auxImages[RemappedDepthImage] = rifContext->CreateImage(desc);
@@ -107,7 +107,7 @@ FilterEaw::FilterEaw(Context* rifContext, std::uint32_t width, std::uint32_t hei
     m_auxFilters[Mlaa] = rifContext->CreateImageFilter(RIF_IMAGE_FILTER_MLAA);
 
     // auxillary rif images
-    rif_image_desc desc = { width, height, 1, width, width * height, 4, RIF_COMPONENT_TYPE_FLOAT32 };
+    auto desc = Image::GetDesc(width, height, HdFormatFloat32Vec4);
 
     m_auxImages.resize(AuxImageMax);
     m_auxImages[ColorVarianceImage] = rifContext->CreateImage(desc);
@@ -237,7 +237,7 @@ void Filter::SetParam(const char* name, FilterParam param) {
 }
 
 void Filter::Resize(std::uint32_t width, std::uint32_t height) {
-    rif_image_desc desc = {width, height, 1, width, width * height, 4, RIF_COMPONENT_TYPE_FLOAT32};
+    auto desc = Image::GetDesc(width, height, HdFormatFloat32Vec4);
     for (auto& image : m_auxImages) {
         if (image) {
             image = m_rifContext->CreateImage(desc);

--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifImage.cpp
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifImage.cpp
@@ -34,8 +34,8 @@ rif_image_desc Image::GetDesc(uint32_t width, uint32_t height, HdFormat format) 
     imageDesc.image_width = width;
     imageDesc.image_height = height;
     imageDesc.image_depth = 1;
-    imageDesc.image_row_pitch = width;
-    imageDesc.image_slice_pitch = width * height;
+    imageDesc.image_row_pitch = 0;
+    imageDesc.image_slice_pitch = 0;
 
     return imageDesc;
 }

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1685,17 +1685,15 @@ private:
             imageDesc.image_width = textureData->ResizedWidth();
             imageDesc.image_height = textureData->ResizedHeight();
             imageDesc.image_depth = 1;
+            imageDesc.image_row_pitch = 0;
+            imageDesc.image_slice_pitch = 0;
 
-            int bytesPerChannel;
             if (textureData->GLType() == GL_UNSIGNED_BYTE) {
                 imageDesc.type = RIF_COMPONENT_TYPE_UINT8;
-                bytesPerChannel = 1;
             } else if (textureData->GLType() == GL_HALF_FLOAT) {
                 imageDesc.type = RIF_COMPONENT_TYPE_FLOAT16;
-                bytesPerChannel = 2;
             } else if (textureData->GLType() == GL_FLOAT) {
                 imageDesc.type = RIF_COMPONENT_TYPE_FLOAT32;
-                bytesPerChannel = 4;
             } else {
                 TF_RUNTIME_ERROR("\"%s\" image has unsupported pixel channel type: %#x", path.c_str(), textureData->GLType());
                 return false;
@@ -1711,9 +1709,6 @@ private:
                 TF_RUNTIME_ERROR("\"%s\" image has unsupported pixel format: %#x", path.c_str(), textureData->GLFormat());
                 return false;
             }
-
-            imageDesc.image_row_pitch = bytesPerChannel * imageDesc.num_components * imageDesc.image_width;
-            imageDesc.image_slice_pitch = imageDesc.image_row_pitch * imageDesc.image_height;
 
             auto rifImage = m_rifContext->CreateImage(imageDesc);
 


### PR DESCRIPTION
After [RIF-#330](https://github.com/Radeon-Pro/RadeonProImageProcessing/pull/330) row_pitch value is in bytes, previously it was in pixels.
Also, automatic row_pitch calculation has been introduced, i.e. when row_pitch is 0 RIF will calculate it by himself

This PR should be merged when we move to RIF 1.4.3+