### PR TITLE
Add ability to dump USD errors to a specified file

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -8,6 +8,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdRprDiagnosticMgrDelegate;
 class HdRprRenderParam;
 class HdRprApi;
 
@@ -73,6 +74,9 @@ private:
     std::unique_ptr<HdRprRenderParam> m_renderParam;
     HdRenderSettingDescriptorList m_settingDescriptors;
     HdRprRenderThread m_renderThread;
+
+    using DiagnostMgrDelegatePtr = std::unique_ptr<HdRprDiagnosticMgrDelegate, std::function<void (HdRprDiagnosticMgrDelegate*)>>;
+    DiagnostMgrDelegatePtr m_diagnosticMgrDelegate;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
This very useful feature that allows getting important info from hdRpr users in case of any issues,
especially in Houdini where all USD errors go to console which could be inaccessible in case of crashes.
Currently, there is no such embedded functionality in USD