### PR TITLE
Implement support of tapered basis curves

### DIFF
--- a/pxr/imaging/plugin/hdRpr/basisCurves.cpp
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.cpp
@@ -4,7 +4,61 @@
 #include "renderParam.h"
 #include "rprApi.h"
 
+#include "pxr/usd/usdUtils/pipeline.h"
+
 PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+void FillPrimvarDescsPerInterpolation(
+    HdSceneDelegate* sceneDelegate,
+    SdfPath const& id,
+    std::map<HdInterpolation, HdPrimvarDescriptorVector>* primvarDescsPerInterpolation) {
+    if (!primvarDescsPerInterpolation->empty()) {
+        return;
+    }
+
+    auto interpolations = {
+        HdInterpolationConstant,
+        HdInterpolationUniform,
+        HdInterpolationVarying,
+        HdInterpolationVertex,
+        HdInterpolationFaceVarying,
+        HdInterpolationInstance,
+    };
+    for (auto& interpolation : interpolations) {
+        primvarDescsPerInterpolation->emplace(interpolation, sceneDelegate->GetPrimvarDescriptors(id, interpolation));
+    }
+}
+
+bool IsPrimvarExists(TfToken const& primvarName,
+                     std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation,
+                     HdInterpolation* interpolation = nullptr) {
+    for (auto& entry : primvarDescsPerInterpolation) {
+        for (auto& pv : entry.second) {
+            if (pv.name == primvarName) {
+                if (interpolation) {
+                    *interpolation = entry.first;
+                }
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool IsValidPrimvarSize(size_t primvarSize, HdInterpolation primvarInterpolation, size_t uniformInterpSize, size_t vertexInterpSize) {
+    switch (primvarInterpolation) {
+        case HdInterpolationConstant:
+            return primvarSize > 0;
+        case HdInterpolationUniform:
+            return primvarSize == uniformInterpSize;
+        default:
+            return primvarSize == vertexInterpSize;
+    }
+}
+
+} // anonymouse namespace
 
 HdRprBasisCurves::HdRprBasisCurves(SdfPath const& id,
                                    SdfPath const& instancerId)
@@ -28,6 +82,7 @@ HdDirtyBits HdRprBasisCurves::GetInitialDirtyBitsMask() const {
     return HdChangeTracker::DirtyTopology
         | HdChangeTracker::DirtyPoints
         | HdChangeTracker::DirtyWidths
+        | HdChangeTracker::DirtyPrimvar
         | HdChangeTracker::DirtyTransform
         | HdChangeTracker::DirtyVisibility
         | HdChangeTracker::DirtyMaterialId;
@@ -41,21 +96,72 @@ void HdRprBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
     auto rprApi = rprRenderParam->AcquireRprApiForEdit();
 
     SdfPath const& id = GetId();
+    std::map<HdInterpolation, HdPrimvarDescriptorVector> primvarDescsPerInterpolation;
 
     bool newCurve = false;
 
     if (*dirtyBits & HdChangeTracker::DirtyPoints) {
-        m_points = sceneDelegate->Get(id, HdTokens->points).Get<VtVec3fArray>();
+        FillPrimvarDescsPerInterpolation(sceneDelegate, id, &primvarDescsPerInterpolation);
+        if (IsPrimvarExists(HdTokens->points, primvarDescsPerInterpolation)) {
+            m_points = sceneDelegate->Get(id, HdTokens->points).Get<VtVec3fArray>();
+        } else {
+            m_points = VtVec3fArray();
+        }
         newCurve = true;
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyTopology) {
         m_topology = sceneDelegate->GetBasisCurvesTopology(id);
+        m_indices = VtIntArray();
+        if (m_topology.HasIndices()) {
+            if (m_topology.GetCurveWrap() == HdTokens->nonperiodic || // GL_LINE_STRIP
+                m_topology.GetCurveWrap() == HdTokens->periodic) { // GL_LINE_LOOP
+                bool isPeriodic = m_topology.GetCurveWrap() == HdTokens->periodic;
+
+                auto indices = m_topology.GetCurveIndices();
+                m_indices.reserve(indices.size() * 2 + isPeriodic ? 2 : 0);
+                for (size_t i = 0; i < indices.size() - 1; ++i) {
+                    m_indices.push_back(indices[i]);
+                    m_indices.push_back(indices[i + 1]);
+                }
+                if (isPeriodic) {
+                    m_indices.push_back(indices.back());
+                    m_indices.push_back(indices.front());
+                }
+            } else if (m_topology.GetCurveWrap() == HdTokens->segmented) {
+                m_indices = m_topology.GetCurveIndices();
+            } else {
+                TF_RUNTIME_ERROR("[%s] Curve could not be created: unsupported curve wrap type - %s", id.GetText(), m_topology.GetCurveWrap().GetText());
+            }
+        } else {
+            m_indices.reserve(m_points.size());
+            for (int i = 0; i < m_points.size(); ++i) {
+                m_indices.push_back(i);
+            }
+        }
         newCurve = true;
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyWidths) {
-        m_widths = sceneDelegate->Get(id, HdTokens->widths).Get<VtFloatArray>();
+        FillPrimvarDescsPerInterpolation(sceneDelegate, id, &primvarDescsPerInterpolation);
+        if (IsPrimvarExists(HdTokens->widths, primvarDescsPerInterpolation, &m_widthsInterpolation)) {
+            m_widths = sceneDelegate->Get(id, HdTokens->widths).Get<VtFloatArray>();
+        } else {
+            m_widths = VtFloatArray(1, 1.0f);
+            m_widthsInterpolation = HdInterpolationConstant;
+            TF_WARN("[%s] Curve do not have widths. Fallback value is 1.0f with a constant interpolation");
+        }
+        newCurve = true;
+    }
+
+    if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
+        FillPrimvarDescsPerInterpolation(sceneDelegate, id, &primvarDescsPerInterpolation);
+        auto stToken = UsdUtilsGetPrimaryUVSetName();
+        if (IsPrimvarExists(stToken, primvarDescsPerInterpolation, &m_uvsInterpolation)) {
+            m_uvs = sceneDelegate->Get(id, stToken).Get<VtVec2fArray>();
+        } else {
+            m_uvs = VtVec2fArray();
+        }
         newCurve = true;
     }
 
@@ -73,34 +179,31 @@ void HdRprBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
     }
 
     if (newCurve) {
-        VtIntArray indices;
-        if (m_topology.HasIndices()) {
-            indices = m_topology.GetCurveIndices();
+        m_rprCurve = nullptr;
+
+        if (m_points.empty()) {
+            TF_RUNTIME_ERROR("[%s] Curve could not be created: missing points", id.GetText());
+        } else if (m_indices.empty()) {
+            TF_RUNTIME_ERROR("[%s] Curve could not be created: missing indices", id.GetText());
+        } else if (m_widths.empty()) {
+            TF_RUNTIME_ERROR("[%s] Curve could not be created: missing width", id.GetText());
+        } else if (m_topology.GetCurveType() != HdTokens->linear) {
+            TF_RUNTIME_ERROR("[%s] Curve could not be created: unsupported basis curve type - %s", id.GetText(), m_topology.GetCurveType().GetText());
+        } else if (!IsValidPrimvarSize(m_widths.size(), m_widthsInterpolation, m_topology.GetCurveVertexCounts().size(), m_points.size())) {
+            TF_RUNTIME_ERROR("[%s] Curve could not be created: mismatch in number of widths and requested interpolation type", id.GetText());
+        } else if (!m_uvs.empty() && !IsValidPrimvarSize(m_uvs.size(), m_uvsInterpolation, m_topology.GetCurveVertexCounts().size(), m_points.size())) {
+            TF_RUNTIME_ERROR("[%s] Curve could not be created: mismatch in number of uvs and requested interpolation type", id.GetText());
         } else {
-            indices.reserve(m_points.size());
-            for (int i = 0; i < m_points.size(); ++i) {
-                indices.push_back(i);
+            FillPrimvarDescsPerInterpolation(sceneDelegate, id, &primvarDescsPerInterpolation);
+            if (IsPrimvarExists(HdTokens->normals, primvarDescsPerInterpolation)) {
+                TF_WARN("[%s] Ribbon curves are not supported. Curve of tube type will be created", id.GetText());
             }
-        }
 
-        float curveWidth = 1.0f;
-        if (!m_widths.empty()) {
-            float curveWidth = m_widths[0];
-            float currentWidth = curveWidth;
-            const size_t curveWidthCount = m_points.size();
-            for (int i = 1; i < curveWidthCount; ++i) {
-                if (i < m_widths.size()) {
-                    currentWidth = m_widths[i];
-                }
-
-                curveWidth += currentWidth;
+            if (m_uvsInterpolation != HdInterpolationConstant || m_uvsInterpolation != HdInterpolationUniform) {
+                TF_WARN("[%s] Unsupported uv interpolation type", id.GetText());
             }
-            curveWidth /= curveWidthCount;
-        }
 
-        m_rprCurve = rprApi->CreateCurve(m_points, indices, curveWidth);
-        if (!m_rprCurve) {
-            TF_RUNTIME_ERROR("Failed to create curve");
+            m_rprCurve = CreateRprCurve(rprApi);
         }
     }
 
@@ -109,18 +212,20 @@ void HdRprBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
             if (m_cachedMaterial && m_cachedMaterial->GetRprMaterialObject()) {
                 rprApi->SetCurveMaterial(m_rprCurve.get(), m_cachedMaterial->GetRprMaterialObject());
             } else {
-                if (!m_fallbackMaterial) {
-                    auto primvars = sceneDelegate->GetPrimvarDescriptors(id, HdInterpolationConstant);
-                    auto colorPrimvarDescIter = std::find_if(primvars.begin(), primvars.end(), [](HdPrimvarDescriptor const& desc) { return desc.name == HdPrimvarRoleTokens->color; });
-                    if (colorPrimvarDescIter != primvars.end()) {
-                        VtValue val = sceneDelegate->Get(id, HdPrimvarRoleTokens->color);
-                        if (!val.IsEmpty()) {
-                            VtArray<GfVec4f> color = val.Get<VtArray<GfVec4f>>();
-                            MaterialAdapter matAdapter(EMaterialType::COLOR, MaterialParams{{HdRprMaterialTokens->color, VtValue(color[0])}});
-                            m_fallbackMaterial = rprApi->CreateMaterial(matAdapter);
+                GfVec3f color(0.18f);
+
+                if (IsPrimvarExists(HdTokens->displayColor, primvarDescsPerInterpolation)) {
+                    VtValue val = sceneDelegate->Get(id, HdTokens->displayColor);
+                    if (!val.IsEmpty() && val.IsHolding<VtVec3fArray>()) {
+                        auto colors = val.UncheckedGet<VtVec3fArray>();
+                        if (!colors.empty()) {
+                            color = colors[0];
                         }
                     }
                 }
+
+                MaterialAdapter matAdapter(EMaterialType::COLOR, MaterialParams{{HdRprMaterialTokens->color, VtValue(color)}});
+                m_fallbackMaterial = rprApi->CreateMaterial(matAdapter);
 
                 rprApi->SetCurveMaterial(m_rprCurve.get(), m_fallbackMaterial.get());
             }
@@ -136,6 +241,89 @@ void HdRprBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
     }
 
     *dirtyBits = HdChangeTracker::Clean;
+}
+
+RprApiObjectPtr HdRprBasisCurves::CreateRprCurve(HdRprApi* rprApi) {
+    bool isCurveTapered = m_widthsInterpolation != HdInterpolationConstant && m_widthsInterpolation != HdInterpolationUniform;
+    // Each segment of USD linear curves defined by two vertices
+    // For tapered curve we need to convert it to RPR representation:
+    //   4 vertices and 2 radiuses per segment
+    // For cylindrical curve we can leave indices data in the same format as in USD,
+    //   but we have to ensure that number of indices in each curve multiple of kNumPointsPerSegment
+    const int kNumPointsPerSegment = 4;
+
+    VtIntArray rprIndices;
+    VtIntArray rprSegmentPerCurve;
+    VtFloatArray rprRadiuses;
+    VtVec2fArray rprUvs;
+
+    auto& curveCounts = m_topology.GetCurveVertexCounts();
+    rprSegmentPerCurve.reserve(curveCounts.size());
+
+    size_t indicesOffset = 0;
+    for (size_t iCurve = 0; iCurve < curveCounts.size(); ++iCurve) {
+        auto numVertices = curveCounts[iCurve];
+
+        if (numVertices > 1) {
+            auto curveIndices = &m_indices[indicesOffset];
+            for (int i = 0; i < numVertices - 1; ++i) {
+                auto i0 = curveIndices[i + 0];
+                auto i1 = curveIndices[i + 1];
+
+                if (isCurveTapered) {
+                    // Each 2 vertices of USD curve corresponds to 1 tapered RPR curve segment
+                    rprIndices.push_back(i0);
+                    rprIndices.push_back(i0);
+                    rprIndices.push_back(i1);
+                    rprIndices.push_back(i1);
+
+                    // Each segment of tapered curve have 2 radiuses
+                    rprRadiuses.push_back(m_widths[i0] * 0.5f);
+                    rprRadiuses.push_back(m_widths[i1] * 0.5f);
+                } else {
+                    rprIndices.push_back(i0);
+                    rprIndices.push_back(i1);
+                }
+            }
+
+            if (!isCurveTapered) {
+                // RPR requires curves to consist only of segments of kNumPointsPerSegment length
+                auto numPointsInCurve = (numVertices - 1) * 2;
+                auto extraPoints = numPointsInCurve % kNumPointsPerSegment;
+                if (extraPoints) {
+                    extraPoints = kNumPointsPerSegment - extraPoints;
+
+                    auto lastPointIndex = curveIndices[numVertices - 1];
+                    for (int i = 0; i < extraPoints; ++i) {
+                        rprIndices.push_back(lastPointIndex);
+                    }
+                }
+
+                // Each cylindrical curve must have 1 radius
+                if (m_widthsInterpolation == HdInterpolationUniform) {
+                    rprRadiuses.push_back(m_widths[iCurve] * 0.5f);
+                } else if (m_widthsInterpolation == HdInterpolationConstant) {
+                    rprRadiuses.push_back(m_widths[0] * 0.5f);
+                }
+
+                rprSegmentPerCurve.push_back((numPointsInCurve + extraPoints) / kNumPointsPerSegment);
+            } else {
+                rprSegmentPerCurve.push_back(numVertices - 1);
+            }
+        }
+
+        indicesOffset += numVertices;
+    }
+
+    if (!m_uvs.empty()) {
+        if (m_uvsInterpolation == HdInterpolationUniform) {
+            rprUvs = m_uvs;
+        } else if (m_uvsInterpolation == HdInterpolationConstant) {
+            rprUvs = VtVec2fArray(rprSegmentPerCurve.size(), m_uvs[0]);
+        }
+    }
+
+    return rprApi->CreateCurve(m_points, rprIndices, rprRadiuses, rprUvs, rprSegmentPerCurve);
 }
 
 void HdRprBasisCurves::Finalize(HdRenderParam* renderParam) {

--- a/pxr/imaging/plugin/hdRpr/basisCurves.h
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.h
@@ -3,9 +3,11 @@
 
 #include "pxr/imaging/hd/basisCurves.h"
 #include "pxr/base/gf/matrix4f.h"
+#include "pxr/base/gf/vec2f.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdRprApi;
 class HdRprMaterial;
 class RprApiObject;
 using RprApiObjectPtr = std::unique_ptr<RprApiObject>;
@@ -25,14 +27,16 @@ public:
 
     void Finalize(HdRenderParam* renderParam) override;
 
-protected:
-
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
+protected:
     HdDirtyBits _PropagateDirtyBits(HdDirtyBits bits) const override;
 
     void _InitRepr(TfToken const& reprName,
                    HdDirtyBits* dirtyBits) override;
+
+private:
+    RprApiObjectPtr CreateRprCurve(HdRprApi* rprApi);
 
 private:
     RprApiObjectPtr m_rprCurve;
@@ -40,9 +44,13 @@ private:
     HdRprMaterial const* m_cachedMaterial;
 
     HdBasisCurvesTopology m_topology;
-    GfMatrix4f m_transform;
+    VtIntArray m_indices;
     VtFloatArray m_widths;
+    HdInterpolation m_widthsInterpolation;
+    VtVec2fArray m_uvs;
+    HdInterpolation m_uvsInterpolation;
     VtVec3fArray m_points;
+    GfMatrix4f m_transform;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -107,7 +107,10 @@ RprApiObject const* HdRprMesh::GetFallbackMaterial(HdSceneDelegate* sceneDelegat
             if (pv.name == HdTokens->displayColor) {
                 VtValue val = sceneDelegate->Get(GetId(), HdTokens->displayColor);
                 if (val.IsHolding<VtVec3fArray>()) {
-                    color = val.UncheckedGet<VtVec3fArray>()[0];
+                    auto colors = val.UncheckedGet<VtVec3fArray>();
+                    if (!colors.empty()) {
+                        color = colors[0];
+                    }
                     break;
                 }
             }

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -102,7 +102,7 @@ public:
     void SetMeshMaterial(RprApiObject* mesh, RprApiObject const* material);
     void SetMeshVisibility(RprApiObject* mesh, bool isVisible);
 
-    RprApiObjectPtr CreateCurve(const VtVec3fArray& points, const VtIntArray& indexes, float width);
+    RprApiObjectPtr CreateCurve(VtVec3fArray const& points, VtIntArray const& indices, VtFloatArray const& radiuses, VtVec2fArray const& uvs, VtIntArray const& segmentPerCurve);
     void SetCurveMaterial(RprApiObject* curve, RprApiObject const* material);
     void SetCurveVisibility(RprApiObject* curve, bool isVisible);
     void SetCurveTransform(RprApiObject* curve, GfMatrix4f const& transform);


### PR DESCRIPTION
Resolves #154

As from plugin standpoint feature is ready to merge, but the current core has some issues:
* Copypaste from jira ticket FIR-1600:
> Artefacts on tapered curves render in GPU mode
> In general, tapered curves works fine in both GPU and CPU modes, but some of the curves have pronounced artefacts in GPU mode. First of all, it's not expected that they are so wavy, but that's not why I'm creating this bug. Have a look at rendered images when you changing the camera position a bit.
> While rendering with CPU there are no such artefacts, but curves are wavy anyway

[images.zip](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/files/3927154/images.zip)

* Radius interpolation does not seem correct to me. For example, with such parameters of RPR curve:
```
controlPoints[3]: {
  (0.00, -1.00, 0.00),
  (0.00, 0.00, 0.00),
  (0.00, 1.00, 0.00),
}
segments[2]: {
  (0, 0, 1, 1),
  (1, 1, 2, 2),
}
segmentPerCurve[1]: {
  (2),
}
radiuses[4]: {
  (0.00, 0.25),
  (0.25, 0.00),
}
```
I see such result:
![curve](https://user-images.githubusercontent.com/22181845/70241895-85693380-1778-11ea-8aa7-45dd9324b39b.PNG)

 I have already contacted dev that added this functionality, it seems strange to him as well