### PR TITLE
Add support for camera parameters that HdCamera missing

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -43,7 +43,10 @@ set(USD_LIBRARIES
     hdx
     usdLux
     usdUtils
-    pxOsd)
+    usdRender
+    usdGeom
+    pxOsd
+    cameraUtil)
 
 set(_sep ${PXR_RESOURCE_FILE_SRC_DST_SEPARATOR})
 
@@ -137,6 +140,7 @@ pxr_plugin(hdRpr
         renderBuffer
         basisCurves
         imageCache
+        camera
         
         ${OptClass}
 

--- a/pxr/imaging/plugin/hdRpr/camera.cpp
+++ b/pxr/imaging/plugin/hdRpr/camera.cpp
@@ -1,0 +1,171 @@
+#include "camera.h"
+#include "renderParam.h"
+
+#include "pxr/imaging/hd/sceneDelegate.h"
+#include "pxr/usd/usdGeom/tokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+template<typename T>
+bool EvalCameraParam(T* value,
+                     const TfToken& paramName,
+                     HdSceneDelegate* sceneDelegate,
+                     const SdfPath& primPath,
+                     T defaultValue) {
+    VtValue vtval = sceneDelegate->GetCameraParamValue(primPath, paramName);
+    if (vtval.IsEmpty()) {
+        *value = defaultValue;
+        return false;
+    }
+    if (!vtval.IsHolding<T>()) {
+        *value = defaultValue;
+        TF_CODING_ERROR("%s: type mismatch - %s", paramName.GetText(), vtval.GetTypeName().c_str());
+        return false;
+    }
+
+    *value = vtval.UncheckedGet<T>();
+    return true;
+}
+
+template <typename T>
+bool EvalCameraParam(T* value,
+                     const TfToken& paramName,
+                     HdSceneDelegate* sceneDelegate,
+                     const SdfPath& primPath) {
+    return EvalCameraParam(value, paramName, sceneDelegate, primPath, std::numeric_limits<T>::quiet_NaN());
+}
+
+} // namespace anonymous
+
+HdRprCamera::HdRprCamera(SdfPath const& id)
+    : HdCamera(id),
+    m_horizontalAperture(std::numeric_limits<float>::quiet_NaN()),
+    m_verticalAperture(std::numeric_limits<float>::quiet_NaN()),
+    m_horizontalApertureOffset(std::numeric_limits<float>::quiet_NaN()),
+    m_verticalApertureOffset(std::numeric_limits<float>::quiet_NaN()),
+    m_focalLength(std::numeric_limits<float>::quiet_NaN()),
+    m_fStop(std::numeric_limits<float>::quiet_NaN()),
+    m_focusDistance(std::numeric_limits<float>::quiet_NaN()),
+    m_shutterOpen(std::numeric_limits<double>::quiet_NaN()),
+    m_shutterClose(std::numeric_limits<double>::quiet_NaN()),
+    m_clippingRange(std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()) {
+
+}
+
+HdDirtyBits HdRprCamera::GetInitialDirtyBitsMask() const {
+    return HdCamera::DirtyParams | HdCamera::GetInitialDirtyBitsMask();
+}
+
+void HdRprCamera::Sync(HdSceneDelegate* sceneDelegate,
+                       HdRenderParam* renderParam,
+                       HdDirtyBits* dirtyBits) {
+    // HdRprApi uses HdRprCamera directly, so we need to stop the render thread before changing the camera.
+    static_cast<HdRprRenderParam*>(renderParam)->AcquireRprApiForEdit();
+
+    m_rprDirtyBits |= *dirtyBits;
+
+    if (*dirtyBits & HdCamera::DirtyParams) {
+        SdfPath const& id = GetId();
+
+        EvalCameraParam(&m_focalLength, HdCameraTokens->focalLength, sceneDelegate, id);
+
+        EvalCameraParam(&m_horizontalAperture, HdCameraTokens->horizontalAperture, sceneDelegate, id);
+        EvalCameraParam(&m_verticalAperture, HdCameraTokens->verticalAperture, sceneDelegate, id);
+        EvalCameraParam(&m_horizontalApertureOffset, HdCameraTokens->horizontalApertureOffset, sceneDelegate, id);
+        EvalCameraParam(&m_verticalApertureOffset, HdCameraTokens->verticalApertureOffset, sceneDelegate, id);
+
+        EvalCameraParam(&m_fStop, HdCameraTokens->fStop, sceneDelegate, id);
+        EvalCameraParam(&m_focusDistance, HdCameraTokens->focusDistance, sceneDelegate, id);
+        EvalCameraParam(&m_shutterOpen, HdCameraTokens->shutterOpen, sceneDelegate, id);
+        EvalCameraParam(&m_shutterClose, HdCameraTokens->shutterClose, sceneDelegate, id);
+        EvalCameraParam(&m_clippingRange, HdCameraTokens->clippingRange, sceneDelegate, id, GfRange1f(std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::quiet_NaN()));
+
+        EvalCameraParam(&m_projectionType, UsdGeomTokens->projection, sceneDelegate, id, TfToken());
+    }
+
+    HdCamera::Sync(sceneDelegate, renderParam, dirtyBits);
+}
+
+void HdRprCamera::Finalize(HdRenderParam* renderParam) {
+    // HdRprApi uses HdRprCamera directly, so we need to stop the render thread before releasing the camera.
+    static_cast<HdRprRenderParam*>(renderParam)->AcquireRprApiForEdit();
+}
+
+bool HdRprCamera::GetApertureSize(GfVec2f* v) const {
+    if (!std::isnan(m_horizontalAperture) &&
+        !std::isnan(m_verticalAperture)) {
+        *v = {m_horizontalAperture, m_verticalAperture};
+        return true;
+    }
+    return false;
+}
+
+bool HdRprCamera::GetApertureOffset(GfVec2f* v) const {
+    if (!std::isnan(m_horizontalApertureOffset) &&
+        !std::isnan(m_verticalApertureOffset)) {
+        *v = {m_horizontalApertureOffset, m_verticalApertureOffset};
+        return true;
+    }
+    return false;
+}
+
+bool HdRprCamera::GetFocalLength(float* v) const {
+    if (!std::isnan(m_focalLength)) {
+        *v = m_focalLength;
+        return true;
+    }
+    return false;
+}
+
+bool HdRprCamera::GetFStop(float* v) const {
+    if (!std::isnan(m_fStop)) {
+        *v = m_fStop;
+        return true;
+    }
+    return false;
+}
+
+bool HdRprCamera::GetFocusDistance(float* v) const {
+    if (!std::isnan(m_focusDistance)) {
+        *v = m_focusDistance;
+        return true;
+    }
+    return false;
+}
+
+bool HdRprCamera::GetShutterOpen(double* v) const {
+    if (!std::isnan(m_shutterOpen)) {
+        *v = m_shutterOpen;
+        return true;
+    }
+    return false;
+}
+
+bool HdRprCamera::GetShutterClose(double* v) const {
+    if (!std::isnan(m_shutterClose)) {
+        *v = m_shutterClose;
+        return true;
+    }
+    return false;
+}
+
+bool HdRprCamera::GetClippingRange(GfRange1f* v) const {
+    if (!std::isnan(m_clippingRange.GetMin()) &&
+        !std::isnan(m_clippingRange.GetMax())) {
+        *v = m_clippingRange;
+        return true;
+    }
+    return false;
+}
+
+bool HdRprCamera::GetProjectionType(TfToken* v) const {
+    if (!m_projectionType.IsEmpty()) {
+        *v = m_projectionType;
+        return true;
+    }
+    return false;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/camera.h
+++ b/pxr/imaging/plugin/hdRpr/camera.h
@@ -1,0 +1,55 @@
+#ifndef HDRPR_CAMERA_H
+#define HDRPR_CAMERA_H
+
+#include "pxr/imaging/hd/camera.h"
+#include "pxr/base/gf/vec2f.h"
+#include "pxr/base/gf/range1f.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdRprCamera : public HdCamera {
+
+public:
+    HdRprCamera(SdfPath const& id);
+    ~HdRprCamera() override = default;
+
+    void Sync(HdSceneDelegate *sceneDelegate,
+              HdRenderParam   *renderParam,
+              HdDirtyBits     *dirtyBits) override;
+
+    HdDirtyBits GetInitialDirtyBitsMask() const override;
+
+    void Finalize(HdRenderParam* renderParam) override;
+
+    bool GetApertureSize(GfVec2f* value) const;
+    bool GetApertureOffset(GfVec2f* value) const;
+    bool GetFocalLength(float* value) const;
+    bool GetFStop(float* value) const;
+    bool GetFocusDistance(float* value) const;
+    bool GetShutterOpen(double* value) const;
+    bool GetShutterClose(double* value) const;
+    bool GetClippingRange(GfRange1f* value) const;
+    bool GetProjectionType(TfToken* value) const;
+
+    HdDirtyBits GetDirtyBits() const { return m_rprDirtyBits; }
+    void CleanDirtyBits() const { m_rprDirtyBits = HdCamera::Clean; }
+
+private:
+    float m_horizontalAperture;
+    float m_verticalAperture;
+    float m_horizontalApertureOffset;
+    float m_verticalApertureOffset;
+    float m_focalLength;
+    float m_fStop;
+    float m_focusDistance;
+    double m_shutterOpen;
+    double m_shutterClose;
+    GfRange1f m_clippingRange;
+    TfToken m_projectionType;
+
+    mutable HdDirtyBits m_rprDirtyBits = HdCamera::AllDirty;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDRPR_CAMERA_H

--- a/pxr/imaging/plugin/hdRpr/field.h
+++ b/pxr/imaging/plugin/hdRpr/field.h
@@ -14,7 +14,6 @@ public:
               HdRenderParam* renderParam,
               HdDirtyBits* dirtyBits) override;
 
-protected:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 };
 

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -28,9 +28,9 @@ public:
 
     void Finalize(HdRenderParam* renderParam) override;
 
-protected:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
+protected:
     HdDirtyBits _PropagateDirtyBits(HdDirtyBits bits) const override;
 
     void _InitRepr(TfToken const& reprName, HdDirtyBits* dirtyBits) override;

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -3,8 +3,7 @@
 #include "pxr/base/tf/diagnosticMgr.h"
 #include "pxr/base/tf/getenv.h"
 
-#include "pxr/imaging/hd/camera.h"
-
+#include "camera.h"
 #include "config.h"
 #include "renderPass.h"
 #include "renderParam.h"
@@ -238,7 +237,7 @@ void HdRprDelegate::DestroyRprim(HdRprim* rPrim) {
 HdSprim* HdRprDelegate::CreateSprim(TfToken const& typeId,
                                     SdfPath const& sprimId) {
     if (typeId == HdPrimTypeTokens->camera) {
-        return new HdCamera(sprimId);
+        return new HdRprCamera(sprimId);
     } else if (typeId == HdPrimTypeTokens->domeLight) {
         return new HdRprDomeLight(sprimId);
     } else if (typeId == HdPrimTypeTokens->rectLight) {
@@ -263,7 +262,7 @@ HdSprim* HdRprDelegate::CreateFallbackSprim(TfToken const& typeId) {
     // For fallback sprims, create objects with an empty scene path.
     // They'll use default values and won't be updated by a scene delegate.
     if (typeId == HdPrimTypeTokens->camera) {
-        return new HdCamera(SdfPath::EmptyPath());
+        return new HdRprCamera(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->domeLight) {
         return new HdRprDomeLight(SdfPath::EmptyPath());
     } else if (typeId == HdPrimTypeTokens->rectLight) {

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -54,16 +54,8 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState
         m_renderParam->AcquireRprApiForEdit()->SetAovBindings(renderPassState->GetAovBindings());
     }
 
-    auto& cameraViewMatrix = rprApiConst->GetCameraViewMatrix();
-    auto& wvm = renderPassState->GetWorldToViewMatrix();
-    if (cameraViewMatrix != wvm) {
-        m_renderParam->AcquireRprApiForEdit()->SetCameraViewMatrix(wvm);
-    }
-
-    auto& cameraProjMatrix = rprApiConst->GetCameraProjectionMatrix();
-    auto proj = renderPassState->GetProjectionMatrix();
-    if (cameraProjMatrix != proj) {
-        m_renderParam->AcquireRprApiForEdit()->SetCameraProjectionMatrix(proj);
+    if (rprApiConst->GetCamera() != renderPassState->GetCamera()) {
+        m_renderParam->AcquireRprApiForEdit()->SetCamera(renderPassState->GetCamera());
     }
 
     if (rprApiConst->IsChanged()) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -10,10 +10,11 @@
 #include "pxr/base/vt/array.h"
 #include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/gf/quaternion.h"
+#include "pxr/base/tf/staticTokens.h"
 #include "pxr/imaging/hd/types.h"
+#include "pxr/imaging/hd/camera.h"
 #include "pxr/imaging/hd/renderPassState.h"
 #include "pxr/imaging/hd/renderDelegate.h"
-#include "pxr/base/tf/staticTokens.h"
 
 #include <memory>
 #include <vector>
@@ -109,10 +110,11 @@ public:
 
     RprApiObjectPtr CreateMaterial(MaterialAdapter& materialAdapter);
 
-    const GfMatrix4d& GetCameraViewMatrix() const;
+    GfMatrix4d GetCameraViewMatrix() const;
     const GfMatrix4d& GetCameraProjectionMatrix() const;
-    void SetCameraViewMatrix(const GfMatrix4d& m);
-    void SetCameraProjectionMatrix(const GfMatrix4d& m);
+
+    HdCamera const* GetCamera() const;
+    void SetCamera(HdCamera const* camera);
 
     GfVec2i GetViewportSize() const;
     void SetViewportSize(GfVec2i const& size);

--- a/pxr/imaging/plugin/hdRpr/volume.h
+++ b/pxr/imaging/plugin/hdRpr/volume.h
@@ -23,9 +23,9 @@ public:
 
     void Finalize(HdRenderParam* renderParam) override;
 
-protected:
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
+protected:
     HdDirtyBits _PropagateDirtyBits(HdDirtyBits bits) const override;
 
     void _InitRepr(TfToken const& reprName,


### PR DESCRIPTION
Default Hydra Camera (**HdCamera**) does not support parameters defined in **UsdGeomCamera** such as:
* Aperture Size
* Focal Length
* FStop
* Focus Distance
* Shutter Open
* Shutter Close
* Clipping Range

To process these parameters custom **HdRprCamera** class that inherits **HdCamera** is introduced. This class simply adds syncing of missing parameters so that they could be used by the render engine.

Resolves #164