### PR TITLE
Add alpha-compositing support

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.h
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.h
@@ -29,7 +29,7 @@ enum FilterInputType
     MaxInput
 };
 
-using FilterParam = BOOST_NS::variant<int, float, std::string, GfVec2i, GfMatrix4f>;
+using FilterParam = BOOST_NS::variant<int, float, std::string, GfVec2i, GfMatrix4f, rif_image>;
 
 enum class FilterType
 {
@@ -48,13 +48,17 @@ public:
 
     virtual ~Filter();
 
+    void SetInput(FilterInputType inputType, Filter* filter);
     void SetInput(FilterInputType inputType, rif_image rifImage, float sigma = 1.0f);
     void SetInput(FilterInputType inputType, rpr::FrameBuffer* rprFrameBuffer, float sigma = 1.0f);
+    void SetInput(const char* name, rpr::FrameBuffer* rprFrameBuffer);
     void SetOutput(rif_image rifImage);
     void SetOutput(rif_image_desc imageDesc);
     void SetOutput(rpr::FrameBuffer* rprFrameBuffer);
     void SetParam(const char* name, FilterParam param);
+    void SetParamFilter(const char* name, Filter* filter);
 
+    rif_image GetInput(FilterInputType inputType) const;
     rif_image GetOutput();
 
     virtual void Resize(std::uint32_t width, std::uint32_t height);
@@ -64,7 +68,7 @@ protected:
     Filter(Context* rifContext) : m_rifContext(rifContext) {}
 
     void DetachFilter();
-    virtual void AttachFilter() = 0;
+    virtual void AttachFilter(rif_image inputImage);
 
     void ApplyParameters();
 
@@ -93,6 +97,7 @@ protected:
     };
 
     std::unordered_map<FilterInputType, InputTraits, std::hash<std::underlying_type<FilterInputType>::type>> m_inputs;
+    std::map<std::string, InputTraits> m_namedInputs;
     std::unordered_map<std::string, FilterParam> m_params;
 
     rif_image m_outputImage = nullptr;

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -70,6 +70,7 @@ std::unique_ptr<T> make_unique(Args&&... args) {
     (elementId) \
     (normal) \
     (worldCoordinate) \
+    (opacity) \
     ((primvarsSt, "primvars:st"))
 
 TF_DECLARE_PUBLIC_TOKENS(HdRprAovTokens, HDRPR_API, HD_RPR_AOV_TOKENS);

--- a/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprcpp/rprFramebuffer.cpp
@@ -41,7 +41,7 @@ void FrameBuffer::AttachAs(rpr_aov aov) {
     }
 
     if (aov != kAovNone) {
-        RPR_ERROR_CHECK(rprContextSetAOV(m_context, aov, GetHandle()), "Failed to attach aov framebuffer", m_context);
+        RPR_ERROR_CHECK_THROW(rprContextSetAOV(m_context, aov, GetHandle()), "Failed to attach aov framebuffer", m_context);
         m_aov = aov;
     }
 }


### PR DESCRIPTION
Previously all pixels always had 1.0 alpha, now we combine alpha AOV with color AOV to produce an image which is ready for compositing with alpha pre-multiplied colors (as Hydra requires)

Before:
![opacity_before](https://user-images.githubusercontent.com/22181845/71009278-9f006880-20f2-11ea-8de5-fa4cf72a304b.PNG)

After:
![opacity_after](https://user-images.githubusercontent.com/22181845/71009285-a162c280-20f2-11ea-9c2f-da7c92f98402.PNG)
