### PR TITLE
Fix rendering in CPU mode

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.cpp
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.cpp
@@ -282,10 +282,12 @@ void Filter::Update() {
         }
     }
 
+    m_dirtyFlags = Clean;
+}
+
+void Filter::Resolve() {
     UpdateInputs(m_inputs.begin(), m_inputs.end(), m_rifContext);
     UpdateInputs(m_namedInputs.begin(), m_namedInputs.end(), m_rifContext);
-
-    m_dirtyFlags = Clean;
 }
 
 void Filter::AttachFilter(rif_image inputImage) {

--- a/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.h
+++ b/pxr/imaging/plugin/hdRpr/rifcpp/rifFilter.h
@@ -63,6 +63,7 @@ public:
 
     virtual void Resize(std::uint32_t width, std::uint32_t height);
     void Update();
+    void Resolve();
 
 protected:
     Filter(Context* rifContext) : m_rifContext(rifContext) {}

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
@@ -80,6 +80,10 @@ void HdRprApiAov::Resolve() {
     if (m_aov) {
         m_aov->Resolve(m_resolved.get());
     }
+
+    if (m_filter) {
+        m_filter->Resolve();
+    }
 }
 
 void HdRprApiAov::Clear() {
@@ -321,6 +325,14 @@ void HdRprApiColorAov::Update(HdRprApi const* rprApi, rif::Context* rifContext) 
     }
     if (m_filter) {
         m_filter->Update();
+    }
+}
+
+void HdRprApiColorAov::Resolve() {
+    HdRprApiAov::Resolve();
+
+    for (auto& auxFilter : m_auxFilters) {
+        auxFilter.second->Resolve();
     }
 }
 

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -23,9 +23,9 @@ public:
 
     virtual void Resize(int width, int height, HdFormat format);
     virtual void Update(HdRprApi const* rprApi, rif::Context* rifContext);
+    virtual void Resolve();
 
     bool GetData(void* dstBuffer, size_t dstBufferSize);
-    void Resolve();
     void Clear();
 
     HdFormat GetFormat() const { return m_format; }
@@ -62,6 +62,7 @@ public:
     ~HdRprApiColorAov() override = default;
 
     void Update(HdRprApi const* rprApi, rif::Context* rifContext) override;
+    void Resolve() override;
 
     void SetOpacityAov(std::shared_ptr<HdRprApiAov> opacity);
 


### PR DESCRIPTION
In CPU mode, we need to move RPR framebuffer data to RIF images explicitly. We were not doing it with the latest AOV changes