### PR TITLE
Fix Hybrid plugin registration on Ubuntu

### DIFF
--- a/cmake/modules/FindRpr.cmake
+++ b/cmake/modules/FindRpr.cmake
@@ -49,7 +49,7 @@ if(WIN32)
         ${RPR_HYBRID_BINARY})
 else()
     find_library(RPR_HYBRID_BINARY
-        NAMES libHybrid Hybrid
+        NAMES Hybrid${CMAKE_SHARED_LIBRARY_SUFFIX}
         PATHS
             "${RPR_LOCATION_LIB}"
         DOC
@@ -62,7 +62,7 @@ else()
     endif()
 
     find_library(RPR_TAHOE_BINARY
-        NAMES libTahoe64 Tahoe64
+        NAMES libTahoe64
         PATHS
             "${RPR_LOCATION_LIB}"
         DOC

--- a/pxr/imaging/plugin/hdRpr/rprcpp/rprContext.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprcpp/rprContext.cpp
@@ -110,7 +110,7 @@ const char* k_PluginLibNames[] = {
         "Hybrid.dll",
 #elif defined __linux__
         "libTahoe64.so",
-        "libHybrid.so",
+        "Hybrid.so",
 #elif defined __APPLE__
         "libTahoe64.dylib",
         "libHybrid.dylib",
@@ -201,7 +201,7 @@ std::unique_ptr<Context> Context::CreateContext(PluginType plugin, RenderDeviceT
     const std::string pluginPath = (rprSdkPath.empty()) ? pluginName : rprSdkPath + "/" + pluginName;
     rpr_int pluginID = rprRegisterPlugin(pluginPath.c_str());
     if (pluginID == -1) {
-        TF_RUNTIME_ERROR("Failed to register %s plugin", pluginName);
+        TF_RUNTIME_ERROR("Failed to register %s plugin located at \"%s\"", pluginName, pluginPath.c_str());
         return nullptr;
     }
 


### PR DESCRIPTION
For some reason, Hybrid library for UNIX systems does not have a "lib" prefix unlike Tahoe library, which is weird.

Fixing it on side of RadeonProRenderUSD is much easier than fixing it in RadeonProRenderThirdPartyComponents and all other plugins