### PR TITLE
Fix building on macOS

### DIFF
--- a/cmake/modules/FindRpr.cmake
+++ b/cmake/modules/FindRpr.cmake
@@ -62,7 +62,7 @@ else()
     endif()
 
     find_library(RPR_TAHOE_BINARY
-        NAMES libTahoe64
+        NAMES libTahoe64 Tahoe64
         PATHS
             "${RPR_LOCATION_LIB}"
         DOC


### PR DESCRIPTION
This [change](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/commit/95ac0af97f2038e37f2ff126061a384e451d67fc) works on Ubuntu and CentOS, but does not work on macOS