### PR TITLE
Do not mark refractive materials as doublesided

### DIFF
--- a/pxr/imaging/plugin/hdRpr/material.cpp
+++ b/pxr/imaging/plugin/hdRpr/material.cpp
@@ -51,7 +51,6 @@ void HdRprMaterial::Sync(HdSceneDelegate* sceneDelegate,
 
             if (GetMaterial(networkMap, materialType, surface)) {
                 MaterialAdapter matAdapter = MaterialAdapter(materialType, surface);
-                matAdapter.MarkAsDoublesided();
                 m_rprMaterial = rprApi->CreateMaterial(matAdapter);
             } else {
                 TF_CODING_WARNING("Material type not supported");

--- a/pxr/imaging/plugin/hdRpr/materialAdapter.h
+++ b/pxr/imaging/plugin/hdRpr/materialAdapter.h
@@ -116,9 +116,6 @@ public:
         return m_displacementTexture;
     }
 
-    void MarkAsDoublesided() {
-        m_doublesided = true;
-    }
     bool IsDoublesided() const {
         return m_doublesided;
     }


### PR DESCRIPTION
Because refractive material can not be single-sided