### PR TITLE
Unlock medium quality

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1041,11 +1041,6 @@ public:
     void UpdateHybridSettings(HdRprConfig const& preferences, bool force) {
         if (preferences.IsDirty(HdRprConfig::DirtyRenderQuality) || force) {
             auto quality = preferences.GetRenderQuality();
-            if (quality == kRenderQualityMedium) {
-                // XXX (Hybrid): temporarily disable until issues on hybrid side is not solved
-                // otherwise driver crashes guaranteed (Radeon VII)
-                quality = kRenderQualityHigh;
-            }
             RPR_ERROR_CHECK(rprContextSetParameterByKey1u(m_rprContext->GetHandle(), RPR_CONTEXT_RENDER_QUALITY, quality), "Fail to set context hybrid render quality");
         }
     }
@@ -1446,7 +1441,7 @@ public:
     }
 
     bool IsConverged() const {
-        if (m_currentRenderQuality == kRenderQualityLow) {
+        if (m_currentRenderQuality < kRenderQualityHigh) {
             return m_iter == 1;
         }
 


### PR DESCRIPTION
Also, make medium quality single-sampled (just like Low quality)

I want to point out that medium quality still crashes GPU driver on Radeon VII but I've tested it on RTX 2060 SUPER and it works. So I think it would be better to remove this quality lock so that more users could try it