### PR TITLE
Update to USD 20.02

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -70,7 +70,7 @@ set(PXR_OBJECT_LIBS ""
     "Aggregation of all core libraries built as OBJECT libraries."
 )
 
-set(PXR_LIB_PREFIX "lib"
+set(PXR_LIB_PREFIX ${CMAKE_SHARED_LIBRARY_PREFIX}
     CACHE
     STRING
     "Prefix for build library name"

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -1232,6 +1232,7 @@ function(_pxr_library NAME)
         PROPERTIES
             FOLDER "${folder}"
             POSITION_INDEPENDENT_CODE ON
+            IMPORT_PREFIX "${args_PREFIX}"
             PREFIX "${args_PREFIX}"
             SUFFIX "${args_SUFFIX}"
             PUBLIC_HEADER "${args_PUBLIC_HEADERS}"

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -863,6 +863,7 @@ function(pxr_toplevel_prologue)
                 PROPERTIES
                     FOLDER "${folder}"
                     PREFIX "${PXR_LIB_PREFIX}"
+                    IMPORT_PREFIX "${PXR_LIB_PREFIX}"
             )
             _get_install_dir("lib" libInstallPrefix)
             install(
@@ -986,6 +987,7 @@ function(pxr_monolithic_epilogue)
             FOLDER "${folder}"
             POSITION_INDEPENDENT_CODE ON
             PREFIX "${PXR_LIB_PREFIX}"
+            IMPORT_PREFIX "${PXR_LIB_PREFIX}"
     )
 
     # Adding $<TARGET_OBJECTS:foo> will not bring along compile

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -3,11 +3,11 @@
 if(RPR_BUILD_AS_HOUDINI_PLUGIN)
     set(USD_INCLUDE_DIR ${HOUDINI_INCLUDE_DIR})
     set(USD_LIBRARY_DIR ${HOUDINI_LIB})
+    set(PXR_LIB_PREFIX pxr_)
     if(WIN32)
-        set(USD_LIBRARY_MONOLITHIC TRUE)
-    else()
-        set(USD_LIBRARY_MONOLITHIC FALSE)
+        set(PXR_LIB_PREFIX libpxr_)
     endif()
+    set(USD_LIBRARY_MONOLITHIC FALSE)
 else(RPR_BUILD_AS_HOUDINI_PLUGIN)
     find_path(USD_INCLUDE_DIR pxr/pxr.h
               PATHS ${USD_ROOT}/include
@@ -17,7 +17,7 @@ else(RPR_BUILD_AS_HOUDINI_PLUGIN)
               NO_SYSTEM_ENVIRONMENT_PATH)
 
     find_path(USD_LIBRARY_DIR
-              NAMES libusd.dylib libusd.dll libusd.so
+              NAMES "${PXR_LIB_PREFIX}usd${CMAKE_SHARED_LIBRARY_SUFFIX}"
               PATHS ${USD_ROOT}/lib
                     $ENV{USD_ROOT}/lib
               DOC "USD Libraries directory"
@@ -27,7 +27,7 @@ else(RPR_BUILD_AS_HOUDINI_PLUGIN)
 
     if(NOT USD_LIBRARY_DIR)
         find_path(USD_LIBRARY_DIR
-                  NAMES libusd_ms.dylib libusd_ms.dll libusd_ms.so
+                  NAMES "${PXR_LIB_PREFIX}usd_ms${CMAKE_SHARED_LIBRARY_SUFFIX}"
                   PATHS ${USD_ROOT}/lib
                         $ENV{USD_ROOT}/lib
                   DOC "USD Libraries directory"

--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -37,28 +37,22 @@ set(USD_LIBRARIES
     usdGeom
     pxOsd
     cameraUtil)
+if(${USD_LIBRARY_MONOLITHIC})
+    set(USD_LIBRARIES usd_ms)
+endif()
+
+set(_prefixedUsdLibraries "")
+foreach(name ${USD_LIBRARIES})
+    list(APPEND _prefixedUsdLibraries "${PXR_LIB_PREFIX}${name}")
+endforeach()
+set(USD_LIBRARIES "${_prefixedUsdLibraries}")
 
 set(_sep ${PXR_RESOURCE_FILE_SRC_DST_SEPARATOR})
-
 if(RPR_BUILD_AS_HOUDINI_PLUGIN)
-    set(USD_LIB_PREFIX pxr_)
-    if(WIN32)
-        set(USD_LIB_PREFIX libpxr_)
-    endif()
-
-    set(HOUDINI_USD_LIBRARIES "")
-    foreach(name ${USD_LIBRARIES})
-        list(APPEND HOUDINI_USD_LIBRARIES "${USD_LIB_PREFIX}${name}")
-    endforeach()
-    set(USD_LIBRARIES "${HOUDINI_USD_LIBRARIES}")
-
     list(APPEND OptLibs Houdini)
     add_definitions(-DENABLE_RAT)
     set(RESTART_REQUIRED_RESOURCE_FILE images/restartRequired_Houdini.png${_sep}images/restartRequired.png)
 else(RPR_BUILD_AS_HOUDINI_PLUGIN)
-    if(${USD_LIBRARY_MONOLITHIC})
-        set(USD_LIBRARIES usd_ms)
-    endif()
     add_definitions(-DENABLE_PREFERENCES_FILE)
     set(RESTART_REQUIRED_RESOURCE_FILE images/restartRequired_Usdview.png${_sep}images/restartRequired.png)
 endif(RPR_BUILD_AS_HOUDINI_PLUGIN)

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -316,7 +316,7 @@ HdAovDescriptor HdRprDelegate::GetDefaultAovDescriptor(TfToken const& name) cons
         name != HdAovTokens->normal &&
         name != HdAovTokens->primId &&
         name != HdAovTokens->depth &&
-        name != HdAovTokens->linearDepth &&
+        name != HdRprUtilsGetCameraDepthName() &&
         !(aovId.isPrimvar && aovId.name == "st")) {
         // TODO: implement support for instanceId and elementId aov
         return HdAovDescriptor();
@@ -335,8 +335,8 @@ HdAovDescriptor HdRprDelegate::GetDefaultAovDescriptor(TfToken const& name) cons
 
     float clearColorValue = 0.0f;
     if (name == HdAovTokens->depth ||
-        name == HdAovTokens->linearDepth) {
-        clearColorValue = name == HdAovTokens->linearDepth ? 0.0f : 1.0f;
+        name == HdRprUtilsGetCameraDepthName()) {
+        clearColorValue = name == HdRprUtilsGetCameraDepthName() ? 0.0f : 1.0f;
         format = HdFormatFloat32;
     } else if (name == HdAovTokens->color) {
         format = HdFormatFloat32Vec4;
@@ -386,6 +386,14 @@ bool HdRprDelegate::Pause() {
 bool HdRprDelegate::Resume() {
     m_renderThread.ResumeRender();
     return true;
+}
+
+TfToken const& HdRprUtilsGetCameraDepthName() {
+#if PXR_VERSION < 2002
+    return HdAovTokens->linearDepth;
+#else
+    return HdAovTokens->cameraDepth;
+#endif
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -79,6 +79,8 @@ private:
     DiagnostMgrDelegatePtr m_diagnosticMgrDelegate;
 };
 
+TfToken const& HdRprUtilsGetCameraDepthName();
+
 PXR_NAMESPACE_CLOSE_SCOPE
 
 extern "C" {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -60,21 +60,6 @@ std::unique_ptr<T> make_unique(Args&&... args) {
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-#define HD_RPR_AOV_TOKENS \
-    (color) \
-    (albedo) \
-    (depth) \
-    (linearDepth) \
-    (primId) \
-    (instanceId) \
-    (elementId) \
-    (normal) \
-    (worldCoordinate) \
-    (opacity) \
-    ((primvarsSt, "primvars:st"))
-
-TF_DECLARE_PUBLIC_TOKENS(HdRprAovTokens, HDRPR_API, HD_RPR_AOV_TOKENS);
-
 class HdRprApi final {
 public:
     HdRprApi(HdRenderDelegate* delegate);

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -125,6 +125,11 @@ public:
     void Resize(int width, int height, HdFormat format) override;
 
 private:
+    std::unique_ptr<rif::Filter> m_retainedFilter;
+
+    rif::Filter* m_ndcFilter;
+    rif::Filter* m_remapFilter;
+
     std::shared_ptr<HdRprApiAov> m_retainedWorldCoordinateAov;
     int m_width;
     int m_height;


### PR DESCRIPTION
These changes keep compatibility with 19.11 but also provide support of 20.02

Summary of 19.11 to 20.02 changes that affect hdRpr:
* 20.02 renamed `linearDepth` to `cameraDepth` and changed depth range from [-1, 1] to [0, 1]. (https://github.com/PixarAnimationStudios/USD/commit/609ccf1cc59670443a56e682bbe4a0c2611fb8b4)

    So I refactored usage of this token to support both 19.11 and 20.02 names and added additional remapping filter.

* In 20.02 library prefix on windows was fixed (https://github.com/PixarAnimationStudios/USD/commit/1ca7422061007fd7b91db7e68620cdd571dd8cb5s)

    I've updated cmake files in accordance with the changes in USD repo. Now if the user compiled USD with custom library prefix he can feed the same prefix to hdRpr's cmake and it will link against correct libraries (previously only default library prefixes were supported). Also, I use `PXR_LIB_PREFIX` to handle Houdini's `libpxr` prefix