### PR TITLE
Add "restart required" popup

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -151,6 +151,19 @@ pxr_plugin(hdRpr
         ${CMAKE_CURRENT_BINARY_DIR}/config.cpp
 )
 
+target_sources(hdRpr PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/notify/message.h)
+if(APPLE)
+    target_sources(hdRpr PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/notify/message.mm)
+    target_link_libraries(hdRpr
+        objc
+        "-framework AppKit")
+else()
+    target_sources(hdRpr PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/notify/message.cpp)
+endif()
+
 target_compile_definitions(hdRpr PRIVATE
     RPR_CPPWRAPER_DISABLE_MUTEXLOCK
     RPR_API_USE_HEADER_V2)

--- a/pxr/imaging/plugin/hdRpr/notify/message.cpp
+++ b/pxr/imaging/plugin/hdRpr/notify/message.cpp
@@ -1,0 +1,20 @@
+#include "message.h"
+
+#include "pxr/base/tf/stringUtils.h"
+
+#if defined WIN32
+#include <windows.h>
+#endif
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+bool HdRprShowMessage(std::string const& title, std::string const& message) {
+#if defined WIN32
+    return MessageBox(nullptr, message.c_str(), title.c_str(), MB_YESNO | MB_ICONEXCLAMATION) == IDYES;
+#else
+    auto command = TfStringPrintf("xmessage -nearmouse -buttons Yes:0,No:1 -title \"%s\" \"%s\"", title.c_str(), message.c_str());
+    return system(command.c_str()) == 0;
+#endif
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/notify/message.h
+++ b/pxr/imaging/plugin/hdRpr/notify/message.h
@@ -1,0 +1,13 @@
+#ifndef HDRPR_NOTIFY_MESSAGE_H
+#define HDRPR_NOTIFY_MESSAGE_H
+
+#include "pxr/pxr.h"
+#include <string>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+bool HdRprShowMessage(std::string const& title, std::string const& message);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDRPR_NOTIFY_MESSAGE_H

--- a/pxr/imaging/plugin/hdRpr/notify/message.mm
+++ b/pxr/imaging/plugin/hdRpr/notify/message.mm
@@ -1,0 +1,26 @@
+#include "message.h"
+#include <Cocoa/Cocoa.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+bool HdRprShowMessage(std::string const& title, std::string const& message) {
+    NSString* titleText = [NSString stringWithCString: title.c_str() encoding: [NSString defaultCStringEncoding]];
+    NSString* msgText = [NSString stringWithCString: message.c_str() encoding: [NSString defaultCStringEncoding]];
+
+    NSAlert* alert = [[NSAlert alloc] init];
+    [alert setMessageText: titleText];
+    [alert setInformativeText: msgText];
+    [alert setAlertStyle:NSCriticalAlertStyle];
+    [alert addButtonWithTitle:@"Yes"];
+    [alert addButtonWithTitle:@"No"];
+
+    NSModalResponse response = [alert runModal];
+
+    [alert release];
+    [msgText release];
+    [titleText release];
+
+    return response == NSAlertFirstButtonReturn;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
Implement long-living Fianna's request - popup window when you have to restart renderer.
On windows, I use `MessageBox` from the Windows Forms library.
On macOS AppKit's `NSAlert`.
Linux is the hard one, there are no such system GUI APIs on Linux. The easiest way I've found is to use `xmessage`.