### PR TITLE
Add the factory method to create render delegate with initial settings

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rendererPlugin.cpp
+++ b/pxr/imaging/plugin/hdRpr/rendererPlugin.cpp
@@ -36,6 +36,14 @@ HdRenderDelegate* HdRprPlugin::CreateRenderDelegate() {
     return new HdRprDelegate();
 }
 
+HdRenderDelegate* HdRprPlugin::CreateRenderDelegate(HdRenderSettingsMap const& settingsMap) {
+    auto renderDelegate = new HdRprDelegate();
+    for (auto& entry : settingsMap) {
+        renderDelegate->SetRenderSetting(entry.first, entry.second);
+    }
+    return renderDelegate;
+}
+
 void HdRprPlugin::DeleteRenderDelegate(HdRenderDelegate* renderDelegate) {
     delete renderDelegate;
 }

--- a/pxr/imaging/plugin/hdRpr/rendererPlugin.h
+++ b/pxr/imaging/plugin/hdRpr/rendererPlugin.h
@@ -15,6 +15,8 @@ public:
 
     HdRenderDelegate* CreateRenderDelegate() override;
 
+    HdRenderDelegate* CreateRenderDelegate(HdRenderSettingsMap const& settingsMap) override;
+
     void DeleteRenderDelegate(HdRenderDelegate* renderDelegate) override;
 
     bool IsSupported() const override { return true; }


### PR DESCRIPTION
It's used by Houdini's husk to pass all its render settings