### PR TITLE
Fix light transform sync

### DIFF
--- a/pxr/imaging/plugin/hdRpr/light.cpp
+++ b/pxr/imaging/plugin/hdRpr/light.cpp
@@ -404,7 +404,7 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
         }
     }
 
-    if (bits & (DirtyTransform || DirtyParams)) {
+    if (bits & (DirtyTransform | DirtyParams)) {
         struct LightTransformSetter : public BOOST_NS::static_visitor<> {
             HdRprApi* rprApi;
             GfMatrix4f const& transform;


### PR DESCRIPTION
Lights were working because `DirtyParams` equals 1 and Hydra creates light from scratch when it's changed. But `||` is obviously a typo