### PR TITLE
Remove spotlight empirical intensity multiplier

### DIFF
--- a/pxr/imaging/plugin/hdRpr/light.cpp
+++ b/pxr/imaging/plugin/hdRpr/light.cpp
@@ -382,8 +382,7 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
             }
 
             bool operator()(rpr::SpotLight* light) const {
-                // XXX: multiplied by 4 to be closer to Karma intensity
-                if (emissionColorIsDirty) { rprApi->SetLightColor(light, emissionColor * 4.0); }
+                if (emissionColorIsDirty) { rprApi->SetLightColor(light, emissionColor); }
                 return true;
             }
 


### PR DESCRIPTION
The spotlight in RPR and Karma is fundamentally different. The former has hard shadows, the latter has soft shadows. Also, the RPR spotlight penumbra uses different attenuation function.
No way to match them, at least on the plugin side.

The motivation for the removal of an empirical multiplier is very big intensity on the scenes with a big number of spotlights (like [BarScene](https://www.sidefx.com/contentlibrary/bar-scene/) and [RenderMan's Solaris teapot demo](https://rmanwiki.pixar.com/display/RFH23/Solaris+Tutorial))