### PR TITLE
Fix querying of "interactive mode" setting

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -332,7 +332,7 @@ void HdRprConfig::Sync(HdRenderDelegate* renderDelegate) {{
             return defaultValue;
         }};
 
-        auto interactiveMode = renderDelegate->GetRenderSetting<std::string>(_tokens->houdiniInteractive, "");
+        auto interactiveMode = renderDelegate->GetRenderSetting<std::string>(_tokens->houdiniInteractive, "normal");
         SetInteractiveMode(interactiveMode != "normal");
 
 {rs_sync}


### PR DESCRIPTION
If `houdini:interactive` render setting was not set, an interactive mode was mistakenly enabled due to incorrect fallback value