### PR TITLE
Set non-black color as default volume color

### DIFF
--- a/pxr/imaging/plugin/hdRpr/volume.cpp
+++ b/pxr/imaging/plugin/hdRpr/volume.cpp
@@ -49,7 +49,7 @@ inline GridType const* openvdbGridCast(openvdb::GridBase const* grid) {
 }
 
 const float defaultDensity = 100.f;      // RPR take density value of 100 as fully opaque
-GfVec3f defaultColor = GfVec3f(0.0f);    // Default color of black
+GfVec3f defaultColor = GfVec3f(0.18f);
 GfVec3f defaultEmission = GfVec3f(0.0f); // Default to no emission
 
 } // namespace anonymous


### PR DESCRIPTION
Typical volume file consists of a density grid only, in such cases we set default color for each voxel.
When voxel color is black it will not be lit up with any existing light type.