### PR TITLE
Force normal map texture linear space

### DIFF
--- a/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
@@ -440,6 +440,7 @@ void MaterialAdapter::PopulateUsdPreviewSurface(const MaterialParams& params, co
         } else if (paramName == HdRprMaterialTokens->normal) {
             NormalMapParam param;
             param.texture = materialTexture;
+            param.texture.forceLinearSpace = true;
             m_normalMapParams.emplace_back(std::vector<rpr::MaterialNodeInput>{RPR_MATERIAL_INPUT_UBER_DIFFUSE_NORMAL, RPR_MATERIAL_INPUT_UBER_REFLECTION_NORMAL}, param);
         } else if (paramName == HdRprMaterialTokens->displacement) {
             m_displacementTexture = materialTexture;
@@ -851,6 +852,7 @@ void MaterialAdapter::PopulateHoudiniPrincipledShader(HdMaterialNetwork const& s
             coatNormalMapParam.texture = getMaterialTexture(HoudiniPrincipledShaderTokens->coatNormal);
             if (!coatNormalMapParam.texture.path.empty()) {
                 coatNormalMapParam.effectScale = GetParameter(HoudiniPrincipledShaderTokens->coatNormalScale, params, 1.0f);
+                coatNormalMapParam.texture.forceLinearSpace = true;
                 m_normalMapParams.emplace_back(std::vector<rpr::MaterialNodeInput>{RPR_MATERIAL_INPUT_UBER_COATING_NORMAL}, coatNormalMapParam);
             }
         } else {
@@ -859,6 +861,7 @@ void MaterialAdapter::PopulateHoudiniPrincipledShader(HdMaterialNetwork const& s
 
         if (!baseNormalMapParam.texture.path.empty()) {
             baseNormalMapParam.effectScale = GetParameter(HoudiniPrincipledShaderTokens->baseNormalScale, params, 1.0f);
+            baseNormalMapParam.texture.forceLinearSpace = true;
             m_normalMapParams.emplace_back(rprInputs, baseNormalMapParam);
         }
     }


### PR DESCRIPTION
For some reason, this [line](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/blob/master/pxr/imaging/plugin/hdRpr/rpr/imageHelpers.cpp#L180) giving us GL_SRGB even for normal map .png images. So as normal maps are never sRGB encoded, we can safely force linear space usage for such textures

Related issue [FIR-1630](https://amdrender.atlassian.net/browse/FIR-1630)