### PR TITLE
BasisCurves improvements

### DIFF
--- a/pxr/imaging/plugin/hdRpr/basisCurves.h
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.h
@@ -51,7 +51,8 @@ protected:
                    HdDirtyBits* dirtyBits) override;
 
 private:
-    rpr::Curve* CreateRprCurve(HdRprApi* rprApi);
+    rpr::Curve* CreateLinearRprCurve(HdRprApi* rprApi);
+    rpr::Curve* CreateBezierRprCurve(HdRprApi* rprApi);
 
 private:
     rpr::Curve* m_rprCurve = nullptr;

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
@@ -120,8 +120,12 @@ bool HdRprIsValidPrimvarSize(size_t primvarSize, HdInterpolation primvarInterpol
         return primvarSize > 0;
     case HdInterpolationUniform:
         return primvarSize == uniformInterpSize;
-    default:
+    case HdInterpolationVertex:
         return primvarSize == vertexInterpSize;
+    case HdInterpolationVarying:
+        return true;
+    default:
+        return false;
     }
 }
 


### PR DESCRIPTION
### New

* Support for curves of bezier basis
* Primitive support for catmullRom and spline bases by interpreting them as linear
* Support varying interpolation for widths
* Optimized a bit memory usage for linear curves - there is no need to [allocate memory](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/blob/v1.2.2/pxr/imaging/plugin/hdRpr/basisCurves.cpp#L100) for dummy indices when there are no authored ones 

### Open Questions

* Should we consider converting (in the plugin) catmullRom and spline bases to bezier or the current behavior is sufficient?