### PR TITLE
Embed tone mapping filter support

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -198,6 +198,61 @@ render_setting_categories = [
         ]
     },
     {
+        'name': 'Tonemapping',
+        'settings': [
+            {
+                'name': 'enableTonemap',
+                'ui_name': 'Enable Tone Mapping',
+                'help': 'Enable linear photographic tone mapping filter. More info in RIF documentation',
+                'defaultValue': False
+            },
+            {
+                'name': 'tonemapExposure',
+                'ui_name': 'Tone Mapping Exposure',
+                'help': 'Film exposure time',
+                'defaultValue': 0.125,
+                'minValue': 0.0,
+                'maxValue': 10.0,
+                'houdini': {
+                    'hidewhen': 'enableTonemap == 0'
+                }
+            },
+            {
+                'name': 'tonemapSensitivity',
+                'ui_name': 'Tone Mapping Sensitivity',
+                'help': 'Luminance of the scene (in candela per m^2)',
+                'defaultValue': 1.0,
+                'minValue': 0.0,
+                'maxValue': 10.0,
+                'houdini': {
+                    'hidewhen': 'enableTonemap == 0'
+                }
+            },
+            {
+                'name': 'tonemapFstop',
+                'ui_name': 'Tone Mapping Fstop',
+                'help': 'Aperture f-number',
+                'defaultValue': 1.0,
+                'minValue': 0.0,
+                'maxValue': 100.0,
+                'houdini': {
+                    'hidewhen': 'enableTonemap == 0'
+                }
+            },
+            {
+                'name': 'tonemapGamma',
+                'ui_name': 'Tone Mapping Gamma',
+                'help': 'Gamma correction value',
+                'defaultValue': 1.0,
+                'minValue': 0.0,
+                'maxValue': 5.0,
+                'houdini': {
+                    'hidewhen': 'enableTonemap == 0'
+                }
+            }
+        ]
+    },
+    {
         'name': 'UsdNativeCamera',
         'settings': [
             {

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -87,6 +87,25 @@ public:
                           std::shared_ptr<HdRprApiAov> worldCoordinate);
     void DisableDenoise(rif::Context* rifContext);
 
+    struct TonemapParams {
+        bool enable;
+        float exposure;
+        float sensitivity;
+        float fstop;
+        float gamma;
+
+        bool operator==(TonemapParams const& lhs) {
+            return exposure == lhs.exposure &&
+                sensitivity == lhs.sensitivity &&
+                fstop == lhs.fstop &&
+                gamma == lhs.gamma;
+        }
+        bool operator!=(TonemapParams const& lhs) {
+            return !(*this == lhs);
+        }
+    };
+    void SetTonemap(TonemapParams const& params);
+
 protected:
     void OnFormatChange(rif::Context* rifContext) override;
     void OnSizeChange(rif::Context* rifContext) override;
@@ -98,11 +117,14 @@ private:
         kFilterAIDenoise = 1 << 1,
         kFilterEAWDenoise = 1 << 2,
         kFilterComposeOpacity = 1 << 3,
+        kFilterTonemap = 1 << 4,
     };
     void SetFilter(Filter filter, bool enable);
     
     template <typename T>
     void ResizeFilter(int width, int height, Filter filterType, rif::Filter* filter, T input);
+
+    void SetTonemapFilterParams(rif::Filter* filter);
 
 private:
     std::shared_ptr<HdRprApiAov> m_retainedOpacity;
@@ -113,6 +135,8 @@ private:
 
     uint32_t m_enabledFilters = kFilterNone;
     bool m_isEnabledFiltersDirty = true;
+
+    TonemapParams m_tonemap;
 };
 
 class HdRprApiNormalAov : public HdRprApiAov {


### PR DESCRIPTION
While working with indoor scenes (like the attic and the esper room) I felt the need to apply tone mapping. So as RIF already has a bunch of tone mapping filter I tested a few of them and selected the most versatile one - [Linear Photographic Tone Mapping Filter](https://radeon-pro.github.io/RadeonProRenderDocs/rif/filters/linear_photographic_tone_mapping.html).


It's possible to add support for more tone mapping filters but I don't feel such need right now