### PR TITLE
Optimize batch rendering

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -118,7 +118,8 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (openvdbAsset) \
     (percentDone) \
     (renderMode) \
-    (batch)
+    (batch) \
+    (progressive)
 );
 
 const TfTokenVector HdRprDelegate::SUPPORTED_RPRIM_TYPES = {
@@ -155,6 +156,7 @@ HdRprDelegate::HdRprDelegate(HdRenderSettingsMap const& renderSettings) {
     }
 
     m_isBatch = GetRenderSetting(_tokens->renderMode) == _tokens->batch;
+    m_isProgressive = GetRenderSetting(_tokens->progressive).GetWithDefault(true);
 
     m_rprApi.reset(new HdRprApi(this));
     g_rprApi = m_rprApi.get();

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -13,7 +13,7 @@ limitations under the License.
 
 #include "renderDelegate.h"
 
-#include"pxr/imaging/hd/extComputation.h"
+#include "pxr/imaging/hd/extComputation.h"
 
 #include "pxr/base/tf/diagnosticMgr.h"
 #include "pxr/base/tf/getenv.h"
@@ -116,7 +116,9 @@ private:
 
 TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (openvdbAsset) \
-    (percentDone)
+    (percentDone) \
+    (renderMode) \
+    (batch)
 );
 
 const TfTokenVector HdRprDelegate::SUPPORTED_RPRIM_TYPES = {
@@ -147,7 +149,13 @@ const TfTokenVector HdRprDelegate::SUPPORTED_BPRIM_TYPES = {
     HdPrimTypeTokens->renderBuffer
 };
 
-HdRprDelegate::HdRprDelegate() {
+HdRprDelegate::HdRprDelegate(HdRenderSettingsMap const& renderSettings) {
+    for (auto& entry : renderSettings) {
+        SetRenderSetting(entry.first, entry.second);
+    }
+
+    m_isBatch = GetRenderSetting(_tokens->renderMode) == _tokens->batch;
+
     m_rprApi.reset(new HdRprApi(this));
     g_rprApi = m_rprApi.get();
 

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -86,6 +86,7 @@ public:
 #endif // PXR_VERSION >= 2005
 
     bool IsBatch() const { return m_isBatch; }
+    bool IsProgressive() const { return m_isProgressive; }
 
 private:
     static const TfTokenVector SUPPORTED_RPRIM_TYPES;
@@ -93,6 +94,7 @@ private:
     static const TfTokenVector SUPPORTED_BPRIM_TYPES;
 
     bool m_isBatch;
+    bool m_isProgressive;
 
     std::unique_ptr<HdRprApi> m_rprApi;
     std::unique_ptr<HdRprRenderParam> m_renderParam;

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -28,7 +28,7 @@ class HdRprApi;
 class HdRprDelegate final : public HdRenderDelegate {
 public:
 
-    HdRprDelegate();
+    HdRprDelegate(HdRenderSettingsMap const& renderSettings);
     ~HdRprDelegate() override;
 
     HdRprDelegate(const HdRprDelegate&) = delete;
@@ -85,10 +85,14 @@ public:
     bool Restart() override;
 #endif // PXR_VERSION >= 2005
 
+    bool IsBatch() const { return m_isBatch; }
+
 private:
     static const TfTokenVector SUPPORTED_RPRIM_TYPES;
     static const TfTokenVector SUPPORTED_SPRIM_TYPES;
     static const TfTokenVector SUPPORTED_BPRIM_TYPES;
+
+    bool m_isBatch;
 
     std::unique_ptr<HdRprApi> m_rprApi;
     std::unique_ptr<HdRprRenderParam> m_renderParam;

--- a/pxr/imaging/plugin/hdRpr/rendererPlugin.cpp
+++ b/pxr/imaging/plugin/hdRpr/rendererPlugin.cpp
@@ -46,15 +46,11 @@ TF_REGISTRY_FUNCTION(TfType) {
 }
 
 HdRenderDelegate* HdRprPlugin::CreateRenderDelegate() {
-    return new HdRprDelegate();
+    return new HdRprDelegate(HdRenderSettingsMap());
 }
 
 HdRenderDelegate* HdRprPlugin::CreateRenderDelegate(HdRenderSettingsMap const& settingsMap) {
-    auto renderDelegate = new HdRprDelegate();
-    for (auto& entry : settingsMap) {
-        renderDelegate->SetRenderSetting(entry.first, entry.second);
-    }
-    return renderDelegate;
+    return new HdRprDelegate(settingsMap);
 }
 
 void HdRprPlugin::DeleteRenderDelegate(HdRenderDelegate* renderDelegate) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -132,7 +132,7 @@ static const std::map<TfToken, rpr_aov> kAovTokenToRprAov = {
 
 class HdRprApiImpl {
 public:
-    HdRprApiImpl(HdRenderDelegate* delegate)
+    HdRprApiImpl(HdRprDelegate* delegate)
         : m_delegate(delegate) {
         // Postpone initialization as further as possible to allow Hydra user to set custom render settings before creating a context
         //InitIfNeeded();
@@ -1376,6 +1376,7 @@ public:
     }
 
     void RenderImpl(HdRprRenderThread* renderThread, std::vector<std::pair<void*, size_t>> const& outputRenderBuffers) {
+        const bool isBatch = m_delegate->IsBatch();
         bool stopRequested = false;
         while (!IsConverged() || stopRequested) {
             renderThread->WaitUntilPaused();
@@ -1403,7 +1404,7 @@ public:
                 }
             }
 
-            if (!IsConverged()) {
+            if (!isBatch && !IsConverged()) {
                 // Last framebuffer resolve will be called after "while" in case framebuffer is converged.
                 // We do not resolve framebuffers in case user requested render stop
                 ResolveFramebuffers(outputRenderBuffers);
@@ -2078,7 +2079,7 @@ private:
     }
 
 private:
-    HdRenderDelegate* m_delegate;
+    HdRprDelegate* m_delegate;
 
     enum ChangeTracker : uint32_t {
         Clean = 0,
@@ -2132,7 +2133,7 @@ private:
     std::string m_rprSceneExportPath;
 };
 
-HdRprApi::HdRprApi(HdRenderDelegate* delegate) : m_impl(new HdRprApiImpl(delegate)) {
+HdRprApi::HdRprApi(HdRprDelegate* delegate) : m_impl(new HdRprApiImpl(delegate)) {
 
 }
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -35,6 +35,7 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdRprDelegate;
 class HdRprRenderThread;
 class MaterialAdapter;
 
@@ -65,7 +66,7 @@ const uint32_t kInvisible = 0u;
 
 class HdRprApi final {
 public:
-    HdRprApi(HdRenderDelegate* delegate);
+    HdRprApi(HdRprDelegate* delegate);
     ~HdRprApi();
 
     HdRprApiEnvironmentLight* CreateEnvironmentLight(const std::string& pathTotexture, float intensity);


### PR DESCRIPTION
First of all, track whether we are rendering in batch mode or not and if so then do not resolve framebuffers on each iteration.

As the second optimization, introduce a progressive mode - whether we should update renderStats each sample or should we render at once as many samples as possible, depending on sampling mode: when uniform sampling mode is used, render all samples per one Render call; when adaptive sampling mode is used, render min samples first and then call Render for each sample progressively querying current active pixel count.

As for the naming convention, I followed husk because usdrecord has none of it. I'm going to add `renderMode` to usdrecord.

Here are some measurements: 12% performance gain (before:01:38.02-after:01:26.06) on basic0 test with adaptive sampling and 7% performance gain (before:04:28.75-after:04:10.65) with uniform sampling.