### PR TITLE
Add render mode render setting

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1085,6 +1085,24 @@ public:
         }
     }
 
+    rpr_uint GetRprRenderMode(RenderModeType mode) {
+        static std::map<RenderModeType, rpr_render_mode> s_mapping = {
+            {kRenderModeGlobalIllumination, RPR_RENDER_MODE_GLOBAL_ILLUMINATION},
+            {kRenderModeDirectIllumination, RPR_RENDER_MODE_DIRECT_ILLUMINATION},
+            {kRenderModeWireframe, RPR_RENDER_MODE_WIREFRAME},
+            {kRenderModeMaterialIndex, RPR_RENDER_MODE_MATERIAL_INDEX},
+            {kRenderModePosition, RPR_RENDER_MODE_POSITION},
+            {kRenderModeNormal, RPR_RENDER_MODE_NORMAL},
+            {kRenderModeTexcoord, RPR_RENDER_MODE_TEXCOORD},
+            {kRenderModeAmbientOcclusion, RPR_RENDER_MODE_AMBIENT_OCCLUSION},
+            {kRenderModeDiffuse, RPR_RENDER_MODE_DIFFUSE},
+        };
+
+        auto it = s_mapping.find(mode);
+        if (it == s_mapping.end()) return RPR_RENDER_MODE_GLOBAL_ILLUMINATION;
+        return it->second;
+    }
+
     void UpdateTahoeSettings(HdRprConfig const& preferences, bool force) {
         if (preferences.IsDirty(HdRprConfig::DirtyAdaptiveSampling) || force) {
             m_varianceThreshold = preferences.GetVarianceThreshold();
@@ -1128,6 +1146,15 @@ public:
             RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_MAX_RECURSION, maxRayDepth), "Failed to set max recursion");
             RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_PREVIEW, int(is_interactive)), "Failed to set preview mode");
 
+            m_dirtyFlags |= ChangeTracker::DirtyScene;
+        }
+
+        if (preferences.IsDirty(HdRprConfig::DirtyRenderMode)) {
+            auto renderMode = preferences.GetRenderMode();
+            RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_RENDER_MODE, GetRprRenderMode(renderMode)), "Failed to set render mode");
+            if (renderMode == kRenderModeAmbientOcclusion) {
+                RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_AO_RAY_LENGTH, preferences.GetAoRadius()), "Failed to set ambient occlusion radius");
+            }
             m_dirtyFlags |= ChangeTracker::DirtyScene;
         }
     }


### PR DESCRIPTION
I'm not exposing "Direct Illumination No Shadows" render mode because it does not work in core. See [FIR-1584](https://amdrender.atlassian.net/browse/FIR-1584)

Global Illumination

![globalIllumination](https://user-images.githubusercontent.com/22181845/83496382-b2956500-a4c1-11ea-93f5-1c9497d7a81e.png)


Direct Illumination

![directIllumination](https://user-images.githubusercontent.com/22181845/83496390-b4f7bf00-a4c1-11ea-992c-bc55e57ba3ff.png)


Wireframe

![wireframe](https://user-images.githubusercontent.com/22181845/83496396-b628ec00-a4c1-11ea-91d6-90bc47ed65f6.png)


Ambient Occlusion

![ao](https://user-images.githubusercontent.com/22181845/83496401-b88b4600-a4c1-11ea-8ee5-868e6998bf12.png)


Diffuse

![diffuse](https://user-images.githubusercontent.com/22181845/83496407-ba550980-a4c1-11ea-9a90-284e45e6bdad.png)


