### PR TITLE
Fix dome light visibility

### DIFF
--- a/pxr/imaging/plugin/hdRpr/distantLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/distantLight.cpp
@@ -61,7 +61,6 @@ void HdRprDistantLight::Sync(HdSceneDelegate* sceneDelegate,
                 *dirtyBits = HdLight::Clean;
                 return;
             }
-            rprRenderParam->AddLight();
         }
 
         float angle = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->angle).Get<float>();
@@ -88,8 +87,6 @@ void HdRprDistantLight::Finalize(HdRenderParam* renderParam) {
         auto rprRenderParam = static_cast<HdRprRenderParam*>(renderParam);
         rprRenderParam->AcquireRprApiForEdit()->Release(m_rprLight);
         m_rprLight = nullptr;
-
-        rprRenderParam->RemoveLight();
     }
 
     HdSprim::Finalize(renderParam);

--- a/pxr/imaging/plugin/hdRpr/domeLight.h
+++ b/pxr/imaging/plugin/hdRpr/domeLight.h
@@ -42,7 +42,6 @@ public:
 protected:
     HdRprApiEnvironmentLight* m_rprLight = nullptr;
     GfMatrix4f m_transform;
-    bool m_created = false;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/light.h
+++ b/pxr/imaging/plugin/hdRpr/light.h
@@ -81,8 +81,6 @@ private:
 
     GfVec3f m_emisionColor = GfVec3f(0.0f);
     GfMatrix4f m_transform;
-
-    bool m_created = false;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderParam.h
+++ b/pxr/imaging/plugin/hdRpr/renderParam.h
@@ -37,7 +37,6 @@ public:
     HdRprRenderParam(HdRprApi* rprApi, HdRprRenderThread* renderThread)
         : m_rprApi(rprApi)
         , m_renderThread(renderThread) {
-        m_numLights.store(0);
         InitializeEnvParameters();
     }
     ~HdRprRenderParam() override = default;
@@ -49,10 +48,6 @@ public:
     }
 
     HdRprRenderThread* GetRenderThread() { return m_renderThread; }
-
-    void AddLight() { ++m_numLights; }
-    void RemoveLight() { --m_numLights; }
-    bool HasLights() const { return m_numLights != 0; }
 
     TfToken const& GetMaterialNetworkSelector() const { return m_materialNetworkSelector; }
 
@@ -70,8 +65,6 @@ private:
 
     HdRprApi* m_rprApi;
     HdRprRenderThread* m_renderThread;
-
-    std::atomic<uint32_t> m_numLights;
 
     TfToken m_materialNetworkSelector;
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -86,6 +86,9 @@ public:
 
     void Release(rpr::Light* light);
 
+    HdRprApiMaterial* CreateGeometryLightMaterial(GfVec3f const& emissionColor);
+    void ReleaseGeometryLightMaterial(HdRprApiMaterial* material);
+
     struct VolumeMaterialParameters {
         GfVec3f scatteringColor = GfVec3f(1.0f);
         GfVec3f transmissionColor = GfVec3f(1.0f);


### PR DESCRIPTION
Due to how is environment light creation/deletion implemented in RPR API we must remove default environment light before creating a new one