### PR TITLE
Improve AOV system

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -139,6 +139,7 @@ pxr_plugin(hdRpr
         ${OptIncludeDir}
 
     PRIVATE_CLASSES
+        aovDescriptor
         rendererPlugin
         renderDelegate
         renderPass

--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
@@ -1,0 +1,144 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#include "aovDescriptor.h"
+
+#include "pxr/base/tf/instantiateSingleton.h"
+
+#include "pxr/imaging/hd/tokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+const HdRprAovDescriptor kInvalidDesc;
+
+TF_INSTANTIATE_SINGLETON(HdRprAovRegistry);
+TF_DEFINE_PUBLIC_TOKENS(HdRprAovTokens, HDRPR_AOV_TOKENS);
+
+HdRprAovRegistry::HdRprAovRegistry() {
+    const auto rprAovMax = RPR_AOV_COLOR_RIGHT + 1;
+    const GfVec4f idClearValue(255.0f, 255.0f, 255.0f, 0.0f);
+
+    m_aovDescriptors.resize(rprAovMax);
+    m_aovDescriptors[RPR_AOV_COLOR] = HdRprAovDescriptor(RPR_AOV_COLOR);
+    m_aovDescriptors[RPR_AOV_DIFFUSE_ALBEDO] = HdRprAovDescriptor(RPR_AOV_DIFFUSE_ALBEDO); // XXX: RPR's albedo can be noisy in some cases, so we left it as multisampled
+    m_aovDescriptors[RPR_AOV_VARIANCE] = HdRprAovDescriptor(RPR_AOV_VARIANCE);
+    m_aovDescriptors[RPR_AOV_OPACITY] = HdRprAovDescriptor(RPR_AOV_OPACITY);
+    m_aovDescriptors[RPR_AOV_EMISSION] = HdRprAovDescriptor(RPR_AOV_EMISSION);
+    m_aovDescriptors[RPR_AOV_DIRECT_ILLUMINATION] = HdRprAovDescriptor(RPR_AOV_DIRECT_ILLUMINATION);
+    m_aovDescriptors[RPR_AOV_INDIRECT_ILLUMINATION] = HdRprAovDescriptor(RPR_AOV_INDIRECT_ILLUMINATION);
+    m_aovDescriptors[RPR_AOV_AO] = HdRprAovDescriptor(RPR_AOV_AO);
+    m_aovDescriptors[RPR_AOV_DIRECT_DIFFUSE] = HdRprAovDescriptor(RPR_AOV_DIRECT_DIFFUSE);
+    m_aovDescriptors[RPR_AOV_DIRECT_REFLECT] = HdRprAovDescriptor(RPR_AOV_DIRECT_REFLECT);
+    m_aovDescriptors[RPR_AOV_INDIRECT_DIFFUSE] = HdRprAovDescriptor(RPR_AOV_INDIRECT_DIFFUSE);
+    m_aovDescriptors[RPR_AOV_INDIRECT_REFLECT] = HdRprAovDescriptor(RPR_AOV_INDIRECT_REFLECT);
+    m_aovDescriptors[RPR_AOV_REFRACT] = HdRprAovDescriptor(RPR_AOV_REFRACT);
+    m_aovDescriptors[RPR_AOV_VOLUME] = HdRprAovDescriptor(RPR_AOV_VOLUME);
+    m_aovDescriptors[RPR_AOV_LIGHT_GROUP0] = HdRprAovDescriptor(RPR_AOV_LIGHT_GROUP0);
+    m_aovDescriptors[RPR_AOV_LIGHT_GROUP1] = HdRprAovDescriptor(RPR_AOV_LIGHT_GROUP1);
+    m_aovDescriptors[RPR_AOV_LIGHT_GROUP2] = HdRprAovDescriptor(RPR_AOV_LIGHT_GROUP2);
+    m_aovDescriptors[RPR_AOV_LIGHT_GROUP3] = HdRprAovDescriptor(RPR_AOV_LIGHT_GROUP3);
+    m_aovDescriptors[RPR_AOV_COLOR_RIGHT] = HdRprAovDescriptor(RPR_AOV_COLOR_RIGHT);
+    m_aovDescriptors[RPR_AOV_SHADOW_CATCHER] = HdRprAovDescriptor(RPR_AOV_SHADOW_CATCHER);
+    m_aovDescriptors[RPR_AOV_REFLECTION_CATCHER] = HdRprAovDescriptor(RPR_AOV_REFLECTION_CATCHER);
+
+    m_aovDescriptors[RPR_AOV_DEPTH] = HdRprAovDescriptor(RPR_AOV_DEPTH, false, HdFormatFloat32, GfVec4f(std::numeric_limits<float>::infinity()));
+    m_aovDescriptors[RPR_AOV_UV] = HdRprAovDescriptor(RPR_AOV_UV, false, HdFormatFloat32Vec3);
+    m_aovDescriptors[RPR_AOV_SHADING_NORMAL] = HdRprAovDescriptor(RPR_AOV_SHADING_NORMAL, false, HdFormatFloat32Vec3);
+    m_aovDescriptors[RPR_AOV_GEOMETRIC_NORMAL] = HdRprAovDescriptor(RPR_AOV_GEOMETRIC_NORMAL, false);
+    m_aovDescriptors[RPR_AOV_OBJECT_ID] = HdRprAovDescriptor(RPR_AOV_OBJECT_ID, false, HdFormatInt32, idClearValue);
+    m_aovDescriptors[RPR_AOV_MATERIAL_IDX] = HdRprAovDescriptor(RPR_AOV_MATERIAL_IDX, false, HdFormatInt32, idClearValue);
+    m_aovDescriptors[RPR_AOV_OBJECT_GROUP_ID] = HdRprAovDescriptor(RPR_AOV_OBJECT_GROUP_ID, false, HdFormatInt32, idClearValue);
+    m_aovDescriptors[RPR_AOV_WORLD_COORDINATE] = HdRprAovDescriptor(RPR_AOV_WORLD_COORDINATE, false);
+    m_aovDescriptors[RPR_AOV_BACKGROUND] = HdRprAovDescriptor(RPR_AOV_BACKGROUND, false);
+    m_aovDescriptors[RPR_AOV_VELOCITY] = HdRprAovDescriptor(RPR_AOV_VELOCITY, false);
+    m_aovDescriptors[RPR_AOV_VIEW_SHADING_NORMAL] = HdRprAovDescriptor(RPR_AOV_VIEW_SHADING_NORMAL, false);
+
+    m_computedAovDescriptors.resize(kComputedAovsCount);
+    m_computedAovDescriptors[kNdcDepth] = HdRprAovDescriptor(kNdcDepth, false, HdFormatFloat32, GfVec4f(std::numeric_limits<float>::infinity()), true);
+
+    auto addAovNameLookup = [this](TfToken const& name, HdRprAovDescriptor const& descriptor) {
+        auto status = m_aovNameLookup.emplace(name, AovNameLookupValue(descriptor.id, descriptor.computed));
+        if (!status.second) {
+            TF_CODING_ERROR("AOV lookup name should be unique");
+        }
+    };
+
+    addAovNameLookup(HdAovTokens->color, m_aovDescriptors[RPR_AOV_COLOR]);
+    addAovNameLookup(HdAovTokens->normal, m_aovDescriptors[RPR_AOV_SHADING_NORMAL]);
+    addAovNameLookup(HdAovTokens->primId, m_aovDescriptors[RPR_AOV_OBJECT_ID]);
+    addAovNameLookup(HdAovTokens->Neye, m_aovDescriptors[RPR_AOV_VIEW_SHADING_NORMAL]);
+    addAovNameLookup(HdAovTokens->depth, m_computedAovDescriptors[kNdcDepth]);
+    addAovNameLookup(HdRprGetCameraDepthAovName(), m_aovDescriptors[RPR_AOV_DEPTH]);
+
+    addAovNameLookup(HdRprAovTokens->albedo, m_aovDescriptors[RPR_AOV_DIFFUSE_ALBEDO]);
+    addAovNameLookup(HdRprAovTokens->variance, m_aovDescriptors[RPR_AOV_VARIANCE]);
+    addAovNameLookup(HdRprAovTokens->opacity, m_aovDescriptors[RPR_AOV_OPACITY]);
+    addAovNameLookup(HdRprAovTokens->emission, m_aovDescriptors[RPR_AOV_EMISSION]);
+    addAovNameLookup(HdRprAovTokens->directIllumination, m_aovDescriptors[RPR_AOV_DIRECT_ILLUMINATION]);
+    addAovNameLookup(HdRprAovTokens->indirectIllumination, m_aovDescriptors[RPR_AOV_INDIRECT_ILLUMINATION]);
+    addAovNameLookup(HdRprAovTokens->ao, m_aovDescriptors[RPR_AOV_AO]);
+    addAovNameLookup(HdRprAovTokens->directDiffuse, m_aovDescriptors[RPR_AOV_DIRECT_DIFFUSE]);
+    addAovNameLookup(HdRprAovTokens->directReflect, m_aovDescriptors[RPR_AOV_DIRECT_REFLECT]);
+    addAovNameLookup(HdRprAovTokens->indirectDiffuse, m_aovDescriptors[RPR_AOV_INDIRECT_DIFFUSE]);
+    addAovNameLookup(HdRprAovTokens->indirectReflect, m_aovDescriptors[RPR_AOV_INDIRECT_REFLECT]);
+    addAovNameLookup(HdRprAovTokens->refract, m_aovDescriptors[RPR_AOV_REFRACT]);
+    addAovNameLookup(HdRprAovTokens->volume, m_aovDescriptors[RPR_AOV_VOLUME]);
+    addAovNameLookup(HdRprAovTokens->lightGroup0, m_aovDescriptors[RPR_AOV_LIGHT_GROUP0]);
+    addAovNameLookup(HdRprAovTokens->lightGroup1, m_aovDescriptors[RPR_AOV_LIGHT_GROUP1]);
+    addAovNameLookup(HdRprAovTokens->lightGroup2, m_aovDescriptors[RPR_AOV_LIGHT_GROUP2]);
+    addAovNameLookup(HdRprAovTokens->lightGroup3, m_aovDescriptors[RPR_AOV_LIGHT_GROUP3]);
+    addAovNameLookup(HdRprAovTokens->colorRight, m_aovDescriptors[RPR_AOV_COLOR_RIGHT]);
+    addAovNameLookup(HdRprAovTokens->materialIdx, m_aovDescriptors[RPR_AOV_MATERIAL_IDX]);
+    addAovNameLookup(HdRprAovTokens->objectGroupId, m_aovDescriptors[RPR_AOV_OBJECT_GROUP_ID]);
+    addAovNameLookup(HdRprAovTokens->geometricNormal, m_aovDescriptors[RPR_AOV_GEOMETRIC_NORMAL]);
+    addAovNameLookup(HdRprAovTokens->worldCoordinate, m_aovDescriptors[RPR_AOV_WORLD_COORDINATE]);
+    addAovNameLookup(HdRprAovTokens->primvarsSt, m_aovDescriptors[RPR_AOV_UV]);
+    addAovNameLookup(HdRprAovTokens->shadowCatcher, m_aovDescriptors[RPR_AOV_SHADOW_CATCHER]);
+    addAovNameLookup(HdRprAovTokens->reflectionCatcher, m_aovDescriptors[RPR_AOV_REFLECTION_CATCHER]);
+    addAovNameLookup(HdRprAovTokens->background, m_aovDescriptors[RPR_AOV_BACKGROUND]);
+    addAovNameLookup(HdRprAovTokens->velocity, m_aovDescriptors[RPR_AOV_VELOCITY]);
+    addAovNameLookup(HdRprAovTokens->viewShadingNormal, m_aovDescriptors[RPR_AOV_VIEW_SHADING_NORMAL]);
+}
+
+HdRprAovDescriptor const& HdRprAovRegistry::GetAovDesc(TfToken const& name) {
+    auto it = m_aovNameLookup.find(name);
+    if (it == m_aovNameLookup.end()) {
+        return kInvalidDesc;
+    }
+
+    return GetAovDesc(it->second.id, it->second.isComputed);
+}
+
+HdRprAovDescriptor const& HdRprAovRegistry::GetAovDesc(uint32_t id, bool computed) {
+    size_t descsSize = computed ? m_computedAovDescriptors.size() : m_aovDescriptors.size();
+    if (id < 0 || id >= descsSize) {
+        TF_RUNTIME_ERROR("Invalid arguments: %#x (computed=%d)", id, int(computed));
+        return kInvalidDesc;
+    }
+
+    if (computed) {
+        return m_computedAovDescriptors[id];
+    } else {
+        return m_aovDescriptors[id];
+    }
+}
+
+TfToken const& HdRprGetCameraDepthAovName() {
+#if PXR_VERSION < 2002
+    return HdAovTokens->linearDepth;
+#else
+    return HdAovTokens->cameraDepth;
+#endif
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
@@ -65,6 +65,7 @@ HdRprAovRegistry::HdRprAovRegistry() {
 
     m_computedAovDescriptors.resize(kComputedAovsCount);
     m_computedAovDescriptors[kNdcDepth] = HdRprAovDescriptor(kNdcDepth, false, HdFormatFloat32, GfVec4f(std::numeric_limits<float>::infinity()), true);
+    m_computedAovDescriptors[kColorAlpha] = HdRprAovDescriptor(kColorAlpha);
 
     auto addAovNameLookup = [this](TfToken const& name, HdRprAovDescriptor const& descriptor) {
         auto status = m_aovNameLookup.emplace(name, AovNameLookupValue(descriptor.id, descriptor.computed));
@@ -73,13 +74,14 @@ HdRprAovRegistry::HdRprAovRegistry() {
         }
     };
 
-    addAovNameLookup(HdAovTokens->color, m_aovDescriptors[RPR_AOV_COLOR]);
+    addAovNameLookup(HdAovTokens->color, m_computedAovDescriptors[kColorAlpha]);
     addAovNameLookup(HdAovTokens->normal, m_aovDescriptors[RPR_AOV_SHADING_NORMAL]);
     addAovNameLookup(HdAovTokens->primId, m_aovDescriptors[RPR_AOV_OBJECT_ID]);
     addAovNameLookup(HdAovTokens->Neye, m_aovDescriptors[RPR_AOV_VIEW_SHADING_NORMAL]);
     addAovNameLookup(HdAovTokens->depth, m_computedAovDescriptors[kNdcDepth]);
     addAovNameLookup(HdRprGetCameraDepthAovName(), m_aovDescriptors[RPR_AOV_DEPTH]);
 
+    addAovNameLookup(HdRprAovTokens->rawColor, m_aovDescriptors[RPR_AOV_COLOR]);
     addAovNameLookup(HdRprAovTokens->albedo, m_aovDescriptors[RPR_AOV_DIFFUSE_ALBEDO]);
     addAovNameLookup(HdRprAovTokens->variance, m_aovDescriptors[RPR_AOV_VARIANCE]);
     addAovNameLookup(HdRprAovTokens->opacity, m_aovDescriptors[RPR_AOV_OPACITY]);

--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.h
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.h
@@ -1,0 +1,121 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#ifndef HDRPR_AOV_DESCRIPTOR_H
+#define HDRPR_AOV_DESCRIPTOR_H
+
+#include "pxr/base/tf/singleton.h"
+#include "pxr/base/tf/staticTokens.h"
+#include "pxr/base/gf/vec4f.h"
+
+#include "pxr/imaging/hd/types.h"
+
+#include <RadeonProRender.hpp>
+
+#include <map>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+#define HDRPR_AOV_TOKENS \
+    (albedo) \
+    (variance) \
+    (worldCoordinate) \
+    (opacity) \
+    ((primvarsSt, "primvars:st")) \
+    (materialIdx) \
+    (geometricNormal) \
+    (objectGroupId) \
+    (shadowCatcher) \
+    (background) \
+    (emission) \
+    (velocity) \
+    (directIllumination) \
+    (indirectIllumination) \
+    (ao) \
+    (directDiffuse) \
+    (directReflect) \
+    (indirectDiffuse) \
+    (indirectReflect) \
+    (refract) \
+    (volume) \
+    (lightGroup0) \
+    (lightGroup1) \
+    (lightGroup2) \
+    (lightGroup3) \
+    (viewShadingNormal) \
+    (reflectionCatcher) \
+    (colorRight)
+
+TF_DECLARE_PUBLIC_TOKENS(HdRprAovTokens, HDRPR_AOV_TOKENS);
+
+const rpr::Aov kAovNone = static_cast<rpr::Aov>(-1);
+
+enum ComputedAovs {
+    kNdcDepth = 0,
+    kComputedAovsCount
+};
+
+struct HdRprAovDescriptor {
+    uint32_t id;
+    HdFormat format;
+    bool multiSampled;
+    bool computed;
+    GfVec4f clearValue;
+
+    HdRprAovDescriptor(uint32_t id = kAovNone, bool multiSampled = true, HdFormat format = HdFormatFloat32Vec4, GfVec4f clearValue = GfVec4f(0.0f), bool computed = false)
+        : id(id), multiSampled(multiSampled), format(format), clearValue(clearValue), computed(computed) {
+
+    }
+};
+
+class HdRprAovRegistry {
+public:
+    static HdRprAovRegistry& GetInstance() {
+        return TfSingleton<HdRprAovRegistry>::GetInstance();
+    }
+
+    HdRprAovDescriptor const& GetAovDesc(TfToken const& name);
+    HdRprAovDescriptor const& GetAovDesc(uint32_t id, bool computed);
+
+    HdRprAovRegistry(HdRprAovRegistry const&) = delete;
+    HdRprAovRegistry& operator=(HdRprAovRegistry const&) = delete;
+    HdRprAovRegistry(HdRprAovRegistry&&) = delete;
+    HdRprAovRegistry& operator=(HdRprAovRegistry&&) = delete;
+
+private:
+    HdRprAovRegistry();
+    ~HdRprAovRegistry() = default;
+
+    friend class TfSingleton<HdRprAovRegistry>;
+
+private:
+    struct AovNameLookupValue {
+        uint32_t id;
+        bool isComputed;
+
+        AovNameLookupValue(uint32_t id, bool isComputed = false)
+            : id(id), isComputed(isComputed) {
+
+        }
+    };
+    std::map<TfToken, AovNameLookupValue> m_aovNameLookup;
+
+    std::vector<HdRprAovDescriptor> m_aovDescriptors;
+    std::vector<HdRprAovDescriptor> m_computedAovDescriptors;
+};
+
+TfToken const& HdRprGetCameraDepthAovName();
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDRPR_AOV_DESCRIPTOR_H

--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.h
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.h
@@ -27,6 +27,7 @@ limitations under the License.
 PXR_NAMESPACE_OPEN_SCOPE
 
 #define HDRPR_AOV_TOKENS \
+    (rawColor) \
     (albedo) \
     (variance) \
     (worldCoordinate) \
@@ -62,6 +63,7 @@ const rpr::Aov kAovNone = static_cast<rpr::Aov>(-1);
 
 enum ComputedAovs {
     kNdcDepth = 0,
+    kColorAlpha,
     kComputedAovsCount
 };
 

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -305,6 +305,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         m_geomSubsets = m_topology.GetGeomSubsets();
         if (m_geomSubsets.empty()) {
             if (auto rprMesh = rprApi->CreateMesh(m_points, m_faceVertexIndices, m_normals, m_normalIndices, m_uvs, m_uvIndices, m_faceVertexCounts, m_topology.GetOrientation())) {
+                rprApi->SetMeshId(rprMesh, GetPrimId());
                 m_rprMeshes.push_back(rprMesh);
             }
         } else {
@@ -431,6 +432,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                 }
 
                 if (auto rprMesh = rprApi->CreateMesh(subsetPoints, subsetIndexes, subsetNormals, subsetNormalIndices, subsetUv, subsetUvIndices, subsetVertexPerFace, m_topology.GetOrientation())) {
+                    rprApi->SetMeshId(rprMesh, GetPrimId());
                     m_rprMeshes.push_back(rprMesh);
                     ++it;
                 } else {

--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -300,6 +300,19 @@ render_setting_categories = [
         ]
     },
     {
+        'name': 'Alpha',
+        'settings': [
+            {
+                'name': 'enableAlpha',
+                'ui_name': 'Enable Color Alpha',
+                'defaultValue': True,
+                'houdini': {
+                    'hidewhen': 'renderQuality != 3'
+                }
+            }
+        ]
+    },
+    {
         'name': 'UsdNativeCamera',
         'settings': [
             {
@@ -474,7 +487,7 @@ bool HdRprConfig::PrefData::Load() {{
 
     if (FILE* f = fopen(rprPreferencePath.c_str(), "rb")) {{
         if (!fread(this, sizeof(PrefData), 1, f)) {{
-            TF_CODING_ERROR("Fail to read rpr preferences dat file");
+            TF_RUNTIME_ERROR("Fail to read rpr preferences dat file");
         }}
         fclose(f);
         return IsValid();

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
@@ -49,7 +49,6 @@ void HdRprRenderBuffer::Finalize(HdRenderParam* renderParam) {
 bool HdRprRenderBuffer::Allocate(GfVec3i const& dimensions,
                                  HdFormat format,
                                  bool multiSampled) {
-    TF_VERIFY(!IsMapped());
     TF_UNUSED(multiSampled);
 
     if (dimensions[2] != 1) {
@@ -69,8 +68,6 @@ bool HdRprRenderBuffer::Allocate(GfVec3i const& dimensions,
 }
 
 void HdRprRenderBuffer::_Deallocate() {
-    TF_VERIFY(!IsMapped());
-
     m_width = 0u;
     m_height = 0u;
     m_format = HdFormatInvalid;

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -12,6 +12,7 @@ limitations under the License.
 ************************************************************************/
 
 #include "renderDelegate.h"
+#include "aovDescriptor.h"
 
 #include "pxr/imaging/hd/extComputation.h"
 
@@ -334,42 +335,14 @@ void HdRprDelegate::DestroyBprim(HdBprim* bPrim) {
 }
 
 HdAovDescriptor HdRprDelegate::GetDefaultAovDescriptor(TfToken const& name) const {
-    HdParsedAovToken aovId(name);
-    if (name != HdAovTokens->color &&
-        name != HdAovTokens->normal &&
-        name != HdAovTokens->primId &&
-        name != HdAovTokens->depth &&
-        name != HdRprUtilsGetCameraDepthName() &&
-        !(aovId.isPrimvar && aovId.name == "st")) {
-        // TODO: implement support for instanceId and elementId aov
-        return HdAovDescriptor();
-    }
+    auto& rprAovDesc = HdRprAovRegistry::GetInstance().GetAovDesc(name);
 
-    if (!m_rprApi->IsAovFormatConversionAvailable()) {
-        if (name == HdAovTokens->primId) {
-            // Integer images required, no way to support it
-            return HdAovDescriptor();
-        }
-        // Only native RPR format can be used for AOVs when there is no support for AOV format conversion
-        return HdAovDescriptor(HdFormatFloat32Vec4, false, VtValue(GfVec4f(0.0f)));
-    }
+    HdAovDescriptor hdAovDesc;
+    hdAovDesc.format = rprAovDesc.format;
+    hdAovDesc.multiSampled = rprAovDesc.multiSampled;
+    hdAovDesc.clearValue = VtValue(rprAovDesc.clearValue);
 
-    HdFormat format = HdFormatInvalid;
-
-    float clearColorValue = 0.0f;
-    if (name == HdAovTokens->depth ||
-        name == HdRprUtilsGetCameraDepthName()) {
-        clearColorValue = name == HdRprUtilsGetCameraDepthName() ? 0.0f : 1.0f;
-        format = HdFormatFloat32;
-    } else if (name == HdAovTokens->color) {
-        format = HdFormatFloat32Vec4;
-    } else if (name == HdAovTokens->primId) {
-        format = HdFormatInt32;
-    } else {
-        format = HdFormatFloat32Vec3;
-    }
-
-    return HdAovDescriptor(format, false, VtValue(GfVec4f(clearColorValue)));
+    return hdAovDesc;
 }
 
 HdRenderSettingDescriptorList HdRprDelegate::GetRenderSettingDescriptors() const {
@@ -429,14 +402,6 @@ bool HdRprDelegate::Restart() {
 }
 
 #endif // PXR_VERSION >= 2005
-
-TfToken const& HdRprUtilsGetCameraDepthName() {
-#if PXR_VERSION < 2002
-    return HdAovTokens->linearDepth;
-#else
-    return HdAovTokens->cameraDepth;
-#endif
-}
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -105,7 +105,6 @@ private:
     DiagnostMgrDelegatePtr m_diagnosticMgrDelegate;
 };
 
-TfToken const& HdRprUtilsGetCameraDepthName();
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -146,7 +146,6 @@ public:
 
     bool IsChanged() const;
     bool IsGlInteropEnabled() const;
-    bool IsAovFormatConversionAvailable() const;
     bool IsArbitraryShapedLightSupported() const;
     int GetCurrentRenderQuality() const;
     void ExportRprSceneOnNextRender(const char* exportPath);

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -14,6 +14,7 @@ limitations under the License.
 #ifndef HDRPR_RPR_API_AOV_H
 #define HDRPR_RPR_API_AOV_H
 
+#include "aovDescriptor.h"
 #include "rprApiFramebuffer.h"
 #include "rifcpp/rifFilter.h"
 #include "rpr/contextMetadata.h"
@@ -40,16 +41,20 @@ public:
     void Clear();
 
     HdFormat GetFormat() const { return m_format; }
+    HdRprAovDescriptor const& GetDesc() const { return m_aovDescriptor; }
+
     HdRprApiFramebuffer* GetAovFb() { return m_aov.get(); };
     HdRprApiFramebuffer* GetResolvedFb();
 
 protected:
-    HdRprApiAov() = default;
+    HdRprApiAov(HdRprAovDescriptor const& aovDescriptor) : m_aovDescriptor(aovDescriptor) {};
 
     virtual void OnFormatChange(rif::Context* rifContext);
     virtual void OnSizeChange(rif::Context* rifContext);
 
 protected:
+    HdRprAovDescriptor const& m_aovDescriptor;
+
     std::unique_ptr<HdRprApiFramebuffer> m_aov;
     std::unique_ptr<HdRprApiFramebuffer> m_resolved;
     std::unique_ptr<rif::Filter> m_filter;

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -37,7 +37,7 @@ public:
     virtual void Update(HdRprApi const* rprApi, rif::Context* rifContext);
     virtual void Resolve();
 
-    bool GetData(void* dstBuffer, size_t dstBufferSize);
+    virtual bool GetData(void* dstBuffer, size_t dstBufferSize);
     void Clear();
 
     HdFormat GetFormat() const { return m_format; }
@@ -74,10 +74,11 @@ private:
 
 class HdRprApiColorAov : public HdRprApiAov {
 public:
-    HdRprApiColorAov(int width, int height, HdFormat format, rpr::Context* rprContext, rpr::ContextMetadata const& rprContextMetadata);
+    HdRprApiColorAov(HdFormat format, std::shared_ptr<HdRprApiAov> rawColorAov, rpr::Context* rprContext, rpr::ContextMetadata const& rprContextMetadata);
     ~HdRprApiColorAov() override = default;
 
     void Update(HdRprApi const* rprApi, rif::Context* rifContext) override;
+    bool GetData(void* dstBuffer, size_t dstBufferSize) override;
     void Resolve() override;
 
     void SetOpacityAov(std::shared_ptr<HdRprApiAov> opacity);
@@ -132,6 +133,7 @@ private:
     void SetTonemapFilterParams(rif::Filter* filter);
 
 private:
+    std::shared_ptr<HdRprApiAov> m_retainedRawColor;
     std::shared_ptr<HdRprApiAov> m_retainedOpacity;
     std::shared_ptr<HdRprApiAov> m_retainedDenoiseInputs[rif::MaxInput];
 

--- a/pxr/imaging/plugin/hdRpr/rprApiFramebuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApiFramebuffer.cpp
@@ -12,6 +12,7 @@ limitations under the License.
 ************************************************************************/
 
 #include "rprApiFramebuffer.h"
+#include "aovDescriptor.h"
 #include "rpr/helpers.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -63,11 +64,19 @@ void HdRprApiFramebuffer::AttachAs(rpr::Aov aov) {
     m_aov = aov;
 }
 
-void HdRprApiFramebuffer::Clear() {
+void HdRprApiFramebuffer::Clear(float r, float g, float b, float a) {
     if (m_width == 0 || m_height == 0) {
         return;
     }
     RPR_ERROR_CHECK(m_rprFb->Clear(), "Failed to clear framebuffer");
+
+    // XXX (FIR-1681): We can not rely on clear values because every AOV in RPR is multisampled, i.e.
+    // value of singlesampled AOV (any ID AOV, worldCoordinate, etc) is always equals to `clearValue + renderedValue`
+    /*if (r == 0.0f && g == 0.0f && b == 0.0f && a == 0.0f) {
+        RPR_ERROR_CHECK(m_rprFb->Clear(), "Failed to clear framebuffer");
+    } else {
+        RPR_ERROR_CHECK(m_rprFb->FillWithColor(r, g, b, a), "Failed to clear framebuffer");
+    }*/
 }
 
 void HdRprApiFramebuffer::Resolve(HdRprApiFramebuffer* dstFrameBuffer) {

--- a/pxr/imaging/plugin/hdRpr/rprApiFramebuffer.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiFramebuffer.h
@@ -23,7 +23,6 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdRprApiFramebuffer {
 public:
-    static constexpr rpr::Aov kAovNone = static_cast<rpr::Aov>(-1);
     static constexpr uint32_t kNumChannels = 4;
 
     HdRprApiFramebuffer(rpr::Context* context, uint32_t width, uint32_t height);
@@ -33,7 +32,7 @@ public:
     HdRprApiFramebuffer& operator=(HdRprApiFramebuffer&& fb) noexcept;
 
     void AttachAs(rpr::Aov aov);
-    void Clear();
+    void Clear(float r, float g, float b, float a);
     void Resolve(HdRprApiFramebuffer* dstFrameBuffer);
     /// Return true if framebuffer was actually resized
     bool Resize(uint32_t width, uint32_t height);


### PR DESCRIPTION
* Allow the user to bind any AOV supported by RPR
* Fix primId AOV: use `HdRprim::GetPrimId` as object id - effectively enables usdview's selection logic

    ![primId-selection](https://user-images.githubusercontent.com/22181845/83874639-7d497b00-a73e-11ea-99de-f4d7305dc0bc.gif)

* Workaround RPR's rule that sounds like "every AOV is multisampled" by resolving singlesampled AOV (any ID AOV, worldCoordinate, etc) only once. Related Issue [FIR-1681](https://amdrender.atlassian.net/browse/FIR-1681).


    To be clear, by `singlesampled AOV` I mean AOV for which accumulation does not make any sense. The most outstanding example is `RPR_AOV_OBJECT_ID` - if a pixel on the edge of a few objects RPR will average IDs, this averaging will give you invalid ID.
    Here are [AOVs](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/blob/c7e153d7eed8e8b035562beb97bcd991aba0872a/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp#L54-L64) that I identified as singlesampled. Please verify.
* Allow hydra user to get raw unmodified color AOV.


    In hdRpr, we actually have two different kinds of AOVs - raw and computed. Raw AOV is an AOV that is fed to Hydra directly without any math applied to values (except maybe converting formats, e.g. from RPR's native HdFormatFloat32Vec4 to HdFormatFloat32Vec3 (e.g. RPR_AOV_UV)). Computed AOV is an AOV that requires some sort of computations, with raw AOVs as its inputs, before giving results to Hydra. Before the current changes, we had only one computed AOV - depth, which is actually the clip-space depth (aka OpenGL depth). Previously, there was no way for the user to simultaneously get denoised\tonemapped\alpha-composited color AOV and raw color AOV. These changes will allow this.

* Replace `HDRPR_DISABLE_ALPHA` environment setting with corresponding render setting to allow runtime changes.

    ![enable-alpha](https://user-images.githubusercontent.com/22181845/83876135-019cfd80-a741-11ea-94d5-387bbced6d2b.gif)

You might ask why do we need to be able to disable alpha at all? Here are at least two points:
* You have more than one shadow/reflection catcher on the scene and you want to view them. You have two options: disable them all one by one or disable alpha.
* Opacity AOV is not bugfree in RPR, e.g. https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/issues/210 but it's already fixed. Here is another example of a still existing issue.

Alpha off
<img width="757" alt="image_2020-06-05_16-09-43" src="https://user-images.githubusercontent.com/22181845/83879875-049aec80-a747-11ea-8f9d-4cdfaf3ad573.png">

Alpha on
<img width="760" alt="image_2020-06-05_16-09-33" src="https://user-images.githubusercontent.com/22181845/83879918-14b2cc00-a747-11ea-9545-af5ca30b78bf.png">

Opacity is clearly broken where the same ray simultaneously intersects volume shape and invisible sphere light (I want to point out that light's shape does not intersect volume's shape). Related issue [FIR-1682](https://amdrender.atlassian.net/browse/FIR-1682).

