### PR TITLE
Query UV primvar name from bound material

### DIFF
--- a/pxr/imaging/plugin/hdRpr/material.cpp
+++ b/pxr/imaging/plugin/hdRpr/material.cpp
@@ -102,6 +102,7 @@ void HdRprMaterial::Sync(HdSceneDelegate* sceneDelegate,
                 }
 
                 MaterialAdapter matAdapter(surfaceType, *surface, displacement ? *displacement : HdMaterialNetwork{});
+                m_stName = matAdapter.GetStName();
                 m_rprMaterial = rprApi->CreateMaterial(matAdapter);
             } else {
                 TF_CODING_WARNING("Material type not supported");

--- a/pxr/imaging/plugin/hdRpr/material.h
+++ b/pxr/imaging/plugin/hdRpr/material.h
@@ -39,8 +39,11 @@ public:
     /// In case material сreation failure return nullptr
     HdRprApiMaterial const* GetRprMaterialObject() const;
 
+    TfToken const& GetStName() const { return m_stName; }
+
 private:
     HdRprApiMaterial* m_rprMaterial = nullptr;
+    TfToken m_stName;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
+++ b/pxr/imaging/plugin/hdRpr/materialAdapter.cpp
@@ -125,7 +125,7 @@ void GetParameters(const  HdMaterialNetwork& materialNetwork, const HdMaterialNo
     out_materialParams.insert(previewNode.parameters.begin(), previewNode.parameters.end());
 }
 
-void GetTextures(const  HdMaterialNetwork& materialNetwork, MaterialTextures& out_materialTextures) {
+void GetTextures(const  HdMaterialNetwork& materialNetwork, MaterialTextures& out_materialTextures, TfToken* stName) {
     out_materialTextures.clear();
 
     auto stToken = UsdUtilsGetPrimaryUVSetName();
@@ -161,6 +161,14 @@ void GetTextures(const  HdMaterialNetwork& materialNetwork, MaterialTextures& ou
                 TF_RUNTIME_ERROR("Invalid material network. Relationship %s does not match to any node", stRel.outputName.GetText());
                 continue;
             }
+
+            if (stName->IsEmpty()) {
+                if (GetParam(HdRprMaterialTokens->varname, *stNodeIter, param) &&
+                    param.IsHolding<TfToken>()) {
+                    *stName = param.UncheckedGet<TfToken>();
+                }
+            }
+
             // Actually some much more complex node graph could exists
             // But we support only direct UsdUvTexture<->UsdTransform2d relationship for now
             if (stNodeIter->identifier == HdRprMaterialTokens->UsdTransform2d) {
@@ -312,13 +320,14 @@ MaterialAdapter::MaterialAdapter(EMaterialType type, const HdMaterialNetwork& su
             setFallbackValue(HdRprMaterialTokens->opacityThreshold, VtValue(0.0f));
 
             MaterialTextures materialTextures;
-            GetTextures(surfaceNetwork, materialTextures);
+            GetTextures(surfaceNetwork, materialTextures, &m_stName);
 
             PopulateUsdPreviewSurface(materialParameters, materialTextures);
             break;
         }
         case EMaterialType::HOUDINI_PRINCIPLED_SHADER: {
             PopulateHoudiniPrincipledShader(surfaceNetwork, displacementNetwork);
+            m_stName = UsdUtilsGetPrimaryUVSetName();
             break;
         }
         default:

--- a/pxr/imaging/plugin/hdRpr/materialAdapter.h
+++ b/pxr/imaging/plugin/hdRpr/materialAdapter.h
@@ -55,7 +55,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     (displacement) \
     (transparency) \
     (rotation) \
-    (translation)
+    (translation) \
+    (varname)
 
 TF_DECLARE_PUBLIC_TOKENS(HdRprMaterialTokens, HDRPR_MATERIAL_TOKENS);
 
@@ -149,6 +150,10 @@ public:
         return m_doublesided;
     }
 
+    TfToken GetStName() const {
+        return m_stName;
+    }
+
 private:
     void PopulateRprColor(const MaterialParams& params);
     void PopulateEmissive(const MaterialParams& params);
@@ -165,6 +170,8 @@ private:
 
     MaterialTexture m_displacementTexture;
     bool m_doublesided = false;
+
+    TfToken m_stName;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -214,15 +214,17 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         newMesh = true;
     }
 
-    auto stToken = UsdUtilsGetPrimaryUVSetName();
-    if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, stToken)) {
-        GetPrimvarData(stToken, sceneDelegate, primvarDescsPerInterpolation, m_uvs, m_uvIndices);
-
-        newMesh = true;
-    }
-
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
         m_cachedMaterialId = sceneDelegate->GetMaterialId(id);
+    }
+
+    auto material = static_cast<const HdRprMaterial*>(sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, m_cachedMaterialId));
+    if (material) {
+        if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, material->GetStName())) {
+            GetPrimvarData(material->GetStName(), sceneDelegate, primvarDescsPerInterpolation, m_uvs, m_uvIndices);
+
+            newMesh = true;
+        }
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyVisibility) {


### PR DESCRIPTION
When mesh has few UV sets or it has non-standard (`st`) UV primvar name we must query the name of the needed UV primvar from bound material