### PR TITLE
Add UsdRenderVar support

### DIFF
--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
@@ -65,7 +65,7 @@ HdRprAovRegistry::HdRprAovRegistry() {
 
     m_computedAovDescriptors.resize(kComputedAovsCount);
     m_computedAovDescriptors[kNdcDepth] = HdRprAovDescriptor(kNdcDepth, false, HdFormatFloat32, GfVec4f(std::numeric_limits<float>::infinity()), true);
-    m_computedAovDescriptors[kColorAlpha] = HdRprAovDescriptor(kColorAlpha);
+    m_computedAovDescriptors[kColorAlpha] = HdRprAovDescriptor(kColorAlpha, true, HdFormatFloat32Vec4, GfVec4f(0.0f), true);
 
     auto addAovNameLookup = [this](TfToken const& name, HdRprAovDescriptor const& descriptor) {
         auto status = m_aovNameLookup.emplace(name, AovNameLookupValue(descriptor.id, descriptor.computed));

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
@@ -77,11 +77,15 @@ void HdRprRenderBuffer::_Deallocate() {
 }
 
 void* HdRprRenderBuffer::Map() {
+    if (!m_isValid) return nullptr;
+
     ++m_numMappers;
     return m_mappedBuffer.data();
 }
 
 void HdRprRenderBuffer::Unmap() {
+    if (!m_isValid) return;
+
     // XXX We could consider clearing _mappedBuffer here to free RAM.
     //     For now we assume that Map() will be called frequently so we prefer
     //     to avoid the cost of clearing the buffer over memory savings.
@@ -104,6 +108,10 @@ bool HdRprRenderBuffer::IsConverged() const {
 
 void HdRprRenderBuffer::SetConverged(bool converged) {
     return m_isConverged.store(converged);
+}
+
+void HdRprRenderBuffer::SetStatus(bool isValid) {
+    m_isValid = isValid;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.h
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.h
@@ -55,6 +55,8 @@ public:
 
     void SetConverged(bool converged);
 
+    void SetStatus(bool isValid);
+
 protected:
     void _Deallocate() override;
 
@@ -66,6 +68,8 @@ private:
     std::vector<uint8_t> m_mappedBuffer;
     std::atomic<int> m_numMappers;
     std::atomic<bool> m_isConverged;
+
+    bool m_isValid = true;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -132,6 +132,8 @@ private:
 
     void SetTonemapFilterParams(rif::Filter* filter);
 
+    bool CanComposeAlpha();
+
 private:
     std::shared_ptr<HdRprApiAov> m_retainedRawColor;
     std::shared_ptr<HdRprApiAov> m_retainedOpacity;


### PR DESCRIPTION
UsdRenderVar API allows the user to control the currently rendered AOV set.
The main difference of UsdRenderVar AOV from good old well-known AOV is that it fully defines `HdAovDescriptor`, while "default" AOV takes its descriptor from render delegate.

https://www.youtube.com/watch?v=bgXHaty7jD4