### PR TITLE
Unlock alpha for northstar

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -307,7 +307,7 @@ render_setting_categories = [
                 'ui_name': 'Enable Color Alpha',
                 'defaultValue': True,
                 'houdini': {
-                    'hidewhen': 'renderQuality != 3'
+                    'hidewhen': 'renderQuality < 3'
                 }
             }
         ]

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1353,10 +1353,6 @@ public:
 
         if (preferences.IsDirty(HdRprConfig::DirtyAlpha) || force) {
             m_isAlphaEnabled = preferences.GetEnableAlpha();
-            if (m_rprContextMetadata.pluginType == kPluginNorthStar) {
-                // Disable opacity AOV in Northstar because it's always zeroed
-                m_isAlphaEnabled = false;
-            }
 
             UpdateColorAlpha();
         }


### PR DESCRIPTION
It was previously disabled because Northstar was always returning fully zeroed data despite the scene. It will be fixed in the next RPR SDK release