### PR TITLE
Support SideFX-style UDIM tag

### DIFF
--- a/pxr/imaging/rprUsd/CMakeLists.txt
+++ b/pxr/imaging/rprUsd/CMakeLists.txt
@@ -18,6 +18,7 @@ pxr_library(rprUsd
         MaterialXFormat
 
     PUBLIC_CLASSES
+        util
         contextHelpers
         coreImage
         debugCodes

--- a/pxr/imaging/rprUsd/imageCache.cpp
+++ b/pxr/imaging/rprUsd/imageCache.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 #include "pxr/imaging/rprUsd/imageCache.h"
 #include "pxr/imaging/rprUsd/coreImage.h"
 #include "pxr/imaging/rprUsd/helpers.h"
+#include "pxr/imaging/rprUsd/util.h"
 #include "pxr/base/arch/fileSystem.h"
 #include "pxr/base/tf/diagnostic.h"
 
@@ -48,11 +49,10 @@ bool RprUsdImageCache::InitCacheKey(
 
     if (tiles.size() != 1 || tiles[0].id != 0) {
         // UDIM tiles
-        auto udimStr = std::strstr(path.c_str(), "<UDIM>");
-        if (!udimStr) return false;
-
-        std::string formatString = path;
-        formatString.replace(udimStr - path.c_str(), 6, "%i");
+        std::string formatString;
+        if (!RprUsdGetUDIMFormatString(path, &formatString)) {
+            return false;
+        }
 
         for (auto& tile : tiles) {
             if (!processTile(TfStringPrintf(formatString.c_str(), tile.id))) {

--- a/pxr/imaging/rprUsd/util.cpp
+++ b/pxr/imaging/rprUsd/util.cpp
@@ -1,0 +1,41 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#include "util.h"
+
+#include "pxr/base/tf/staticTokens.h"
+
+#include <cstring>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PRIVATE_TOKENS(
+    RprUsdUDIMTags,
+    ((arnoldTag, "<UDIM>"))
+    ((sidefxTag, "%(UDIM)d"))
+);
+
+bool RprUsdGetUDIMFormatString(std::string const& filepath, std::string* out_formatString) {
+    for (auto& udimTag : RprUsdUDIMTags->allTokens) {
+        auto idx = filepath.rfind(udimTag.GetString());
+        if (idx != std::string::npos) {
+            *out_formatString = filepath;
+            out_formatString->replace(idx, udimTag.size(), "%i");
+            return true;
+        }
+    }
+
+    return false;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/util.h
+++ b/pxr/imaging/rprUsd/util.h
@@ -1,0 +1,27 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#ifndef RPRUSD_UTIL_H
+#define RPRUSD_UTIL_H
+
+#include "pxr/pxr.h"
+
+#include <string>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+bool RprUsdGetUDIMFormatString(std::string const& filepath, std::string* out_formatString);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // RPRUSD_UTIL_H


### PR DESCRIPTION
Before, hdRpr supported only `<UDIM>` tag in UDIM image paths.

These changes add support for SideFX syntax to define UDIM tiles - `%(UDIM)d`.