### PR TITLE
Fix undefined behavior on abort of the first rprContextRender

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1827,9 +1827,23 @@ Don't show this message again?
     }
 
     void AbortRender() {
-        if (m_rprContext) {
-            RPR_ERROR_CHECK(m_rprContext->AbortRender(), "Failed to abort render");
+        if (!m_rprContext) {
+            return;
         }
+
+        // Do not abort the very first sample
+        //
+        // Ideally, aborting the first sample should not be the problem.
+        // We would like to be able to abort it: to reduce response time,
+        // to avoid doing calculations that may be discarded by the following changes.
+        // But in reality, aborting the very first sample may cause crashes or
+        // unwanted behavior when we will call rprContextRender next time.
+        // So until RPR core fixes these issues, we are not aborting the first sample.
+        if (m_numSamples == 0) {
+            return;
+        }
+
+        RPR_ERROR_CHECK(m_rprContext->AbortRender(), "Failed to abort render");
     }
 
     int GetNumCompletedSamples() const {


### PR DESCRIPTION
# Why

Houdini's Hydra makes some unnecessary changes with camera and viewport size on start. In short, something like this happens:

- **HdRenderIndex::SyncAll**
- **HdRenderPass::Execute** (the very first `rprContextRender` call happens here when RPR builds/compiles/syncs all its data)
- **Hydra releases camera and changes viewport size** (here is abort called when we are stoping the render thread) - that is how Houdini's Hydra used, we cannot do anything with it
- **HdRenderPass::Execute** (for some reason next `rprContextRender` is broken and renders nothing, most likely RPR was not thoroughly tested with such usage case - when the very first iteration is aborted)

# How

Ideally, aborting the first sample should not be the problem. We would like to be able to abort it: to reduce response time, to avoid doing calculations that may be discarded by the following changes.

But in reality, aborting the very first sample may cause crashes or unwanted behavior when we will call `rprContextRender` next time.

So until RPR core fixes these issues (RPRNEXT-293), we are not aborting the first sample.
