### PR TITLE
Check cmake build return code

### DIFF
--- a/pxr/imaging/plugin/hdRpr/package/generatePackage.py
+++ b/pxr/imaging/plugin/hdRpr/package/generatePackage.py
@@ -77,7 +77,9 @@ with current_working_directory(build_dir):
             package_name = line[len('-- PACKAGE_FILE_NAME: '):]
             break
 
-    subprocess.call(['cmake', '--build', '.', '--config', args.config, '--target', 'install', '--', format_multi_procs(get_cpu_count())])
+    return_code = subprocess.call(['cmake', '--build', '.', '--config', args.config, '--target', 'install', '--', format_multi_procs(get_cpu_count())])
+    if return_code != 0:
+        exit(return_code)
 
     with tarfile.open('tmpPackage.tar.gz', 'w:gz') as tar:
         tar.add(package_dir, package_name)


### PR DESCRIPTION
Without this check, CIS marks build as successful even in case of failed `cmake --build ...` command. Check [this build](https://rpr.cis.luxoft.com/blue/organizations/jenkins/RadeonProRenderUSDHoudiniPluginAuto/detail/develop/64) for example.