### PR TITLE
Support mesh primvars with `varying` interpolation

### DIFF
--- a/pxr/imaging/plugin/hdRpr/basisCurves.cpp
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.cpp
@@ -122,7 +122,7 @@ void HdRprBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
 
         HdRprGeometrySettings geomSettings = {};
         geomSettings.visibilityMask = kVisibleAll;
-        HdRprParseGeometrySettings(sceneDelegate, id, primvarDescsPerInterpolation.at(HdInterpolationConstant), &geomSettings);
+        HdRprParseGeometrySettings(sceneDelegate, id, primvarDescsPerInterpolation, &geomSettings);
 
         if (m_visibilityMask != geomSettings.visibilityMask) {
             m_visibilityMask = geomSettings.visibilityMask;

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -54,11 +54,15 @@ private:
     template <typename T>
     bool GetPrimvarData(TfToken const& name,
                         HdSceneDelegate* sceneDelegate,
-                        std::map<HdInterpolation, HdPrimvarDescriptorVector> primvarDescsPerInterpolation,
+                        std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation,
                         VtArray<T>& out_data,
                         VtIntArray& out_indices);
 
-    RprUsdMaterial const* GetFallbackMaterial(HdSceneDelegate* sceneDelegate, HdRprApi* rprApi, HdDirtyBits dirtyBits);
+    RprUsdMaterial const* GetFallbackMaterial(
+        HdSceneDelegate* sceneDelegate,
+        HdRprApi* rprApi,
+        HdDirtyBits dirtyBits,
+        std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation);
 
     uint32_t GetVisibilityMask() const;
 

--- a/pxr/imaging/plugin/hdRpr/points.cpp
+++ b/pxr/imaging/plugin/hdRpr/points.cpp
@@ -105,7 +105,7 @@ void HdRprPoints::Sync(
         HdRprGeometrySettings geomSettings;
         geomSettings.visibilityMask = kVisibleAll;
         HdRprFillPrimvarDescsPerInterpolation(sceneDelegate, id, &primvarDescsPerInterpolation);
-        HdRprParseGeometrySettings(sceneDelegate, id, primvarDescsPerInterpolation[HdInterpolationConstant], &geomSettings);
+        HdRprParseGeometrySettings(sceneDelegate, id, primvarDescsPerInterpolation, &geomSettings);
 
         if (m_subdivisionLevel != geomSettings.subdivisionLevel) {
             m_subdivisionLevel = geomSettings.subdivisionLevel;

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
@@ -93,7 +93,17 @@ void HdRprFillPrimvarDescsPerInterpolation(
         HdInterpolationInstance,
     };
     for (auto& interpolation : interpolations) {
-        primvarDescsPerInterpolation->emplace(interpolation, sceneDelegate->GetPrimvarDescriptors(id, interpolation));
+        auto primvarDescs = sceneDelegate->GetPrimvarDescriptors(id, interpolation);
+        if (!primvarDescs.empty()) {
+            primvarDescsPerInterpolation->emplace(interpolation, std::move(primvarDescs));
+        }
+    }
+
+    // If primitive has no primvars,
+    // insert dummy entry so that the next time user calls this function,
+    // it will not rerun sceneDelegate->GetPrimvarDescriptors which is quite costly
+    if (primvarDescsPerInterpolation->empty()) {
+        primvarDescsPerInterpolation->emplace(HdInterpolationCount, HdPrimvarDescriptorVector{});
     }
 }
 

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.h
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.h
@@ -45,6 +45,18 @@ void HdRprParseGeometrySettings(
     HdPrimvarDescriptorVector const& constantPrimvarDescs,
     HdRprGeometrySettings* geomSettings);
 
+inline void HdRprParseGeometrySettings(
+    HdSceneDelegate* sceneDelegate, SdfPath const& id,
+    std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation,
+    HdRprGeometrySettings* geomSettings) {
+    auto constantPrimvarDescIt = primvarDescsPerInterpolation.find(HdInterpolationConstant);
+    if (constantPrimvarDescIt == primvarDescsPerInterpolation.end()) {
+        return;
+    }
+
+    HdRprParseGeometrySettings(sceneDelegate, id, constantPrimvarDescIt->second, geomSettings);
+}
+
 template <typename T>
 bool HdRprGetConstantPrimvar(TfToken const& name, HdSceneDelegate* sceneDelegate, SdfPath const& id, T* out_value) {
     auto value = sceneDelegate->Get(id, name);


### PR DESCRIPTION
RPR does not expose any way to control interpolation of values over faces, we can just interpret `varying` interpolation as `vertex` interpolation as they only differ in how exactly is data interpolated over the face (see [USD docs](https://graphics.pixar.com/usd/docs/api/class_usd_geom_mesh.html)):
* **varying**: One element for each point of the mesh; interpolation of point data is always linear.
* **vertex**: One element for each point of the mesh; interpolation of point data is applied according to the subdivisionScheme attribute.

As a bonus: I optimized a bit primvar descriptors querying - make sure we query them from the scene delegate only when required.

Added test here https://github.com/Radeon-Pro/USDTests/pull/9