### PR TITLE
Fix CIS compilation errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "deps/MaterialX"]
 	path = deps/MaterialX
 	url = https://github.com/materialx/MaterialX
+[submodule "deps/ghc_filesystem"]
+	path = deps/ghc_filesystem
+	url = https://github.com/gulrak/filesystem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,11 @@ if(NOT MaterialX_FOUND)
     add_subdirectory(deps/MaterialX)
 endif()
 
+if(HoudiniUSD_FOUND)
+    # Currently we use it only in activateHoudiniPlugin utility
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/deps/ghc_filesystem)
+endif()
+
 add_subdirectory(pxr/imaging)
 
 install(FILES README.md DESTINATION .)

--- a/pxr/imaging/plugin/hdRpr/package/generatePackage.py
+++ b/pxr/imaging/plugin/hdRpr/package/generatePackage.py
@@ -65,6 +65,9 @@ if platform.system() == 'Windows':
 cmake_configure_cmd += ['..']
 
 build_dir = 'build_generatePackage_tmp_dir'
+if not args.disable_auto_cleanup and os.path.isdir(build_dir):
+    shutil.rmtree(build_dir)
+
 os.makedirs(build_dir, exist_ok=True)
 
 with current_working_directory(build_dir):

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -2001,17 +2001,17 @@ private:
                 }
             };
             std::vector<ListDescriptor> lists = {
-                {RPR_CONTEXT_LIST_CREATED_CAMERAS, "cameras", rprCameraGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_MATERIALNODES, "materialnodes", rprMaterialNodeGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_LIGHTS, "lights", rprLightGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_SHAPES, "shapes", rprShapeGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_HETEROVOLUMES, "heterovolumes", rprHeteroVolumeGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_GRIDS, "grids", rprGridGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_BUFFERS, "buffers", rprBufferGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_IMAGES, "images", rprImageGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_FRAMEBUFFERS, "framebuffers", rprFrameBufferGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_SCENES, "scenes", rprSceneGetInfo},
-                {RPR_CONTEXT_LIST_CREATED_CURVES, "curves", rprCurveGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_CAMERAS, "cameras", (void*)rprCameraGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_MATERIALNODES, "materialnodes", (void*)rprMaterialNodeGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_LIGHTS, "lights", (void*)rprLightGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_SHAPES, "shapes", (void*)rprShapeGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_HETEROVOLUMES, "heterovolumes", (void*)rprHeteroVolumeGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_GRIDS, "grids", (void*)rprGridGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_BUFFERS, "buffers", (void*)rprBufferGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_IMAGES, "images", (void*)rprImageGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_FRAMEBUFFERS, "framebuffers", (void*)rprFrameBufferGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_SCENES, "scenes", (void*)rprSceneGetInfo},
+                {RPR_CONTEXT_LIST_CREATED_CURVES, "curves", (void*)rprCurveGetInfo},
             };
 
             bool hasLeaks = false;

--- a/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
+++ b/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
@@ -24,10 +24,9 @@ houdini_configure_target(RPR_for_Houdini "INSTDIR" "${CMAKE_INSTALL_PREFIX}/houd
 set(HOUDINI_MAJOR_MINOR_VERSION "${Houdini_VERSION_MAJOR}.${Houdini_VERSION_MINOR}")
 configure_file(activateHoudiniPlugin.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/activateHoudiniPlugin.cpp)
 add_executable(activateHoudiniPlugin ${CMAKE_CURRENT_BINARY_DIR}/activateHoudiniPlugin.cpp)
-set_property(TARGET activateHoudiniPlugin PROPERTY CXX_STANDARD 17)
-if(NOT WIN32 AND NOT APPLE)
-    target_link_libraries(activateHoudiniPlugin PRIVATE stdc++fs)
-endif()
+set_property(TARGET activateHoudiniPlugin PROPERTY CXX_STANDARD 11)
+target_link_libraries(activateHoudiniPlugin PRIVATE ghc_filesystem)
+target_compile_definitions(activateHoudiniPlugin PRIVATE GHC_WIN_WSTRING_STRING_TYPE)
 install(
     TARGETS activateHoudiniPlugin
     RUNTIME DESTINATION .)

--- a/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp.in
+++ b/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp.in
@@ -4,19 +4,12 @@
 #include <iostream>
 #include <functional>
 
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+
 #if defined(__linux__)
-
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-
 #include <unistd.h>
 #include <sys/stat.h>
-
-#else
-
-#include <filesystem>
-namespace fs = std::filesystem;
-
 #endif
 
 #if defined(_WIN32) || defined(_WIN64)


### PR DESCRIPTION
* Weird error on Linux
* Use open-source implementation of std::filesystem in activateHoudiniPlugin utility:
      CIS uses High Sierra but std::filesystem implemented only on Catalina+
* Package generation: if auto cleanup is enabled (default), make sure that the temporary build directory is removed to reset CMakeCache