### PR TITLE
Fix rendering of ID AOVs

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -2121,6 +2121,17 @@ private:
             m_isRenderUpdateCallbackEnabled = true;
         }
 
+        // We need it for correct rendering of ID AOVs (e.g. RPR_AOV_OBJECT_ID)
+        // XXX: it takes approximately 32ms due to RPR API indirection,
+        //      replace with rprContextSetAOVindexLookupRange when ready
+        // XXX: only up to 2^16 indices, internal LUT limit
+        for (uint32_t i = 0; i < (1 << 16); ++i) {
+            m_rprContext->SetAOVindexLookup(rpr_int(i),
+                float((i << 0) % 256) / 255.0f,
+                float((i << 8) % 256) / 255.0f,
+                0.0f, 0.0f);
+        }
+
         {
             HdRprConfig* config;
             auto configInstanceLock = HdRprConfig::GetInstance(&config);


### PR DESCRIPTION
Recent RPR core changed default LUT values for ID AOVs.
We need it to be exactly as it was before.

RPR 1.35.1
![rpr_1 35 1](https://user-images.githubusercontent.com/22181845/92620875-d4c22e80-f2cb-11ea-91b0-d8a92403be03.png)

RPR 1.35.5
![rpr_1 35 5](https://user-images.githubusercontent.com/22181845/92620884-d7bd1f00-f2cb-11ea-9384-45b0b06b9d65.png)
