### PR TITLE
Set mesh instance id to prototype mesh id

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -631,8 +631,10 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                                 }
                                 meshInstances.resize(newNumInstances);
                             } else {
+                                int32_t meshId = GetPrimId();
                                 for (int j = meshInstances.size(); j < newNumInstances; ++j) {
                                     meshInstances.push_back(rprApi->CreateMeshInstance(m_rprMeshes[i]));
+                                    rprApi->SetMeshId(meshInstances.back(), meshId);
                                 }
                             }
                         }


### PR DESCRIPTION
These changes enable selection in usdview for mesh instances:
https://youtu.be/8T865NAhzaQ