### PR TITLE
Fix depth AOV

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
@@ -547,10 +547,10 @@ void HdRprApiDepthAov::Update(HdRprApi const* rprApi, rif::Context* rifContext) 
     auto viewProjectionMatrix = rprApi->GetCameraViewMatrix() * rprApi->GetCameraProjectionMatrix();
     m_ndcFilter->SetParam("viewProjMatrix", GfMatrix4f(viewProjectionMatrix.GetTranspose()));
 
+    m_ndcFilter->Update();
     if (m_remapFilter) {
         m_remapFilter->Update();
     }
-    m_ndcFilter->Update();
 }
 
 void HdRprApiDepthAov::Resize(int width, int height, HdFormat format) {
@@ -563,6 +563,15 @@ void HdRprApiDepthAov::Resize(int width, int height, HdFormat format) {
         m_width = width;
         m_height = height;
         m_dirtyBits |= ChangeTracker::DirtySize;
+    }
+}
+
+void HdRprApiDepthAov::Resolve() {
+    if (m_ndcFilter) {
+        m_ndcFilter->Resolve();
+    }
+    if (m_remapFilter) {
+        m_remapFilter->Resolve();
     }
 }
 

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -172,6 +172,7 @@ public:
 
     void Update(HdRprApi const* rprApi, rif::Context* rifContext) override;
     void Resize(int width, int height, HdFormat format) override;
+    void Resolve() override;
 
 private:
     std::unique_ptr<rif::Filter> m_retainedFilter;


### PR DESCRIPTION
Depth AOV always had wrong values: on the very first render pass it was zeroed, after that depth values were always one frame in the past.


Such behavior is hardly noticeable in the IPR but a quite obvious when rendering from cmd-line.
This was caused by the wrong ordering of `rif::Filter::Update` calls.
`rif::Filter::Update` function attaches the filter to the context's command queue.
The remap filter was attached before the NDC filter.