### PR TITLE
Fix batch rendering

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
@@ -12,6 +12,7 @@ limitations under the License.
 ************************************************************************/
 
 #include "renderBuffer.h"
+#include "renderDelegate.h"
 #include "renderParam.h"
 #include "rprApi.h"
 
@@ -19,8 +20,9 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-HdRprRenderBuffer::HdRprRenderBuffer(SdfPath const& id)
+HdRprRenderBuffer::HdRprRenderBuffer(SdfPath const& id, HdRprApi* rprApi)
     : HdRenderBuffer(id)
+    , m_rprApi(rprApi)
     , m_numMappers(0)
     , m_isConverged(false) {
 
@@ -91,6 +93,7 @@ void HdRprRenderBuffer::_Deallocate() {
 }
 
 void* HdRprRenderBuffer::Map() {
+    m_rprApi->Resolve();
 
 #ifdef ENABLE_MULTITHREADED_RENDER_BUFFER
     std::unique_lock<std::mutex> lock(m_mapMutex);

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.h
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.h
@@ -20,9 +20,11 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdRprApi;
+
 class HdRprRenderBuffer final : public HdRenderBuffer {
 public:
-    HdRprRenderBuffer(SdfPath const& id);
+    HdRprRenderBuffer(SdfPath const& id, HdRprApi* rprApi);
     ~HdRprRenderBuffer() override = default;
 
     void Sync(HdSceneDelegate* sceneDelegate,
@@ -70,6 +72,8 @@ private:
     bool m_multiSampled = false;
 
     std::atomic<bool> m_isConverged;
+
+    HdRprApi* m_rprApi;
 
 #ifdef ENABLE_MULTITHREADED_RENDER_BUFFER
     std::mutex m_mapMutex;

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -314,7 +314,7 @@ void HdRprDelegate::DestroySprim(HdSprim* sPrim) {
 HdBprim* HdRprDelegate::CreateBprim(TfToken const& typeId,
                                     SdfPath const& bprimId) {
     if (typeId == HdPrimTypeTokens->renderBuffer) {
-        return new HdRprRenderBuffer(bprimId);
+        return new HdRprRenderBuffer(bprimId, m_rprApi.get());
     }
 #ifdef USE_VOLUME
     else if (typeId == _tokens->openvdbAsset) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -154,6 +154,7 @@ public:
     RenderStats GetRenderStats() const;
 
     void CommitResources();
+    void Resolve();
     void Render(HdRprRenderThread* renderThread);
     void AbortRender();
 


### PR DESCRIPTION
* Fix rendering of singlesampled AOVs (e.g. depth)
* Remove `progressive` render setting and disable progressive render by default when in batch
    Here disabled progressive rendering means that we try to maximize the number of samples rendered per one `rprContextRender` call, e.g. setting `RPR_CONTEXT_ITERATIONS` to `m_maxSamples` when possible. The only benefit we had with progressive rendering in the batch session is that it was giving us the ability to update the current progress that is logged by husk/usdrecord. Now, as we are moving to RPR 2.0, we have `RENDER_UPDATE_CALLBACK` that allows us to maximize `RPR_CONTEXT_ITERATIONS` without losing updates on progress. Though, progress reporting is lost for Tahoe but: a) it should be really easy for the core team to implement `RENDER_UPDATE_CALLBACK` support for Tahoe (`FIR-1701`) and b) Tahoe is going to be a legacy option soon

Here are some measurements:
| Commit        | Kitchen  | Market   | Attic    |
| ------------- |:--------:|:--------:|:--------:|
| develop (63978ee)       | 00:50.80 | 01:44.22 | 10:20.83 |
| PR (adf9793)      | 00:14.85 | 00:45.58 | 04:42.29 |
|               |          |          |          |
| **Improvement** | x3.42 | x2.29 | x2.2 |