### PR TITLE
Fix crash on AOV resize in Houdini and other improvements

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderBuffer.h
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.h
@@ -33,7 +33,7 @@ public:
                   HdFormat format,
                   bool multiSampled) override;
 
-    unsigned int GetWidth() const override { return m_width; }
+    unsigned int GetWidth() const override;
 
     unsigned int GetHeight() const override { return m_height; }
 
@@ -41,7 +41,7 @@ public:
 
     HdFormat GetFormat() const override { return m_format; }
 
-    bool IsMultiSampled() const override { return false; }
+    bool IsMultiSampled() const override { return m_multiSampled; }
 
     void* Map() override;
 
@@ -55,7 +55,14 @@ public:
 
     void SetConverged(bool converged);
 
-    void SetStatus(bool isValid);
+    bool IsMappable() const;
+
+    void MarkAsReadyForMapping();
+
+    unsigned int GetCommitWidth() const { return m_commitWidth; }
+    unsigned int GetCommitHeight() const { return m_commitHeight; }
+    HdFormat GetCommitFormat() const { return m_commitFormat; }
+    void* Commit(bool isValid);
 
 protected:
     void _Deallocate() override;
@@ -64,12 +71,17 @@ private:
     uint32_t m_width = 0u;
     uint32_t m_height = 0u;
     HdFormat m_format = HdFormat::HdFormatInvalid;
+    bool m_multiSampled = false;
 
     std::vector<uint8_t> m_mappedBuffer;
     std::atomic<int> m_numMappers;
     std::atomic<bool> m_isConverged;
 
     bool m_isValid = true;
+    uint32_t m_commitWidth = 0u;
+    uint32_t m_commitHeight = 0u;
+    HdFormat m_commitFormat = HdFormat::HdFormatInvalid;
+    std::atomic<bool> m_isDataAvailable;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -33,6 +33,10 @@ HdRprRenderPass::HdRprRenderPass(HdRenderIndex* index,
 
 }
 
+HdRprRenderPass::~HdRprRenderPass() {
+    m_renderParam->GetRenderThread()->StopRender();
+}
+
 void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState, TfTokenVector const& renderTags) {
     // To avoid potential deadlock:
     //   main thread locks config instance and requests render stop and

--- a/pxr/imaging/plugin/hdRpr/renderPass.h
+++ b/pxr/imaging/plugin/hdRpr/renderPass.h
@@ -28,7 +28,7 @@ public:
                     HdRprimCollection const& collection,
                     HdRprRenderParam* renderParam);
 
-    ~HdRprRenderPass() override = default;
+    ~HdRprRenderPass() override;
 
     bool IsConverged() const override;
 


### PR DESCRIPTION
* Houdini may reallocate (resync) HdRenderBuffer while it's mapped in another
  thread (most likely for blitting to the viewport on the main thread).
  When HdRenderBuffer is reallocated, we resize the underlying std::vector
  and returned previously pointer from HdRenderBuffer::Map is invalidated.

  github.com/sideeffects/HoudiniUsdBridge tells us that Karma's HdRenderBuffer
  returns a pointer to the memory that is reallocated only on the next
  HdRenderPass::_Execute in validateAOVs function.
  So when Houdini makes Hydra reallocate all HdRenderBuffers it has no
  actual effect. These changes in fact postponed until HdRenderPass::_Execute.

  So we do the same - render buffer is reallocated in HdRprRenderPass::_Execute
  via HdRprRenderBuffer::Commit.
* Allow the user to decide whether a particular AOV should be multisampled or not
* Add more supported AOV data formats