### PR TITLE
Force UNIX path-style in Houdini package json

### DIFF
--- a/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp.in
+++ b/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp.in
@@ -230,7 +230,15 @@ int main() {
         packageJson << '{';
         packageJson << '\"' << it->first << '\"';
         packageJson << ':';
+#if defined(_WIN32) || defined(_WIN64)
+        packageJson << '\"';
+        auto path = it->second.string();
+        std::replace(path.begin(), path.end(), '\\', '/');
+        packageJson << path;
+        packageJson << '\"';
+#else
         packageJson << it->second;
+#endif
         packageJson << '}';
         if (std::next(it) != env.end()) {
             packageJson << ',';


### PR DESCRIPTION
Oleksandr Kupriyanchuk, the writer, reported that when json package description uses a Windows-style path, the plugin does not work. It works for me with both UNIX-style and Windows-style paths. So as the changes required to fix it are very straightforward I was not digging it up for the root cause of this behavior.