### PR TITLE
Fix LPE AOV exporting in .rpr

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -2143,18 +2143,22 @@ Don't show this message again?
                 if (TF_VERIFY(aovDesc->id < kNumRprsAovNames) &&
                     TF_VERIFY(!aovDesc->computed)) {
                     auto aovName = kRprsAovNames[aovDesc->id];
-                    auto outputName = TfStringPrintf("%s.%s.exr", basename.c_str(), aovName);
                     if (aovDesc->id >= RPR_AOV_LPE_0 && aovDesc->id <= RPR_AOV_LPE_8) {
                         try {
+                            auto name = outputRb.aovBinding->aovName.GetText();
+                            if (!*name) {
+                                name = aovName;
+                            }
+
                             json lpeAov;
-                            lpeAov["output"] = outputName;
-                            lpeAov["lpe"] = RprUsdGetInfo<std::string>(outputRb.rprAov->GetAovFb()->GetRprObject(), RPR_FRAMEBUFFER_LPE);
+                            lpeAov["output"] = TfStringPrintf("%s.%s.exr", basename.c_str(), name);
+                            lpeAov["lpe"] = RprUsdGetStringInfo(outputRb.rprAov->GetAovFb()->GetRprObject(), RPR_FRAMEBUFFER_LPE);
                             configAovs[aovName] = lpeAov;
                         } catch (RprUsdError& e) {
                             fprintf(stderr, "Failed to export %s AOV: %s\n", aovName, e.what());
                         }
                     } else {
-                        configAovs[aovName] = outputName;
+                        configAovs[aovName] = TfStringPrintf("%s.%s.exr", basename.c_str(), aovName);
                     }
                 }
             }

--- a/pxr/imaging/rprUsd/helpers.h
+++ b/pxr/imaging/rprUsd/helpers.h
@@ -16,6 +16,8 @@ limitations under the License.
 
 #include "pxr/imaging/rprUsd/error.h"
 
+#include <memory>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 template <typename T, typename U, typename R>
@@ -24,6 +26,24 @@ T RprUsdGetInfo(U* object, R info) {
     size_t dummy;
     RPR_ERROR_CHECK_THROW(object->GetInfo(info, sizeof(value), &value, &dummy), "Failed to get object info");
     return value;
+}
+
+template <typename U, typename R>
+std::string RprUsdGetStringInfo(U* object, R info) {
+    size_t size = 0;
+    RPR_ERROR_CHECK_THROW(object->GetInfo(info, sizeof(size), nullptr, &size), "Failed to get object info");
+
+    if (size <= 1) {
+        return {};
+    }
+
+    auto buffer = std::make_unique<char[]>(size);
+    RPR_ERROR_CHECK_THROW(object->GetInfo(info, size, buffer.get(), &size), "Failed to get object info");
+
+    // discard null-terminator
+    --size;
+
+    return std::string(buffer.get(), size);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
* Correctly query RPR_FRAMEBUFFER_LPE property
* Use aovBinding's name for LPE AOV output name

Despite https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/317 is not merged yet, LPE AOV export in .rpr should be valid