### PR TITLE
OCIO support

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -349,6 +349,31 @@ render_setting_categories = [
         ]
     },
     {
+        'name': 'OCIO',
+        'settings': [
+            {
+                'name': 'ocioConfigPath',
+                'ui_name': 'OpenColorIO Config Path',
+                'defaultValue': '',
+                'c_type': 'std::string',
+                'help': 'The file path of the OpenColorIO config file to be used. Overrides any value specified in OCIO environment variable.',
+                'houdini': {
+                    'type': 'file',
+                    'hidewhen': hidewhen_not_northstar
+                }
+            },
+            {
+                'name': 'ocioRenderingColorSpace',
+                'ui_name': 'OpenColorIO Rendering Color Space',
+                'defaultValue': '',
+                'c_type': 'std::string',
+                'houdini': {
+                    'hidewhen': hidewhen_not_northstar
+                }
+            }
+        ]
+    },
+    {
         'name': 'Seed',
         'settings': [
             {
@@ -573,9 +598,12 @@ PXR_NAMESPACE_CLOSE_SCOPE
 
             default_value = setting['defaultValue']
 
-            c_type_str = type(default_value).__name__
-            if c_type_str == 'str':
-                c_type_str = 'TfToken'
+            if 'c_type' in setting:
+                c_type_str = setting['c_type']
+            else:
+                c_type_str = type(default_value).__name__
+                if c_type_str == 'str':
+                    c_type_str = 'TfToken'
             type_str = c_type_str
 
             if 'values' in setting:

--- a/pxr/imaging/plugin/hdRpr/python/houdiniDsGenerator.py
+++ b/pxr/imaging/plugin/hdRpr/python/houdiniDsGenerator.py
@@ -121,7 +121,7 @@ def generate_houdini_ds(install_path, ds_name, settings):
             c_type_str = type(default_value).__name__
             controlled_type = c_type_str
             if c_type_str == 'str':
-                c_type_str = 'token'
+                c_type_str = 'string'
                 controlled_type = 'string'
             render_param_type = c_type_str
             render_param_default = default_value
@@ -132,6 +132,7 @@ def generate_houdini_ds(install_path, ds_name, settings):
                 default_value = next(value for value in setting['values'] if value == default_value)
                 render_param_default = '"{}"'.format(default_value.get_key())
                 render_param_type = 'string'
+                c_type_str = 'token'
 
                 is_values_constant = True
                 for value in setting['values']:
@@ -153,6 +154,9 @@ def generate_houdini_ds(install_path, ds_name, settings):
                         render_param_values += '[ "{}" ]\n'.format(expression)
                     render_param_values += '[ "return menu_values" ]\n'.format(expression)
                     render_param_values += 'language python\n'
+
+            if 'type' in houdini_settings:
+                render_param_type = houdini_settings['type']
 
             render_param_range = None
             if 'minValue' in setting and 'maxValue' in setting and not 'values' in setting:

--- a/pxr/imaging/rprUsd/coreImage.cpp
+++ b/pxr/imaging/rprUsd/coreImage.cpp
@@ -217,6 +217,14 @@ rpr::Status RprUsdCoreImage::SetGamma(float gamma) {
     return ForEachImage([gamma](rpr::Image* image) { return image->SetGamma(gamma); });
 }
 
+rpr::Status RprUsdCoreImage::SetColorSpace(const char* colorSpace) {
+    return ForEachImage([colorSpace](rpr::Image* image) {
+        // TODO: add C++ wrapper
+        auto rprImageHandle = rpr::GetRprObject(image);
+        return rprImageSetOcioColorspace(rprImageHandle, colorSpace);
+    });
+}
+
 rpr::Status RprUsdCoreImage::SetMipmapEnabled(bool enabled) {
     return ForEachImage([enabled](rpr::Image* image) { return image->SetMipmapEnabled(enabled); });
 }

--- a/pxr/imaging/rprUsd/coreImage.h
+++ b/pxr/imaging/rprUsd/coreImage.h
@@ -62,6 +62,9 @@ public:
     rpr::Status SetGamma(float gamma);
 
     RPRUSD_API
+    rpr::Status SetColorSpace(const char* colorSpace);
+
+    RPRUSD_API
     rpr::Status SetMipmapEnabled(bool enabled);
 
     RPRUSD_API

--- a/pxr/imaging/rprUsd/materialNodes/houdiniPrincipledShaderNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/houdiniPrincipledShaderNode.cpp
@@ -488,7 +488,7 @@ VtValue RprUsd_HoudiniPrincipledNode::GetTextureOutput(
     };
 
     if (forceLinearSpace) {
-        uvTextureParams.emplace(RprUsd_UsdUVTextureTokens->colorSpace, RprUsd_UsdUVTextureTokens->linear);
+        uvTextureParams.emplace(RprUsd_UsdUVTextureTokens->sourceColorSpace, RprUsd_UsdUVTextureTokens->srgblinear);
     }
 
     if (scale != 1.0f) {

--- a/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
@@ -235,10 +235,20 @@ RprUsd_UsdUVTexture::RprUsd_UsdUVTexture(
         throw RprUsd_NodeError("UsdUVTexture: empty file path");
     }
 
-    auto colorSpaceIt = hydraParameters.find(RprUsd_UsdUVTextureTokens->colorSpace);
-    if (colorSpaceIt != hydraParameters.end() &&
-        colorSpaceIt->second.Get<TfToken>() == RprUsd_UsdUVTextureTokens->linear) {
-        textureCommit.forceLinearSpace = true;
+    auto colorSpaceIt = hydraParameters.find(RprUsd_UsdUVTextureTokens->sourceColorSpace);
+    if (colorSpaceIt != hydraParameters.end()) {
+        if (colorSpaceIt->second.IsHolding<TfToken>()) {
+            auto& colorSpace = colorSpaceIt->second.UncheckedGet<TfToken>();
+            if (colorSpace == RprUsd_UsdUVTextureTokens->sRGB) {
+                textureCommit.colorspace = "srgb";
+            } else if (colorSpace == RprUsd_UsdUVTextureTokens->raw) {
+                textureCommit.colorspace = "raw";
+            } else if (colorSpace == RprUsd_UsdUVTextureTokens->colorSpaceAuto) {
+                textureCommit.colorspace = "";
+            } else {
+                textureCommit.colorspace = colorSpace.GetString();
+            }
+        }
     }
 
     rpr::ImageWrapType wrapS = {};

--- a/pxr/imaging/rprUsd/materialNodes/usdNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.h
@@ -57,8 +57,11 @@ private:
     (clamp) \
     (mirror) \
     (repeat) \
-    (colorSpace) \
-    (linear) \
+    (sourceColorSpace) \
+    (sRGB) \
+    (srgblinear) \
+    (raw) \
+    ((colorSpaceAuto, "auto")) \
     (st) \
     (rgba) \
     (rgb) \

--- a/pxr/imaging/rprUsd/materialRegistry.cpp
+++ b/pxr/imaging/rprUsd/materialRegistry.cpp
@@ -129,6 +129,11 @@ void RprUsdMaterialRegistry::CommitResources(
     std::string formatString;
     for (size_t i = 0; i < m_textureCommits.size(); ++i) {
         auto& commit = m_textureCommits[i];
+        if (auto rprImage = imageCache->GetImage(commit.filepath, commit.colorspace, commit.wrapType)) {
+            commit.setTextureCallback(rprImage);
+            continue;
+        }
+
         auto& commitTexIndices = uniqueTextureIndicesPerCommit[i];
 
         if (RprUsdGetUDIMFormatString(commit.filepath, &formatString)) {
@@ -178,7 +183,7 @@ void RprUsdMaterialRegistry::CommitResources(
         }
 
         auto& commit = m_textureCommits[i];
-        auto coreImage = imageCache->GetImage(commit.filepath, commit.forceLinearSpace, commit.wrapType, tiles);
+        auto coreImage = imageCache->GetImage(commit.filepath, commit.colorspace, commit.wrapType, tiles);
         commit.setTextureCallback(coreImage);
     }
 

--- a/pxr/imaging/rprUsd/materialRegistry.h
+++ b/pxr/imaging/rprUsd/materialRegistry.h
@@ -77,7 +77,7 @@ public:
 
     struct TextureCommit {
         std::string filepath;
-        bool forceLinearSpace;
+        std::string colorspace;
         rpr::ImageWrapType wrapType;
 
         std::function<void(std::shared_ptr<RprUsdCoreImage> const&)> setTextureCallback;


### PR DESCRIPTION
This is mainly the support of OCIO on the Hydra level.

In Houdini, you can specify the OCIO config path and the rendering color space. But convenient handling of the color space of the textures is yet to be implemented, most likely it will be implemented as a separate VOP node.

Though it's possible to control texture color space through `sourceColorSpace` parameter on UsdUVTexture with help of the `Edit Properties` node. But that's not obvious for anyone who doesn't know about it.