### PR TITLE
Add `UV Primvar Name` parameter to MaterialX node

### DIFF
--- a/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.cpp
+++ b/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.cpp
@@ -172,6 +172,8 @@ static PRM_Default* NewPRMDefault(
         choiceList = LEAKED(new PRM_ChoiceList(choiceListType, items->data()));
 
         return defau1t;
+    } else if (input->GetType() == RprUsdMaterialNodeElement::kString) {
+        return LEAKED(new PRM_Default(0, LEAKED(strdup(valueStr))));
     }
 
     if (values.size() == i_nb_defaults) {
@@ -605,7 +607,7 @@ void VOP_MaterialX::opChanged(OP_EventType reason, void* data) {
 
 bool VOP_MaterialX::runCreateScript() {
     int numParms = getNumParms();
-    for (int i = 1; i < numParms; ++i) {
+    for (int i = getParmIndex("stPrimvarName") + 1; i < numParms; ++i) {
         getParm(i).setVisibleState(false);
     }
 

--- a/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
@@ -85,6 +85,15 @@ public:
             return SetRenderElement(RPRMtlxLoader::kOutputSurface, value);
         } else if (inputId == RprUsdRprMaterialXNodeTokens->displacementElement) {
             return SetRenderElement(RPRMtlxLoader::kOutputDisplacement, value);
+        } else if (inputId == RprUsdRprMaterialXNodeTokens->stPrimvarName) {
+            if (value.IsHolding<std::string>()) {
+                m_ctx->uvPrimvarName = TfToken(value.UncheckedGet<std::string>());
+                return true;
+            } else {
+                TF_RUNTIME_ERROR("[%s] file input should be of string type: %s",
+                    RprUsdRprMaterialXNodeTokens->rpr_materialx_node.GetText(), value.GetTypeName().c_str());
+                return false;
+            }
         }
 
         TF_RUNTIME_ERROR("[%s] Unknown input %s",
@@ -318,6 +327,12 @@ public:
         fileInput.name = RprUsdRprMaterialXNodeTokens->file.GetText();
         fileInput.uiName = "File";
         nodeInfo.inputs.push_back(fileInput);
+
+        RprUsd_RprNodeInput stPrimvarNameInput(RprUsdMaterialNodeElement::kString);
+        stPrimvarNameInput.name = RprUsdRprMaterialXNodeTokens->stPrimvarName.GetText();
+        stPrimvarNameInput.uiName = "UV Primvar Name";
+        stPrimvarNameInput.valueString = "st";
+        nodeInfo.inputs.push_back(stPrimvarNameInput);
 
         RprUsd_RprNodeInput surfaceElementInput(RprUsdMaterialNodeElement::kString);
         surfaceElementInput.name = RprUsdRprMaterialXNodeTokens->surfaceElement.GetText();

--- a/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.h
@@ -23,7 +23,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     (rpr_materialx_node) \
     (file) \
     (surfaceElement) \
-    (displacementElement)
+    (displacementElement) \
+    (stPrimvarName)
 
 TF_DECLARE_PUBLIC_TOKENS(RprUsdRprMaterialXNodeTokens, RPRUSD_API, RPRUSD_RPR_MATERIALX_NODE_TOKENS);
 


### PR DESCRIPTION
While we don't have a generic primvar reader node, we support only UV primvar.
And for non-materialX material graphs, we can specify the name of the UV primvar via the UsdPrimvarReader node.
These changes add an ability to select UV primvar when we use materialX node.

It was required for the materialX scene from David. Here are before and after:
![chessBroken](https://user-images.githubusercontent.com/22181845/98677554-d2309380-2365-11eb-8d18-e857fb602e29.png)
![chessPanorama](https://user-images.githubusercontent.com/22181845/98677557-d361c080-2365-11eb-9416-a44baae39127.png)
