### PR TITLE
Fix Ubuntu 20.04 build

### DIFF
--- a/cmake/modules/FindHoudiniUSD.cmake
+++ b/cmake/modules/FindHoudiniUSD.cmake
@@ -147,11 +147,6 @@ if(HoudiniUSD_FOUND AND NOT TARGET hd)
             set_target_properties(${targetName} PROPERTIES
                 IMPORTED_IMPLIB "${Houdini_USD_IMPLIB_DIR}/libpxr_${targetName}.lib")
         endif()
-        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-            # Houdini builds with the old ABI. We need to match.
-            target_compile_definitions(${targetName}
-                INTERFACE "_GLIBCXX_USE_CXX11_ABI=0")
-        endif()
         if(WIN32)
             # Shut up compiler about warnings from USD.
             target_compile_options(${targetName} INTERFACE
@@ -161,6 +156,10 @@ if(HoudiniUSD_FOUND AND NOT TARGET hd)
                 INTERFACE "${HOUDINI_ROOT}/custom/houdini/dsolib")
         endif()
     endforeach()
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        # Houdini builds with the old ABI. We need to match.
+        add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+    endif()
     # Add python to tf, usdImagingGL targets.
     target_include_directories(tf INTERFACE ${Houdini_Python_INCLUDE_DIR})
     target_link_libraries(tf INTERFACE ${Houdini_Python_LIB})

--- a/cmake/modules/FindRif.cmake
+++ b/cmake/modules/FindRif.cmake
@@ -18,10 +18,8 @@ elseif(WIN32)
     SET_RIF_VARIABLES(Windows)
 elseif(RPR_SDK_PLATFORM STREQUAL "ubuntu18.04")
     SET_RIF_VARIABLES(Ubuntu18)
-elseif(RPR_SDK_PLATFORM STREQUAL "centos7")
-    SET_RIF_VARIABLES(CentOS7)
 else()
-    message(FATAL_ERROR "Unknown platform: ${RPR_SDK_PLATFORM}")
+    SET_RIF_VARIABLES(CentOS7)
 endif()
 
 find_library(RIF_LIBRARY

--- a/cmake/modules/FindRpr.cmake
+++ b/cmake/modules/FindRpr.cmake
@@ -25,10 +25,8 @@ elseif(WIN32)
     endif()
 elseif(RPR_SDK_PLATFORM STREQUAL "ubuntu18.04")
     SET_RPR_VARIABLES(binUbuntu18)
-elseif(RPR_SDK_PLATFORM STREQUAL "centos7")
-    SET_RPR_VARIABLES(binCentOS7)
 else()
-    message(FATAL_ERROR "Unknown platform: ${RPR_SDK_PLATFORM}")
+    SET_RPR_VARIABLES(binCentOS7)
 endif()
 
 find_library(RPR_LIBRARY

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -4,10 +4,6 @@
 if(NOT MaterialX_FOUND)
     # If MaterialX was not explicitly provided, use the one from a submodule
     set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-    if(HoudiniUSD_FOUND AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        # Houdini builds with the old ABI. We need to match.
-        set(EXTERNAL_COMPILE_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=0")
-    endif()
     set(MATERIALX_PYTHON_LTO OFF)
     set(MATERIALX_INSTALL_PYTHON OFF)
     set(MATERIALX_BUILD_RENDER OFF)


### PR DESCRIPTION
There are few main changes:
* Instead of setting per-target `_GLIBCXX_USE_CXX11_ABI=0` definition, set it globally to make sure that all targets use it
* Fallback to CentOS7 libraries when the current Linux platform is unknown:
    - CentOS7 libs links against older GLIBCXX than Ubuntu18 and so it's more universal