### PR TITLE
Expose contour rendering mode

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -360,6 +360,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         }
     }
 
+    bool isIgnoreContourDirty = false;
     bool isVisibilityMaskDirty = false;
     if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
         HdRprGeometrySettings geomSettings = {};
@@ -375,6 +376,11 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         if (m_visibilityMask != geomSettings.visibilityMask) {
             m_visibilityMask = geomSettings.visibilityMask;
             isVisibilityMaskDirty = true;
+        }
+
+        if (m_ignoreContour != geomSettings.ignoreContour) {
+            m_ignoreContour = geomSettings.ignoreContour;
+            isIgnoreContourDirty = true;
         }
     }
 
@@ -693,6 +699,12 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                         rprApi->SetMeshVisibility(rprMesh, visibilityMask);
                     }
                 }
+            }
+        }
+
+        if (newMesh || isIgnoreContourDirty) {
+            for (auto& rprMesh : m_rprMeshes) {
+                rprApi->SetMeshIgnoreContour(rprMesh, m_ignoreContour);
             }
         }
 

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -97,6 +97,7 @@ private:
     int m_refineLevel = 0;
 
     uint32_t m_visibilityMask;
+    bool m_ignoreContour;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
@@ -18,6 +18,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_PRIVATE_TOKENS(HdRprGeometryPrimvarTokens,
     ((subdivisionLevel, "rpr:subdivisionLevel"))
+    ((ignoreContour, "rpr:ignoreContour"))
     ((visibilityPrimary, "rpr:visibilityPrimary"))
     ((visibilityShadow, "rpr:visibilityShadow"))
     ((visibilityReflection, "rpr:visibilityReflection"))
@@ -54,6 +55,8 @@ void HdRprParseGeometrySettings(
             if (HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->subdivisionLevel, sceneDelegate, id, &subdivisionLevel)) {
                 geomSettings->subdivisionLevel = std::max(0, std::min(subdivisionLevel, 7));
             }
+        } else if (desc.name == HdRprGeometryPrimvarTokens->ignoreContour) {
+            HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->ignoreContour, sceneDelegate, id, &geomSettings->ignoreContour);
         } else if (desc.name == HdRprGeometryPrimvarTokens->visibilityPrimary) {
             setVisibilityFlag(HdRprGeometryPrimvarTokens->visibilityPrimary, kVisiblePrimary);
         } else if (desc.name == HdRprGeometryPrimvarTokens->visibilityShadow) {

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.h
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.h
@@ -38,6 +38,7 @@ bool HdRprIsValidPrimvarSize(
 struct HdRprGeometrySettings {
     uint32_t visibilityMask = 0;
     int subdivisionLevel = 0;
+    bool ignoreContour = false;
 };
 
 void HdRprParseGeometrySettings(

--- a/pxr/imaging/plugin/hdRpr/python/commonSettings.py
+++ b/pxr/imaging/plugin/hdRpr/python/commonSettings.py
@@ -75,10 +75,10 @@ visibility_flag_settings = [
 ]
 
 class SettingValue(object):
-    def __init__(self, key, ui_name=None, disabled_platform=None):
+    def __init__(self, key, ui_name=None, enable_py_condition=None):
         self._key = key
         self._ui_name = ui_name
-        self.disabled_platform = disabled_platform
+        self.enable_py_condition = enable_py_condition
 
     def __eq__(self, obj):
         return self._key == obj

--- a/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
@@ -24,8 +24,18 @@ geometry_settings = [
                 'defaultValue': 0,
                 'minValue': 0,
                 'maxValue': 7
+            },
+            {
+                'name': 'primvars:rpr:ignoreContour',
+                'ui_name': 'Ignore Contour',
+                'defaultValue': False,
+                'help': 'Whether to extract contour for a mesh or not'
+            },
+            {
+                'folder': 'Visibility Settings',
+                'settings': visibility_flag_settings
             }
-        ] + visibility_flag_settings
+        ]
     }
 ]
 

--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -49,7 +49,8 @@ def hidewhen_hybrid(render_setting_categories):
 def hidewhen_not_northstar(render_setting_categories):
     return hidewhen_render_quality('!=', 'Northstar', render_setting_categories)
 
-HYBRID_DISABLED_PLATFORM = 'Darwin'
+HYBRID_IS_AVAILABLE_PY_CONDITION = 'platform.system() != "Darwin"'
+NORTHSTAR_ENABLED_PY_CONDITION = 'hou.pwd().parm("renderQuality").evalAsString() == "Northstar"'
 
 render_setting_categories = [
     {
@@ -61,9 +62,9 @@ render_setting_categories = [
                 'help': 'Render restart might be required',
                 'defaultValue': 'Northstar',
                 'values': [
-                    SettingValue('Low', disabled_platform=HYBRID_DISABLED_PLATFORM),
-                    SettingValue('Medium', disabled_platform=HYBRID_DISABLED_PLATFORM),
-                    SettingValue('High', disabled_platform=HYBRID_DISABLED_PLATFORM),
+                    SettingValue('Low', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
+                    SettingValue('Medium', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
+                    SettingValue('High', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
                     SettingValue('Full', 'Full (Legacy)'),
                     SettingValue('Northstar', 'Full')
                 ]
@@ -86,7 +87,8 @@ render_setting_categories = [
                     SettingValue('Normal'),
                     SettingValue('Texcoord'),
                     SettingValue('Ambient Occlusion'),
-                    SettingValue('Diffuse')
+                    SettingValue('Diffuse'),
+                    SettingValue('Contour', enable_py_condition=NORTHSTAR_ENABLED_PY_CONDITION),
                 ]
             },
             {
@@ -98,6 +100,111 @@ render_setting_categories = [
                 'houdini': {
                     'hidewhen': 'renderMode != "AmbientOcclusion"'
                 }
+            },
+            {
+                'folder': 'Contour Settings',
+                'houdini': {
+                    'hidewhen': 'renderMode != "Contour"'
+                },
+                'settings': [
+                    {
+                        'name': 'contourAntialiasing',
+                        'ui_name': 'Antialiasing',
+                        'defaultValue': 1.0,
+                        'minValue': 0.0,
+                        'maxValue': 1.0,
+                        'houdini': {
+                            'hidewhen': 'renderMode != "Contour"'
+                        }
+                    },
+                    {
+                        'name': 'contourUseNormal',
+                        'ui_name': 'Use Normal',
+                        'defaultValue': True,
+                        'help': 'Whether to use geometry normals for edge detection or not',
+                        'houdini': {
+                            'hidewhen': 'renderMode != "Contour"'
+                        }
+                    },
+                    {
+                        'name': 'contourLinewidthNormal',
+                        'ui_name': 'Linewidth Normal',
+                        'defaultValue': 1.0,
+                        'minValue': 0.0,
+                        'maxValue': 100.0,
+                        'help': 'Linewidth of edges detected via normals',
+                        'houdini': {
+                            'hidewhen': ['renderMode != "Contour"', 'contourUseNormal == 0']
+                        }
+                    },
+                    {
+                        'name': 'contourNormalThreshold',
+                        'ui_name': 'Normal Threshold',
+                        'defaultValue': 45.0,
+                        'minValue': 0.0,
+                        'maxValue': 180.0,
+                        'houdini': {
+                            'hidewhen': ['renderMode != "Contour"', 'contourUseNormal == 0']
+                        }
+                    },
+                    {
+                        'name': 'contourUsePrimId',
+                        'ui_name': 'Use Primitive Id',
+                        'defaultValue': True,
+                        'help': 'Whether to use primitive Id for edge detection or not',
+                        'houdini': {
+                            'hidewhen': 'renderMode != "Contour"'
+                        }
+                    },
+                    {
+                        'name': 'contourLinewidthPrimId',
+                        'ui_name': 'Linewidth Primitive Id',
+                        'defaultValue': 1.0,
+                        'minValue': 0.0,
+                        'maxValue': 100.0,
+                        'help': 'Linewidth of edges detected via primitive Id',
+                        'houdini': {
+                            'hidewhen': ['renderMode != "Contour"', 'contourUsePrimId == 0']
+                        }
+                    },
+                    {
+                        'name': 'contourUseMaterialId',
+                        'ui_name': 'Use Material Id',
+                        'defaultValue': True,
+                        'help': 'Whether to use material Id for edge detection or not',
+                        'houdini': {
+                            'hidewhen': 'renderMode != "Contour"'
+                        }
+                    },
+                    {
+                        'name': 'contourLinewidthMaterialId',
+                        'ui_name': 'Linewidth Material Id',
+                        'defaultValue': 1.0,
+                        'minValue': 0.0,
+                        'maxValue': 100.0,
+                        'help': 'Linewidth of edges detected via material Id',
+                        'houdini': {
+                            'hidewhen': ['renderMode != "Contour"', 'contourUseMaterialId == 0']
+                        }
+                    },
+                    {
+                        'name': 'contourDebug',
+                        'ui_name': 'Debug',
+                        'defaultValue': False,
+                        'help': 'Whether to show colored outlines according to used features or not.\\n'
+                                'Colors legend:\\n'
+                                ' * red - primitive Id\\n'
+                                ' * green - material Id\\n'
+                                ' * blue - normal\\n'
+                                ' * yellow - primitive Id + material Id\\n'
+                                ' * magenta - primitive Id + normal\\n'
+                                ' * cyan - material Id + normal\\n'
+                                ' * black - all',
+                        'houdini': {
+                            'hidewhen': 'renderMode != "Contour"'
+                        }
+                    }
+                ]
             }
         ],
         'houdini': {
@@ -602,29 +709,29 @@ PXR_NAMESPACE_CLOSE_SCOPE
 
     dirty_flags_offset = 1
 
-    rs_public_token_definitions = ''
-    rs_tokens_declaration = '#define HDRPR_RENDER_SETTINGS_TOKENS \\\n'
-    rs_category_dirty_flags = ''
-    rs_get_set_method_declarations = ''
-    rs_variables_declaration = ''
-    rs_mapped_values_enum = ''
-    rs_range_definitions = ''
-    rs_list_initialization = ''
-    rs_sync = ''
-    rs_get_set_method_definitions = ''
-    rs_set_default_values = ''
-    rs_validate_values = ''
+    rs_public_token_definitions = []
+    rs_tokens_declaration = ['#define HDRPR_RENDER_SETTINGS_TOKENS \\\n']
+    rs_category_dirty_flags = []
+    rs_get_set_method_declarations = []
+    rs_variables_declaration = []
+    rs_mapped_values_enum = []
+    rs_range_definitions = []
+    rs_list_initialization = []
+    rs_sync = []
+    rs_get_set_method_definitions = []
+    rs_set_default_values = []
+    rs_validate_values = []
     for category in render_setting_categories:
         disabled_category = False
 
         category_name = category['name']
         dirty_flag = 'Dirty{}'.format(category_name)
-        rs_category_dirty_flags += '        {} = 1 << {},\n'.format(dirty_flag, dirty_flags_offset)
+        rs_category_dirty_flags.append('        {} = 1 << {},\n'.format(dirty_flag, dirty_flags_offset))
         dirty_flags_offset += 1
 
-        for setting in category['settings']:
+        def process_setting(setting):
             name = setting['name']
-            rs_tokens_declaration += '    ({}) \\\n'.format(name)
+            rs_tokens_declaration.append('    ({}) \\\n'.format(name))
 
             name_title = camel_case_capitalize(name)
 
@@ -642,62 +749,62 @@ PXR_NAMESPACE_CLOSE_SCOPE
                 value_tokens_list_name = '__{}Tokens'.format(name_title)
                 value_tokens_name = 'HdRpr{}Tokens'.format(name_title)
 
-                rs_mapped_values_enum += '#define ' + value_tokens_list_name
+                rs_mapped_values_enum.append('#define ' + value_tokens_list_name)
                 for value in setting['values']:
-                    rs_mapped_values_enum += ' ({})'.format(value.get_key())
-                rs_mapped_values_enum += '\n'
+                    rs_mapped_values_enum.append(' ({})'.format(value.get_key()))
+                rs_mapped_values_enum.append('\n')
 
-                rs_mapped_values_enum += 'TF_DECLARE_PUBLIC_TOKENS({}, {});\n\n'.format(value_tokens_name, value_tokens_list_name)
-                rs_public_token_definitions += 'TF_DEFINE_PUBLIC_TOKENS({}, {});\n'.format(value_tokens_name, value_tokens_list_name)
+                rs_mapped_values_enum.append('TF_DECLARE_PUBLIC_TOKENS({}, {});\n\n'.format(value_tokens_name, value_tokens_list_name))
+                rs_public_token_definitions.append('TF_DEFINE_PUBLIC_TOKENS({}, {});\n'.format(value_tokens_name, value_tokens_list_name))
 
                 type_str = 'TfToken'
                 c_type_str = type_str
                 default_value = next(value for value in setting['values'] if value == default_value)
 
-            rs_get_set_method_declarations += '    void Set{}({} {});\n'.format(name_title, c_type_str, name)
-            rs_get_set_method_declarations += '    {} const& Get{}() const {{ return m_prefData.{}; }}\n\n'.format(type_str, name_title, name)
+            rs_get_set_method_declarations.append('    void Set{}({} {});\n'.format(name_title, c_type_str, name))
+            rs_get_set_method_declarations.append('    {} const& Get{}() const {{ return m_prefData.{}; }}\n\n'.format(type_str, name_title, name))
 
-            rs_variables_declaration += '        {} {};\n'.format(type_str, name)
+            rs_variables_declaration.append('        {} {};\n'.format(type_str, name))
 
             if isinstance(default_value, bool):
-                rs_sync += '        Set{name_title}(getBoolSetting(HdRprRenderSettingsTokens->{name}, k{name_title}Default));\n'.format(name_title=name_title, name=name)
+                rs_sync.append('        Set{name_title}(getBoolSetting(HdRprRenderSettingsTokens->{name}, k{name_title}Default));\n'.format(name_title=name_title, name=name))
             else:
-                rs_sync += '        Set{name_title}(renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->{name}, k{name_title}Default));\n'.format(name_title=name_title, name=name)
+                rs_sync.append('        Set{name_title}(renderDelegate->GetRenderSetting(HdRprRenderSettingsTokens->{name}, k{name_title}Default));\n'.format(name_title=name_title, name=name))
 
             if 'values' in setting:
-                rs_range_definitions += '#define k{name_title}Default {value_tokens_name}->{value}'.format(name_title=name_title, value_tokens_name=value_tokens_name, value=default_value.get_key())
+                rs_range_definitions.append('#define k{name_title}Default {value_tokens_name}->{value}'.format(name_title=name_title, value_tokens_name=value_tokens_name, value=default_value.get_key()))
             else:
                 value_str = str(default_value)
                 if isinstance(default_value, bool):
                     value_str = value_str.lower()
-                rs_range_definitions += 'const {type} k{name_title}Default = {type}({value});\n'.format(type=type_str, name_title=name_title, value=value_str)
+                rs_range_definitions.append('const {type} k{name_title}Default = {type}({value});\n'.format(type=type_str, name_title=name_title, value=value_str))
 
             set_validation = ''
             if 'minValue' in setting or 'maxValue' in setting:
-                rs_validate_values += '           '
+                rs_validate_values.append('           ')
             if 'minValue' in setting:
-                rs_range_definitions += 'const {type} k{name_title}Min = {type}({value});\n'.format(type=type_str, name_title=name_title, value=setting['minValue'])
+                rs_range_definitions.append('const {type} k{name_title}Min = {type}({value});\n'.format(type=type_str, name_title=name_title, value=setting['minValue']))
                 set_validation += '    if ({name} < k{name_title}Min) {{ return; }}\n'.format(name=name, name_title=name_title)
-                rs_validate_values += '&& {name} < k{name_title}Min'.format(name=name, name_title=name_title)
+                rs_validate_values.append('&& {name} < k{name_title}Min'.format(name=name, name_title=name_title))
             if 'maxValue' in setting:
-                rs_range_definitions += 'const {type} k{name_title}Max = {type}({value});\n'.format(type=type_str, name_title=name_title, value=setting['maxValue'])
+                rs_range_definitions.append('const {type} k{name_title}Max = {type}({value});\n'.format(type=type_str, name_title=name_title, value=setting['maxValue']))
                 set_validation += '    if ({name} > k{name_title}Max) {{ return; }}\n'.format(name=name, name_title=name_title)
-                rs_validate_values += '&& {name} > k{name_title}Max'.format(name=name, name_title=name_title)
+                rs_validate_values.append('&& {name} > k{name_title}Max'.format(name=name, name_title=name_title))
             if 'minValue' in setting or 'maxValue' in setting:
-                rs_validate_values += '\n'
-            rs_range_definitions += '\n'
+                rs_validate_values.append('\n')
+            rs_range_definitions.append('\n')
 
             if 'values' in setting:
                 value_range = value_tokens_name + '->allTokens'
                 set_validation += '    if (std::find({range}.begin(), {range}.end(), {name}) == {range}.end()) return;\n'.format(range=value_range, name=name)
 
             if 'ui_name' in setting:
-                rs_list_initialization += '    settingDescs.push_back({{"{}", HdRprRenderSettingsTokens->{}, VtValue(k{}Default)}});\n'.format(setting['ui_name'], name, name_title)
+                rs_list_initialization.append('    settingDescs.push_back({{"{}", HdRprRenderSettingsTokens->{}, VtValue(k{}Default)}});\n'.format(setting['ui_name'], name, name_title))
 
             if disabled_category:
-                rs_get_set_method_definitions += 'void HdRprConfig::Set{name_title}({c_type} {name}) {{ /* Platform no-op */ }}'.format(name_title=name_title, c_type=c_type_str, name=name)
+                rs_get_set_method_definitions.append('void HdRprConfig::Set{name_title}({c_type} {name}) {{ /* Platform no-op */ }}'.format(name_title=name_title, c_type=c_type_str, name=name))
             else:
-                rs_get_set_method_definitions += (
+                rs_get_set_method_definitions.append((
 '''
 void HdRprConfig::Set{name_title}({c_type} {name}) {{
 {set_validation}
@@ -706,31 +813,38 @@ void HdRprConfig::Set{name_title}({c_type} {name}) {{
         m_dirtyFlags |= {dirty_flag};
     }}
 }}
-''').format(name_title=name_title, c_type=c_type_str, name=name, dirty_flag=dirty_flag, set_validation=set_validation)
+''').format(name_title=name_title, c_type=c_type_str, name=name, dirty_flag=dirty_flag, set_validation=set_validation))
 
-            rs_set_default_values += '    {name} = k{name_title}Default;\n'.format(name=name, name_title=name_title)
+            rs_set_default_values.append('    {name} = k{name_title}Default;\n'.format(name=name, name_title=name_title))
 
-    rs_tokens_declaration += '\nTF_DECLARE_PUBLIC_TOKENS(HdRprRenderSettingsTokens, HDRPR_RENDER_SETTINGS_TOKENS);\n'
+        for setting in category['settings']:
+            if 'folder' in setting:
+                for sub_setting in setting['settings']:
+                    process_setting(sub_setting)
+            else:
+                process_setting(setting)
+
+    rs_tokens_declaration.append('\nTF_DECLARE_PUBLIC_TOKENS(HdRprRenderSettingsTokens, HDRPR_RENDER_SETTINGS_TOKENS);\n')
 
     header_dst_path = os.path.join(install_path, 'config.h')
     header_file = open(header_dst_path, 'w')
     header_file.write(header_template.format(
-        rs_tokens_declaration=rs_tokens_declaration,
-        rs_category_dirty_flags=rs_category_dirty_flags,
-        rs_get_set_method_declarations=rs_get_set_method_declarations,
-        rs_variables_declaration=rs_variables_declaration,
-        rs_mapped_values_enum=rs_mapped_values_enum))
+        rs_tokens_declaration=''.join(rs_tokens_declaration),
+        rs_category_dirty_flags=''.join(rs_category_dirty_flags),
+        rs_get_set_method_declarations=''.join(rs_get_set_method_declarations),
+        rs_variables_declaration=''.join(rs_variables_declaration),
+        rs_mapped_values_enum=''.join(rs_mapped_values_enum)))
 
     cpp_dst_path = os.path.join(install_path, 'config.cpp')
     cpp_file = open(cpp_dst_path, 'w')
     cpp_file.write(cpp_template.format(
-        rs_public_token_definitions=rs_public_token_definitions,
-        rs_range_definitions=rs_range_definitions,
-        rs_list_initialization=rs_list_initialization,
-        rs_sync=rs_sync,
-        rs_get_set_method_definitions=rs_get_set_method_definitions,
-        rs_set_default_values=rs_set_default_values,
-        rs_validate_values=rs_validate_values))
+        rs_public_token_definitions=''.join(rs_public_token_definitions),
+        rs_range_definitions=''.join(rs_range_definitions),
+        rs_list_initialization=''.join(rs_list_initialization),
+        rs_sync=''.join(rs_sync),
+        rs_get_set_method_definitions=''.join(rs_get_set_method_definitions),
+        rs_set_default_values=''.join(rs_set_default_values),
+        rs_validate_values=''.join(rs_validate_values)))
 
     if generate_ds_files:
         generate_houdini_ds(install_path, 'Global', render_setting_categories)

--- a/pxr/imaging/plugin/hdRpr/python/houdiniDsGenerator.py
+++ b/pxr/imaging/plugin/hdRpr/python/houdiniDsGenerator.py
@@ -44,143 +44,170 @@ parm {{
 '''
 )
 
-def generate_houdini_ds(install_path, ds_name, settings):
-    import hou
+def _get_valid_houdini_param_name(name):
+    if all(c.isalnum() or c == '_' for c in name):
+        return name
+    else:
+        import hou
+        return hou.encode(name)
 
+def _get_houdini_hidewhen_string(conditions, settings):
+    houdini_hidewhen_conditions = []
+    for condition in conditions:
+        if condition and callable(condition):
+            condition = condition(settings)
+        if condition:
+            if isinstance(condition, str):
+                houdini_hidewhen_conditions.append(condition)
+            elif isinstance(condition, list):
+                houdini_hidewhen_conditions.extend(condition);
+
+    houdini_hidewhen = ''
+    if houdini_hidewhen_conditions:
+        houdini_hidewhen += 'hidewhen "'
+        for condition in houdini_hidewhen_conditions:
+            houdini_hidewhen += '{{ {} }} '.format(condition)
+        houdini_hidewhen += '"'
+    return houdini_hidewhen
+
+def _generate_ds_setting(setting, spare_category, global_hidewhen, settings):
+    if not 'ui_name' in setting:
+        return ''
+
+    houdini_settings = setting.get('houdini', {})
+    houdini_hidewhen = _get_houdini_hidewhen_string((houdini_settings.get('hidewhen'), global_hidewhen), settings)
+
+    def CreateHoudiniParam(name, label, htype, default, values=[], tags=[], disablewhen_conditions=[], size=None, valid_range=None, help_msg=None):
+        param = 'parm {\n'
+        param += '    name "{}"\n'.format(_get_valid_houdini_param_name(name))
+        param += '    label "{}"\n'.format(label)
+        param += '    type {}\n'.format(htype)
+        if size: param += '    size {}\n'.format(size)
+        param += '    default {{ {} }}\n'.format(default)
+        for tag in tags:
+            param += '    parmtag {{ {} }}\n'.format(tag)
+        if values:
+            param += '    menu {\n'
+            param += '        ' + values + '\n'
+            param += '    }\n'
+        if houdini_hidewhen:
+            param += '    {}\n'.format(houdini_hidewhen)
+        if disablewhen_conditions:
+            param += '    disablewhen "'
+            for condition in disablewhen_conditions:
+                param += '{{ {} }} '.format(condition)
+            param += '"\n'
+        if valid_range:                    
+            param += '    range {{ {}! {} }}\n'.format(valid_range[0], valid_range[1])
+        if help_msg:
+            param += '    help "{}"\n'.format(help_msg)
+        param += '}\n'
+
+        return param
+
+    name = setting['name']
+
+    control_param_name = _get_valid_houdini_param_name(name + '_control')
+
+    render_param_values = None
+    default_value = setting['defaultValue']
+    c_type_str = type(default_value).__name__
+    controlled_type = c_type_str
+    if c_type_str == 'str':
+        c_type_str = 'string'
+        controlled_type = 'string'
+    render_param_type = c_type_str
+    render_param_default = default_value
+    if isinstance(default_value, bool):
+        render_param_type = 'toggle'
+        render_param_default = 1 if default_value else 0
+    elif 'values' in setting:
+        default_value = next(value for value in setting['values'] if value == default_value)
+        render_param_default = '"{}"'.format(default_value.get_key())
+        render_param_type = 'string'
+        c_type_str = 'token'
+
+        is_values_constant = True
+        for value in setting['values']:
+            if value.enable_py_condition:
+                is_values_constant = False
+                break
+
+        render_param_values = ''
+        if is_values_constant:
+            for value in setting['values']:
+                render_param_values += '"{}" "{}"\n'.format(value.get_key(), value.get_ui_name())
+        else:
+            render_param_values += '[ "import platform" ]\n'
+            render_param_values += '[ "menu_values = []" ]\n'
+            for value in setting['values']:
+                expression = 'menu_values.extend([\\"{}\\", \\"{}\\"])'.format(value.get_key(), value.get_ui_name())
+
+                if value.enable_py_condition:
+                    enable_condition = value.enable_py_condition.replace('"', '\\"')
+                    expression = 'if {}: {}'.format(enable_condition, expression)
+
+                render_param_values += '[ "{}" ]\n'.format(expression)
+            render_param_values += '[ "return menu_values" ]\n'.format(expression)
+            render_param_values += 'language python\n'
+
+    if 'type' in houdini_settings:
+        render_param_type = houdini_settings['type']
+
+    render_param_range = None
+    if 'minValue' in setting and 'maxValue' in setting and not 'values' in setting:
+        render_param_range = (setting['minValue'], setting['maxValue'])
+
+    houdini_param_label = setting['ui_name']
+
+    houdini_params = control_param_template.format(
+        name=control_param_name,
+        label=houdini_param_label,
+        controlled_type=controlled_type,
+        hidewhen=houdini_hidewhen)
+    houdini_params += CreateHoudiniParam(name, houdini_param_label, render_param_type, render_param_default,
+        values=render_param_values,
+        tags=[
+            '"spare_category" "{}"'.format(spare_category),
+            '"uiscope" "viewport"',
+            '"usdvaluetype" "{}"'.format(c_type_str)
+        ] + houdini_settings.get('custom_tags', []),
+        disablewhen_conditions=[
+            control_param_name + ' == block',
+            control_param_name + ' == none',
+        ],
+        size=1,
+        valid_range=render_param_range,
+        help_msg=setting.get('help', None))
+
+    return houdini_params
+
+def generate_houdini_ds(install_path, ds_name, settings):
     houdini_params = ''
 
     for category in settings:
-        disabled_category = False
-
         category_name = category['name']
+        category_hidewhen = None
+        if 'houdini' in category:
+            category_hidewhen = category['houdini'].get('hidewhen')
 
         for setting in category['settings']:
-            if not 'ui_name' in setting:
-                continue
+            if 'folder' in setting:
+                houdini_params += 'groupcollapsible {\n'
+                houdini_params += '  name "{}"\n'.format(setting['folder'].replace(' ', ''))
+                houdini_params += '  label "{}"\n'.format(setting['folder'])
 
-            houdini_hidewhen_conditions = []
-            def add_hidewhen_condition(condition):
-                if condition and callable(condition):
-                    condition = condition(settings)
-                if condition:
-                    if isinstance(condition, str):
-                        houdini_hidewhen_conditions.append(condition)
-                    elif isinstance(condition, list):
-                        houdini_hidewhen_conditions.extend(condition);
-
-            if 'houdini' in category:
-                add_hidewhen_condition(category['houdini'].get('hidewhen'))
-
-            houdini_settings = setting.get('houdini', {})
-            houdini_param_label = setting['ui_name']
-            add_hidewhen_condition(houdini_settings.get('hidewhen'))
-
-            houdini_hidewhen = ''
-            if houdini_hidewhen_conditions:
-                houdini_hidewhen += 'hidewhen "'
-                for condition in houdini_hidewhen_conditions:
-                    houdini_hidewhen += '{{ {} }} '.format(condition)
-                houdini_hidewhen += '"'
-
-            def CreateHoudiniParam(name, label, htype, default, values=[], tags=[], disablewhen_conditions=[], size=None, valid_range=None, help_msg=None):
-                param = 'parm {\n'
-                param += '    name "{}"\n'.format(hou.encode(name))
-                param += '    label "{}"\n'.format(label)
-                param += '    type {}\n'.format(htype)
-                if size: param += '    size {}\n'.format(size)
-                param += '    default {{ {} }}\n'.format(default)
-                for tag in tags:
-                    param += '    parmtag {{ {} }}\n'.format(tag)
-                if values:
-                    param += '    menu {\n'
-                    param += '        ' + values + '\n'
-                    param += '    }\n'
-                if disabled_category:
-                    param += '    invisible\n'
+                houdini_settings = setting.get('houdini', {})
+                houdini_hidewhen = _get_houdini_hidewhen_string((houdini_settings.get('hidewhen'), category_hidewhen), settings)
                 if houdini_hidewhen:
-                    param += '    {}\n'.format(houdini_hidewhen)
-                if disablewhen_conditions:
-                    param += '    disablewhen "'
-                    for condition in disablewhen_conditions:
-                        param += '{{ {} }} '.format(condition)
-                    param += '"\n'
-                if valid_range:                    
-                    param += '    range {{ {}! {} }}\n'.format(valid_range[0], valid_range[1])
-                if help_msg:
-                    param += '    help "{}"\n'.format(help_msg)
-                param += '}\n'
+                    houdini_params += '  {}\n'.format(houdini_hidewhen)
 
-                return param
 
-            name = setting['name']
-
-            control_param_name = hou.encode(name + '_control')
-
-            render_param_values = None
-            default_value = setting['defaultValue']
-            c_type_str = type(default_value).__name__
-            controlled_type = c_type_str
-            if c_type_str == 'str':
-                c_type_str = 'string'
-                controlled_type = 'string'
-            render_param_type = c_type_str
-            render_param_default = default_value
-            if isinstance(default_value, bool):
-                render_param_type = 'toggle'
-                render_param_default = 1 if default_value else 0
-            elif 'values' in setting:
-                default_value = next(value for value in setting['values'] if value == default_value)
-                render_param_default = '"{}"'.format(default_value.get_key())
-                render_param_type = 'string'
-                c_type_str = 'token'
-
-                is_values_constant = True
-                for value in setting['values']:
-                    if value.disabled_platform:
-                        is_values_constant = False
-                        break
-
-                render_param_values = ''
-                if is_values_constant:
-                    for value in setting['values']:
-                        render_param_values += '"{}" "{}"\n'.format(value.get_key(), value.get_ui_name())
-                else:
-                    render_param_values += '[ "import platform" ]\n'
-                    render_param_values += '[ "menu_values = []" ]\n'
-                    for value in setting['values']:
-                        expression = 'menu_values.extend([\\"{}\\", \\"{}\\"])'.format(value.get_key(), value.get_ui_name())
-                        if value.disabled_platform:
-                            expression = 'if platform.system() != \\"{}\\": {}'.format(value.disabled_platform, expression)
-                        render_param_values += '[ "{}" ]\n'.format(expression)
-                    render_param_values += '[ "return menu_values" ]\n'.format(expression)
-                    render_param_values += 'language python\n'
-
-            if 'type' in houdini_settings:
-                render_param_type = houdini_settings['type']
-
-            render_param_range = None
-            if 'minValue' in setting and 'maxValue' in setting and not 'values' in setting:
-                render_param_range = (setting['minValue'], setting['maxValue'])
-
-            houdini_params += control_param_template.format(
-                name=control_param_name,
-                label=houdini_param_label,
-                controlled_type=controlled_type,
-                hidewhen=houdini_hidewhen)
-            houdini_params += CreateHoudiniParam(name, houdini_param_label, render_param_type, render_param_default,
-                values=render_param_values,
-                tags=[
-                    '"spare_category" "{}"'.format(category_name),
-                    '"uiscope" "viewport"',
-                    '"usdvaluetype" "{}"'.format(c_type_str)
-                ] + houdini_settings.get('custom_tags', []),
-                disablewhen_conditions=[
-                    control_param_name + ' == block',
-                    control_param_name + ' == none',
-                ],
-                size=1,
-                valid_range=render_param_range,
-                help_msg=setting.get('help', None))
+                for sub_setting in setting['settings']:
+                    houdini_params += _generate_ds_setting(sub_setting, category_name, category_hidewhen, settings)
+                houdini_params += '}\n'
+            else:
+                houdini_params += _generate_ds_setting(setting, category_name, category_hidewhen, settings)
 
     if houdini_params:
         houdini_ds_dst_path = os.path.join(install_path, 'HdRprPlugin_{}.ds'.format(ds_name))

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -2572,6 +2572,24 @@ Don't show this message again?
             }
             config["aovs"] = configAovs;
 
+            if (m_contourAovs) {
+                HdRprConfig* rprConfig;
+                auto configInstanceLock = HdRprConfig::GetInstance(&rprConfig);
+
+                json contour;
+                contour["object.id"] = int(rprConfig->GetContourUsePrimId());
+                contour["material.id"] = int(rprConfig->GetContourUseMaterialId());
+                contour["normal"] = int(rprConfig->GetContourUseNormal());
+                contour["threshold.normal"] = rprConfig->GetContourNormalThreshold();
+                contour["linewidth.objid"] = rprConfig->GetContourLinewidthPrimId();
+                contour["linewidth.matid"] = rprConfig->GetContourLinewidthMaterialId();
+                contour["linewidth.normal"] = rprConfig->GetContourLinewidthNormal();
+                contour["antialiasing"] = rprConfig->GetContourAntialiasing();
+                contour["debug"] = rprConfig->GetContourDebug();
+
+                config["contour"] = contour;
+            }
+
             configFile << config;
         } catch (json::exception& e) {
             fprintf(stderr, "Failed to fill config file: %s\n", configFilename.c_str());

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -276,6 +276,13 @@ public:
         try {
             InitRpr();
             InitRif();
+
+            {
+                HdRprConfig* config;
+                auto configInstanceLock = HdRprConfig::GetInstance(&config);
+                UpdateSettings(*config, true);
+            }
+
             InitScene();
             InitCamera();
             InitAovs();
@@ -550,6 +557,16 @@ public:
     void SetMeshId(rpr::Shape* mesh, uint32_t id) {
         LockGuard rprLock(m_rprContext->GetMutex());
         RPR_ERROR_CHECK(mesh->SetObjectID(id), "Failed to set mesh id");
+    }
+
+    void SetMeshIgnoreContour(rpr::Shape* mesh, bool ignoreContour) {
+        if (m_rprContextMetadata.pluginType == kPluginNorthstar) {
+            LockGuard rprLock(m_rprContext->GetMutex());
+            // TODO: update C++ wrapper
+            RPR_ERROR_CHECK(rprShapeSetContourIgnore(rpr::GetRprObject(mesh), ignoreContour), "Failed to set shape contour ignore");
+
+            m_dirtyFlags |= ChangeTracker::DirtyScene;
+        }
     }
 
     rpr::Curve* CreateCurve(VtVec3fArray const& points, VtIntArray const& indices, VtFloatArray const& radiuses, VtVec2fArray const& uvs, VtIntArray const& segmentPerCurve) {
@@ -1461,6 +1478,68 @@ public:
         return it->second;
     }
 
+    void UpdateRenderMode(HdRprConfig const& preferences, bool force) {
+        if (!preferences.IsDirty(HdRprConfig::DirtyRenderMode) && !force) {
+            return;
+        }
+        m_dirtyFlags |= ChangeTracker::DirtyScene;
+
+        auto& renderMode = preferences.GetRenderMode();
+
+        if (m_rprContextMetadata.pluginType == kPluginNorthstar) {
+            if (renderMode == HdRprRenderModeTokens->Contour) {
+                if (!m_contourAovs) {
+                    m_contourAovs = std::make_unique<ContourRenderModeAovs>();
+                }
+
+                RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_CONTOUR_DEBUG_ENABLED, preferences.GetContourDebug()), "Failed to set contour debug");
+                RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_CONTOUR_ANTIALIASING, preferences.GetContourAntialiasing()), "Failed to set contour antialiasing");
+
+                if (preferences.GetContourUseNormal()) {
+                    if (!m_contourAovs->normal) {
+                        m_contourAovs->normal = CreateAov(HdAovTokens->normal);
+                    }
+
+                    RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_CONTOUR_LINEWIDTH_NORMAL, preferences.GetContourLinewidthNormal()), "Failed to set contour normal linewidth");
+                    RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_CONTOUR_NORMAL_THRESHOLD, preferences.GetContourNormalThreshold()), "Failed to set contour normal threshold");
+                } else {
+                    m_contourAovs->normal = nullptr;
+                }
+
+                if (preferences.GetContourUsePrimId()) {
+                    if (!m_contourAovs->primId) {
+                        m_contourAovs->primId = CreateAov(HdAovTokens->primId);
+                    }
+
+                    RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_CONTOUR_LINEWIDTH_OBJECTID, preferences.GetContourLinewidthPrimId()), "Failed to set contour primId linewidth");
+                } else {
+                    m_contourAovs->primId = nullptr;
+                }
+
+                if (preferences.GetContourUseMaterialId()) {
+                    if (!m_contourAovs->materialId) {
+                        m_contourAovs->materialId = CreateAov(HdRprAovTokens->materialId);
+                    }
+
+                    RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_CONTOUR_LINEWIDTH_OBJECTID, preferences.GetContourLinewidthPrimId()), "Failed to set contour primId linewidth");
+                } else {
+                    m_contourAovs->materialId = nullptr;
+                }
+
+                RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_GPUINTEGRATOR, "gpucontour"), "Failed to set gpuintegrator");
+                return;
+            } else {
+                m_contourAovs = nullptr;
+                RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_GPUINTEGRATOR, "gpusimple"), "Failed to set gpuintegrator");
+            }
+        }
+
+        RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_RENDER_MODE, GetRprRenderMode(renderMode)), "Failed to set render mode");
+        if (renderMode == HdRprRenderModeTokens->AmbientOcclusion) {
+            RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_AO_RAY_LENGTH, preferences.GetAoRadius()), "Failed to set ambient occlusion radius");
+        }
+    }
+
     void UpdateTahoeSettings(HdRprConfig const& preferences, bool force) {
         if (preferences.IsDirty(HdRprConfig::DirtyAdaptiveSampling) || force) {
             m_varianceThreshold = preferences.GetVarianceThreshold();
@@ -1470,7 +1549,7 @@ public:
 
             if (IsAdaptiveSamplingEnabled()) {
                 if (!m_internalAovs.count(HdRprAovTokens->variance)) {
-                    if (auto aov = CreateAov(HdRprAovTokens->variance, m_viewportSize[0], m_viewportSize[1])) {
+                    if (auto aov = CreateAov(HdRprAovTokens->variance)) {
                         m_internalAovs.emplace(HdRprAovTokens->variance, std::move(aov));
                     } else {
                         TF_RUNTIME_ERROR("Failed to create variance AOV, adaptive sampling will not work");
@@ -1519,14 +1598,7 @@ public:
             }
         }
 
-        if (preferences.IsDirty(HdRprConfig::DirtyRenderMode) || force) {
-            auto& renderMode = preferences.GetRenderMode();
-            RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_RENDER_MODE, GetRprRenderMode(renderMode)), "Failed to set render mode");
-            if (renderMode == HdRprRenderModeTokens->AmbientOcclusion) {
-                RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_AO_RAY_LENGTH, preferences.GetAoRadius()), "Failed to set ambient occlusion radius");
-            }
-            m_dirtyFlags |= ChangeTracker::DirtyScene;
-        }
+        UpdateRenderMode(preferences, force);
 
         if (preferences.IsDirty(HdRprConfig::DirtySeed) || force) {
             m_isUniformSeed = preferences.GetUniformSeed();
@@ -2234,8 +2306,7 @@ public:
     }
 
     void RenderFrame(HdRprRenderThread* renderThread) {
-        if (!m_rprContext ||
-            m_aovRegistry.empty()) {
+        if (!m_rprContext) {
             return;
         }
 
@@ -2252,6 +2323,10 @@ public:
 
         if (!m_rprSceneExportPath.empty()) {
             return ExportRpr();
+        }
+
+        if (m_aovRegistry.empty()) {
+            return;
         }
 
         if (m_state == kStateRender) {
@@ -2755,12 +2830,6 @@ private:
             }
         }
 
-        {
-            HdRprConfig* config;
-            auto configInstanceLock = HdRprConfig::GetInstance(&config);
-            UpdateSettings(*config, true);
-        }
-
         m_imageCache.reset(new RprUsdImageCache(m_rprContext.get()));
 
         m_isAbortingEnabled.store(false);
@@ -3060,7 +3129,7 @@ private:
         return aov;
     }
 
-    std::shared_ptr<HdRprApiAov> CreateAov(TfToken const& aovName, int width = 0, int height = 0, HdFormat format = HdFormatFloat32Vec4) {
+    std::shared_ptr<HdRprApiAov> CreateAov(TfToken const& aovName, int width, int height, HdFormat format) {
         if (!m_rprContext ||
             width < 0 || height < 0 ||
             format == HdFormatInvalid || HdDataSizeOfFormat(format) == 0) {
@@ -3083,6 +3152,9 @@ private:
 
         try {
             if (!aov) {
+                HdRprApiAov* newAov = nullptr;
+                std::function<void(HdRprApiAov*)> aovCustomDestructor;
+
                 if (aovName == HdAovTokens->color) {
                     auto rawColorAov = GetAov(HdRprAovTokens->rawColor, width, height, HdFormatFloat32Vec4);
                     if (!rawColorAov) {
@@ -3090,12 +3162,12 @@ private:
                         return nullptr;
                     }
 
-                    auto colorAov = std::make_shared<HdRprApiColorAov>(format, std::move(rawColorAov), m_rprContext.get(), m_rprContextMetadata);
-                    UpdateColorAlpha(colorAov.get());
+                    auto colorAov = new HdRprApiColorAov(format, std::move(rawColorAov), m_rprContext.get(), m_rprContextMetadata);
+                    UpdateColorAlpha(colorAov);
 
-                    aov = colorAov;
+                    newAov = colorAov;
                 } else if (aovName == HdAovTokens->normal) {
-                    aov = std::make_shared<HdRprApiNormalAov>(width, height, format, m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
+                    newAov = new HdRprApiNormalAov(width, height, format, m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
                 } else if (aovName == HdAovTokens->depth) {
                     auto worldCoordinateAov = GetAov(HdRprAovTokens->worldCoordinate, width, height, HdFormatFloat32Vec4);
                     if (!worldCoordinateAov) {
@@ -3103,24 +3175,36 @@ private:
                         return nullptr;
                     }
 
-                    aov = std::make_shared<HdRprApiDepthAov>(format, std::move(worldCoordinateAov), m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
+                    newAov = new HdRprApiDepthAov(format, std::move(worldCoordinateAov), m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
                 } else if (TfStringStartsWith(aovName.GetString(), "lpe")) {
-                    auto aovPtr = new HdRprApiAov(rpr::Aov(aovDesc.id), width, height, format, m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
-                    aov = std::shared_ptr<HdRprApiAov>(aovPtr, [this](HdRprApiAov* aov) {
+                    newAov = new HdRprApiAov(rpr::Aov(aovDesc.id), width, height, format, m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
+                    aovCustomDestructor = [this](HdRprApiAov* aov) {
                         // Each LPE AOV reserves RPR's LPE AOV id (RPR_AOV_LPE_0, ...)
                         // As soon as LPE AOV is released we want to return reserved id to the pool
                         m_lpeAovPool.push_back(GetRprLpeAovName(aov->GetAovFb()->GetAovId()));
+                        m_dirtyFlags |= ChangeTracker::DirtyAOVRegistry;
                         delete aov;
-                    });
+                    };
                 } else {
                     if (!aovDesc.computed) {
-                        aov = std::make_shared<HdRprApiAov>(rpr::Aov(aovDesc.id), width, height, format, m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
+                        newAov = new HdRprApiAov(rpr::Aov(aovDesc.id), width, height, format, m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
                     } else {
                         TF_CODING_ERROR("Failed to create %s AOV: unprocessed computed AOV", aovName.GetText());
-                        return nullptr;
                     }
                 }
 
+                if (!newAov) {
+                    return nullptr;
+                }
+
+                if (!aovCustomDestructor) {
+                    aovCustomDestructor = [this](HdRprApiAov* aov) {
+                        m_dirtyFlags |= ChangeTracker::DirtyAOVRegistry;
+                        delete aov;
+                    };
+                }
+
+                aov = std::shared_ptr<HdRprApiAov>(newAov, std::move(aovCustomDestructor));
                 m_aovRegistry[aovName] = aov;
                 m_dirtyFlags |= ChangeTracker::DirtyAOVRegistry;
             } else {
@@ -3131,6 +3215,17 @@ private:
         }
 
         return aov;
+    }
+
+    std::shared_ptr<HdRprApiAov> CreateAov(TfToken const& aovName) {
+        auto iter = m_aovRegistry.find(aovName);
+        if (iter != m_aovRegistry.end()) {
+            if (auto aov = iter->second.lock()) {
+                return aov;
+            }
+        }
+
+        return CreateAov(aovName, m_viewportSize[0], m_viewportSize[1], HdFormatFloat32Vec4);
     }
 
     HdRprApiColorAov* GetColorAov() {
@@ -3334,6 +3429,13 @@ private:
     std::map<TfToken, std::shared_ptr<HdRprApiAov>> m_internalAovs;
     HdRenderPassAovBindingVector m_aovBindings;
     std::vector<TfToken> m_lpeAovPool;
+
+    struct ContourRenderModeAovs {
+        std::shared_ptr<HdRprApiAov> normal;
+        std::shared_ptr<HdRprApiAov> primId;
+        std::shared_ptr<HdRprApiAov> materialId;
+    };
+    std::unique_ptr<ContourRenderModeAovs> m_contourAovs;
 
     struct OutputRenderBuffer {
         HdRenderPassAovBinding const* aovBinding;
@@ -3620,6 +3722,10 @@ void HdRprApi::SetMeshVisibility(rpr::Shape* mesh, uint32_t visibilityMask) {
 
 void HdRprApi::SetMeshId(rpr::Shape* mesh, uint32_t id) {
     m_impl->SetMeshId(mesh, id);
+}
+
+void HdRprApi::SetMeshIgnoreContour(rpr::Shape* mesh, bool ignoreContour) {
+    m_impl->SetMeshIgnoreContour(mesh, ignoreContour);
 }
 
 void HdRprApi::SetCurveMaterial(rpr::Curve* curve, RprUsdMaterial const* material) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -121,6 +121,7 @@ public:
     void SetMeshMaterial(rpr::Shape* mesh, RprUsdMaterial const* material, bool displacementEnabled);
     void SetMeshVisibility(rpr::Shape* mesh, uint32_t visibilityMask);
     void SetMeshId(rpr::Shape* mesh, uint32_t id);
+    void SetMeshIgnoreContour(rpr::Shape* mesh, bool ignoreContour);
     void Release(rpr::Shape* shape);
 
     rpr::Curve* CreateCurve(VtVec3fArray const& points, VtIntArray const& indices, VtFloatArray const& radiuses, VtVec2fArray const& uvs, VtIntArray const& segmentPerCurve);


### PR DESCRIPTION
### PURPOSE
Support contour rendering with Northstar.

### EFFECT OF CHANGE
Added new render mode - **Contour**, and its render settings (linewidth of a particular edge detection feature and others). Added new geometry setting - **Ignore Contour**, that controls whether contour should be extracted for a mesh or not.

* Global Illumination mode
![image](https://user-images.githubusercontent.com/22181845/98935452-38dfb980-24ec-11eb-86e3-9dc8f1193565.png)

* Contour mode
![image](https://user-images.githubusercontent.com/22181845/98935475-409f5e00-24ec-11eb-8700-0c1007aa8757.png)


### TECHNICAL STEPS
* Refactored code generation scripts to extend its functionality:
    * More generic way to define dynamic UI menus.
         * It allows us to dynamically add Contour render mode entry depending on the current render quality:
         ![image](https://user-images.githubusercontent.com/22181845/98934258-78a5a180-24ea-11eb-8c9e-186819cf0966.png) ![image](https://user-images.githubusercontent.com/22181845/98934860-5f512500-24eb-11eb-93be-962324e01752.png)

    * Add collapsible folders.
         * It allows us to group contour settings into one collapsible folder
            ![image](https://user-images.githubusercontent.com/22181845/98934540-ebaf1800-24ea-11eb-977d-071f1f7b036c.png) ![image](https://user-images.githubusercontent.com/22181845/98935041-9b848580-24eb-11eb-8240-b6ae1bd69b7e.png)

* Improved HdRprApiAov creation. Now we set the DirtyAOVRegistry flag when HdRprApiAov is released. Previously it was not required because HdRprApiAov could have been released only when we set the DirtyAOVRegistry flag because of a new bound AOVs. Now AOVs can be created/released when the contour render mode is enabled/disabled (see UpdateRenderMode in rprApi.cpp).
