### PR TITLE
Fix motion blur exposure

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1627,7 +1627,11 @@ public:
             m_hdCamera->GetShutterClose(&shutterClose);
         }
         double exposure = std::max(shutterClose - shutterOpen, 0.0);
-        RPR_ERROR_CHECK(m_camera->SetExposure(exposure), "Failed to set camera exposure");
+
+        // Hydra always sample transforms in such a way that
+        // starting transform matches shutterOpen and
+        // ending transform matches shutterClose
+        RPR_ERROR_CHECK(m_camera->SetExposure(1.0f), "Failed to set camera exposure");
 
         auto setCameraLookAt = [this](GfMatrix4d const& viewMatrix, GfMatrix4d const& inverseViewMatrix) {
             auto& iwvm = inverseViewMatrix;


### PR DESCRIPTION
### PURPOSE
To fix the motion blur difference between RPR and Karma.

* RPR
![northstar](https://user-images.githubusercontent.com/22181845/99081813-086f4c80-25cc-11eb-8a55-427e8ac0c309.png)

* Karma
![karma](https://user-images.githubusercontent.com/22181845/99081827-0c02d380-25cc-11eb-8230-1fddc0143faf.png)

### EFFECT OF CHANGE
Correct motion blur camera exposure.

* RPR fixed
![northstar_fixed](https://user-images.githubusercontent.com/22181845/99081857-145b0e80-25cc-11eb-9b7c-2ed9792a01d3.png)

### TECHNICAL STEPS
Hardcode rpr_camera exposure to 1. Hydra always sample transforms in such a way that starting transform matches the camera's `shutterOpen` and ending transform matches the camera's `shutterClose`.
