### PR TITLE
Improve ID AOVs

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -2761,8 +2761,8 @@ private:
                 //   * convert float4 texture to uchar4 using RIF
                 //   * reinterpret uchar4 data as int32_t (works on little-endian CPU only)
                 m_rprContext->SetAOVindexLookup(rpr_int(i),
-                    float((i >> 0) & 0xFF) / 255.0f,
-                    float((i >> 8) & 0xFF) / 255.0f,
+                    float(((i + 1) >> 0) & 0xFF) / 255.0f,
+                    float(((i + 1) >> 8) & 0xFF) / 255.0f,
                     0.0f, 0.0f);
             }
         }

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
@@ -131,7 +131,7 @@ bool HdRprApiAov::GetData(void* dstBuffer, size_t dstBufferSize) {
             // That's why we interpret the value as int and filling the alpha channel with zeros
             auto primIdData = reinterpret_cast<int*>(dstBuffer);
             for (size_t i = 0; i < dstBufferSize / sizeof(int); ++i) {
-                primIdData[i] &= 0xFFFFFF;
+                primIdData[i] = (primIdData[i] & 0xFFFFFF) - 1;
             }
         }
 


### PR DESCRIPTION
### PURPOSE
Previously, we were not able to distinguish 0 id pixels and void pixels (where no geometry present).
By offsetting the AOV index lookup by one we can achieve that void pixels will have -1 id.

### EFFECT OF CHANGE
Empty pixels now have a valid value (-1). It allows distinguishing empty pixels and pixels that contain id==0. For usdview, it enables deselection by pressing on empty space and avoids selection of the first object when selecting empty space.

### TECHNICAL STEPS
Do offset each AOV index lookup by one, thus allowing us to get id 1 for the first element and 0 for empty space. By offsetting it back, we get 0 id for the first element and -1 for empty space.