### PR TITLE
Convert textures into a format required by the material graph

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -50,7 +50,7 @@ add_library(cpprpr STATIC
     ${RPR_CPP_WRAPPER_LOCATION}/RadeonProRenderCpp.cpp
     ${RPR_CPP_WRAPPER_LOCATION}/tinyxml2.cpp)
 set_target_properties(cpprpr PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_include_directories(cpprpr PUBLIC ${RPR_CPP_WRAPPER_LOCATION} ${RPRMTLXLOADER_LOCATION})
+target_include_directories(cpprpr PUBLIC ${RPRMTLXLOADER_LOCATION} ${RPR_CPP_WRAPPER_LOCATION})
 target_link_libraries(cpprpr PUBLIC rpr MaterialXCore MaterialXFormat)
 target_compile_definitions(cpprpr PUBLIC
     RPR_CPPWRAPER_DISABLE_MUTEXLOCK

--- a/deps/rprMtlxLoader/rprMtlxLoader.cpp
+++ b/deps/rprMtlxLoader/rprMtlxLoader.cpp
@@ -367,6 +367,7 @@ struct RprMappedNode : public RprNode {
 struct RprImageNode : public RprMappedNode {
     // TODO: support frame ranges
 
+    std::string type;
     std::string file;
     std::string layer;
     mx::ValuePtr defaultValue;
@@ -379,7 +380,7 @@ struct RprImageNode : public RprMappedNode {
     // TODO: can we support this in RPR?
     //std::string filtertype;
 
-    RprImageNode(LoaderContext* context);
+    RprImageNode(std::string const& type, LoaderContext* context);
     ~RprImageNode() override = default;
 
     rpr_status SetInput(mx::Element* inputElement, std::string const& value, std::string const& valueType, LoaderContext* context) override;
@@ -824,7 +825,7 @@ Node::Ptr Node::Create(mx::Node* mtlxNode, LoaderContext* context) {
         };
         rprNodeMapping = &s_sqrtMapping;
     } else if (mtlxNode->getCategory() == "image") {
-        return std::make_unique<RprImageNode>(context);
+        return std::make_unique<RprImageNode>(mtlxNode->getType(), context);
     } else if (mtlxNode->getCategory() == "swizzle") {
         // TODO: implement healthy man swizzle
 
@@ -1371,7 +1372,7 @@ rpr_status RprMappedNode::SetInput(mx::Element* inputElement, std::string const&
     return RprNode::SetInput(inputIt->second, valueString, valueType, context);
 }
 
-RprImageNode::RprImageNode(LoaderContext* context)
+RprImageNode::RprImageNode(std::string const& type, LoaderContext* context)
     : RprMappedNode(
         [context]() {
             rpr_material_node node = nullptr;
@@ -1386,7 +1387,8 @@ RprImageNode::RprImageNode(LoaderContext* context)
             };
             return &s_imageMapping;
         }()
-    ) {
+    )
+    , type(type) {
 
 }
 
@@ -1995,6 +1997,7 @@ RPRMtlxLoader::Result RPRMtlxLoader::Load(
                     outImageNodes.emplace_back();
                     auto& outImageNode = outImageNodes.back();
 
+                    std::swap(outImageNode.type, imageNode->type);
                     std::swap(outImageNode.file, imageNode->file);
                     std::swap(outImageNode.layer, imageNode->layer);
                     std::swap(outImageNode.defaultValue, imageNode->defaultValue);

--- a/deps/rprMtlxLoader/rprMtlxLoader.h
+++ b/deps/rprMtlxLoader/rprMtlxLoader.h
@@ -41,6 +41,9 @@ public:
         static const size_t kInvalidRootNodeIndex = size_t(-1);
 
         struct ImageNode {
+            /// MaterialX type
+            std::string type;
+
             /// The URI of an image file.
             /// It's responsibility of the loader user to setup rpr_image and bind it to rprNode
             std::string file;

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -804,7 +804,7 @@ public:
 
         LockGuard rprLock(m_rprContext->GetMutex());
 
-        auto image = std::unique_ptr<RprUsdCoreImage>(RprUsdCoreImage::Create(m_rprContext.get(), path));
+        auto image = std::unique_ptr<RprUsdCoreImage>(RprUsdCoreImage::Create(m_rprContext.get(), path, 0));
         if (!image) {
             return nullptr;
         }

--- a/pxr/imaging/rprUsd/coreImage.cpp
+++ b/pxr/imaging/rprUsd/coreImage.cpp
@@ -58,11 +58,11 @@ std::unique_ptr<uint8_t[]> _ConvertTexture(GlfUVTextureData* textureData, rpr::I
 
 template <typename T>
 struct WhiteColor {
-    static constexpr T value = static_cast<T>(1);
+    const T value = static_cast<T>(1);
 };
 
 template <> struct WhiteColor<uint8_t> {
-    static constexpr uint8_t value = 255u;
+    const uint8_t value = 255u;
 };
 
 template <typename ComponentT>
@@ -85,7 +85,7 @@ std::unique_ptr<uint8_t[]> ConvertTexture(GlfUVTextureData* textureData, rpr::Im
             return _ConvertTexture<ComponentT>(textureData, format, dstNumComponents,
                 [](ComponentT* dst, ComponentT* src) {
                     dst[0] = dst[1] = dst[2] = src[0];
-                    dst[3] = WhiteColor<ComponentT>::value;
+                    dst[3] = WhiteColor<ComponentT>{}.value;
                 }
             );
         } else {
@@ -121,7 +121,7 @@ std::unique_ptr<uint8_t[]> ConvertTexture(GlfUVTextureData* textureData, rpr::Im
                 dst[0] = src[0];
                 dst[1] = src[1];
                 dst[2] = src[2];
-                dst[3] = WhiteColor<ComponentT>::value;
+                dst[3] = WhiteColor<ComponentT>{}.value;
             }
         );
     }

--- a/pxr/imaging/rprUsd/coreImage.h
+++ b/pxr/imaging/rprUsd/coreImage.h
@@ -26,7 +26,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 class RprUsdCoreImage {
 public:
     RPRUSD_API
-    static RprUsdCoreImage* Create(rpr::Context* context, std::string const& path);
+    static RprUsdCoreImage* Create(rpr::Context* context, std::string const& path, uint32_t numComponentsRequired);
 
     struct UDIMTile {
         uint32_t id;
@@ -35,7 +35,7 @@ public:
         UDIMTile(uint32_t id, GlfUVTextureData* textureData) : id(id), textureData(textureData) {}
     };
     RPRUSD_API
-    static RprUsdCoreImage* Create(rpr::Context* context, std::vector<UDIMTile> const& textureData);
+    static RprUsdCoreImage* Create(rpr::Context* context, std::vector<UDIMTile> const& textureData, uint32_t numComponentsRequired);
 
     RPRUSD_API
     static RprUsdCoreImage* Create(rpr::Context* context, uint32_t width, uint32_t height, rpr::ImageFormat format, void const* data, rpr::Status* status = nullptr);

--- a/pxr/imaging/rprUsd/imageCache.cpp
+++ b/pxr/imaging/rprUsd/imageCache.cpp
@@ -42,7 +42,8 @@ RprUsdImageCache::GetImage(
     std::string const& path,
     std::string const& colorspace,
     rpr::ImageWrapType wrapType,
-    std::vector<RprUsdCoreImage::UDIMTile> const& tiles) {
+    std::vector<RprUsdCoreImage::UDIMTile> const& tiles,
+    uint32_t numComponentsRequired) {
     if (!wrapType) {
         wrapType = RPR_IMAGE_WRAP_TYPE_REPEAT;
     }
@@ -64,7 +65,7 @@ RprUsdImageCache::GetImage(
         }
     }
 
-    auto coreImage = RprUsdCoreImage::Create(m_context, tiles);
+    auto coreImage = RprUsdCoreImage::Create(m_context, tiles, numComponentsRequired);
     if (!coreImage) {
         return nullptr;
     }

--- a/pxr/imaging/rprUsd/imageCache.h
+++ b/pxr/imaging/rprUsd/imageCache.h
@@ -32,7 +32,8 @@ public:
         std::string const& path,
         std::string const& colorspace,
         rpr::ImageWrapType wrapType,
-        std::vector<RprUsdCoreImage::UDIMTile> const& data = {});
+        std::vector<RprUsdCoreImage::UDIMTile> const& data,
+        uint32_t numComponentsRequired);
 
 private:
     rpr::Context* m_context;

--- a/pxr/imaging/rprUsd/materialNodes/materialNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/materialNode.h
@@ -24,7 +24,26 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class RprUsdImageCache;
 
+struct RprUsd_MaterialNetwork {
+    struct Connection {
+        SdfPath upstreamNode;
+        TfToken upstreamOutputName;
+    };
+
+    struct Node {
+        TfToken nodeTypeId;
+        std::map<TfToken, VtValue> parameters;
+        std::map<TfToken, Connection> inputConnections;
+    };
+
+    std::map<SdfPath, Node> nodes;
+    std::map<TfToken, Connection> terminals;
+};
+
 struct RprUsd_MaterialBuilderContext {
+    RprUsd_MaterialNetwork const* hdMaterialNetwork;
+    SdfPath const* currentNodePath;
+
     rpr::Context* rprContext;
     RprUsdImageCache* imageCache;
 

--- a/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
@@ -212,7 +212,7 @@ public:
 
             } else {
                 // Find the only existing output
-                RPRMtlxLoader::OutputType outputType;
+                RPRMtlxLoader::OutputType outputType = RPRMtlxLoader::kOutputNone;
                 for (int i = 0; i < RPRMtlxLoader::kOutputsTotal; ++i) {
                     if (mtlx.rootNodeIndices[i] != RPRMtlxLoader::Result::kInvalidRootNodeIndex) {
                         outputType = RPRMtlxLoader::OutputType(i);

--- a/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
@@ -268,6 +268,18 @@ public:
                         }
                     }
 
+                    if (mtlxImageNode.type == "float") {
+                        textureCommit.numComponentsRequired = 1;
+                    } else if (mtlxImageNode.type == "vector2" || mtlxImageNode.type == "color2") {
+                        textureCommit.numComponentsRequired = 2;
+                    } else if (mtlxImageNode.type == "vector3" || mtlxImageNode.type == "color3") {
+                        textureCommit.numComponentsRequired = 3;
+                    } else if (mtlxImageNode.type == "vector4" || mtlxImageNode.type == "color4") {
+                        textureCommit.numComponentsRequired = 4;
+                    } else {
+                        TF_WARN("Invalid image materialX type: %s", mtlxImageNode.type.c_str());
+                    }
+
                     rpr_material_node rprImageNode = mtlxImageNode.rprNode;
                     textureCommit.setTextureCallback = [retainedImagesPtr, rprImageNode](std::shared_ptr<RprUsdCoreImage> const& image) {
                         if (!image) return;

--- a/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
@@ -282,6 +282,38 @@ RprUsd_UsdUVTexture::RprUsd_UsdUVTexture(
         }
     };
 
+    // Analyze material graph and find out the minimum required amount of components required
+    textureCommit.numComponentsRequired = 0;
+    for (auto& entry : m_ctx->hdMaterialNetwork->nodes) {
+        for (auto& connection : entry.second.inputConnections) {
+            if (connection.second.upstreamNode == *m_ctx->currentNodePath) {
+                uint32_t numComponentsRequired;
+                if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->rgba) {
+                    numComponentsRequired = 4;
+                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->rgb) {
+                    numComponentsRequired = 3;
+                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->r) {
+                    numComponentsRequired = 1;
+                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->g) {
+                    numComponentsRequired = 2;
+                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->b) {
+                    numComponentsRequired = 3;
+                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->a) {
+                    numComponentsRequired = 4;
+                }
+                textureCommit.numComponentsRequired = std::max(textureCommit.numComponentsRequired, numComponentsRequired);
+
+                if (textureCommit.numComponentsRequired == 4) {
+                    break;
+                }
+            }
+        }
+
+        if (textureCommit.numComponentsRequired == 4) {
+            break;
+        }
+    }
+
     // Texture loading is postponed to allow multi-threading loading.
     //
     RprUsdMaterialRegistry::GetInstance().CommitTexture(std::move(textureCommit));

--- a/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
@@ -287,7 +287,7 @@ RprUsd_UsdUVTexture::RprUsd_UsdUVTexture(
     for (auto& entry : m_ctx->hdMaterialNetwork->nodes) {
         for (auto& connection : entry.second.inputConnections) {
             if (connection.second.upstreamNode == *m_ctx->currentNodePath) {
-                uint32_t numComponentsRequired;
+                uint32_t numComponentsRequired = 0;
                 if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->rgba) {
                     numComponentsRequired = 4;
                 } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->rgb) {

--- a/pxr/imaging/rprUsd/materialRegistry.h
+++ b/pxr/imaging/rprUsd/materialRegistry.h
@@ -86,6 +86,7 @@ public:
         std::string filepath;
         std::string colorspace;
         rpr::ImageWrapType wrapType;
+        uint32_t numComponentsRequired = 0;
 
         std::function<void(std::shared_ptr<RprUsdCoreImage> const&)> setTextureCallback;
     };


### PR DESCRIPTION
Do such conversions:
* single-channel (R) texture to RRR when it's used as RGB input
* RG texture into to RRRG when it's used RGBA input
* and others, see CoreImage.cpp:ConvertTexture

### PURPOSE
Fix unexpected behavior (from the artists point of view) when using single-channel grey textures, dual-channel (red-alpha), and others.

### EFFECT OF CHANGE
More artist-friendly texture appearance, e.g. single-channel greyscale jpegs.

### TECHNICAL STEPS
* Evaluate the required number of channels for a texture:
  * UsdUvTexture: depends on the connections in which this node participates
  * MaterialX: depends on the type of image node
* Knowing the number of required channels and number of actual channels of a texture, convert accordingly

