### PR TITLE
Fix UsdPreviewSurface normal

### DIFF
--- a/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
@@ -145,8 +145,17 @@ bool RprUsd_UsdPreviewSurface::SetInput(
         if (value.IsHolding<RprMaterialNodePtr>()) {
             if (!m_normalMapNode) {
                 m_normalMapNode.reset(new RprUsd_BaseRuntimeNode(RPR_MATERIAL_NODE_NORMAL_MAP, m_ctx));
+                m_normalMapScaleNode = RprUsd_RprArithmeticNode::Create(RPR_MATERIAL_NODE_OP_MUL, m_ctx);
+                m_normalMapBiasNode = RprUsd_RprArithmeticNode::Create(RPR_MATERIAL_NODE_OP_ADD, m_ctx);
             }
-            m_normalMapNode->SetInput(RPR_MATERIAL_INPUT_COLOR, value);
+
+            m_normalMapScaleNode->SetInput(0, value);
+            m_normalMapScaleNode->SetInput(1, VtValue(GfVec4f(0.5f)));
+
+            m_normalMapBiasNode->SetInput(0, m_normalMapScaleNode->GetOutput());
+            m_normalMapBiasNode->SetInput(1, VtValue(GfVec4f(0.5f)));
+
+            m_normalMapNode->SetInput(RPR_MATERIAL_INPUT_COLOR, m_normalMapBiasNode->GetOutput());
 
             auto normalMapOutput = m_normalMapNode->GetOutput(TfToken());
             return (SetRprInput(m_rprNode.get(), RPR_MATERIAL_INPUT_UBER_DIFFUSE_NORMAL, normalMapOutput) == RPR_SUCCESS) &&

--- a/pxr/imaging/rprUsd/materialNodes/usdNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.h
@@ -41,6 +41,9 @@ private:
 
     std::unique_ptr<RprUsd_RprArithmeticNode> m_emissiveWeightNode;
     std::unique_ptr<RprUsd_RprArithmeticNode> m_refractionWeightNode;
+
+    std::unique_ptr<RprUsd_RprArithmeticNode> m_normalMapScaleNode;
+    std::unique_ptr<RprUsd_RprArithmeticNode> m_normalMapBiasNode;
     std::unique_ptr<RprUsd_BaseRuntimeNode> m_normalMapNode;
 
     std::shared_ptr<RprUsd_BaseRuntimeNode> m_displaceNode;


### PR DESCRIPTION
### PURPOSE
UsdPreviewSurface normal mapping looks wrong when used correctly.

### EFFECT OF CHANGE
Normal input now expects values in the correct range (accordingly to UsdPreviewSurface proposal) - tangent space [(-1,-1,-1).(1,1,1)].

### TECHNICAL STEPS
Rescale input value from [-1;1] to [0;1] range required by RPR_MATERIAL_NODE_NORMAL_MAP