### PR TITLE
Add a way to override material IDs

### DIFF
--- a/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
+++ b/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(RPR_for_Houdini SHARED
     plugin.cpp
     VOP_RPRMaterial.h
     VOP_RPRMaterial.cpp
+    LOP_RPRMaterialProperties.h
+    LOP_RPRMaterialProperties.cpp
     LOP_RPRExportHelper.h
     LOP_RPRExportHelper.cpp)
 
@@ -13,6 +15,7 @@ target_link_libraries(RPR_for_Houdini
     arch
     usd
     usdGeom
+    usdShade
     usdRender
     rprUsd
     Houdini)

--- a/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.cpp
+++ b/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.cpp
@@ -1,0 +1,105 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#include "LOP_RPRMaterialProperties.h"
+
+#include <OP/OP_OperatorTable.h>
+#include <OP/OP_Operator.h>
+
+#include <PRM/PRM_Include.h>
+
+#include <LOP/LOP_PRMShared.h>
+#include <LOP/LOP_Error.h>
+#include <HUSD/HUSD_Utils.h>
+#include <HUSD/XUSD_Data.h>
+#include <HUSD/XUSD_Utils.h>
+
+#include <pxr/usd/usd/stage.h>
+#include <pxr/base/tf/staticTokens.h>
+#include <pxr/usd/usdShade/material.h>
+#include <pxr/imaging/rprUsd/tokens.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+static PRM_Name g_materialPath("materialPath", "Material Path");
+static PRM_Name g_id("id", "ID");
+
+static PRM_Template g_templateList[] = {
+    PRM_Template(PRM_STRING_E, 1, &g_materialPath),
+    PRM_Template(PRM_INT, 1, &g_id, nullptr, nullptr, nullptr, nullptr, nullptr, 1,
+        "some help"),
+    PRM_Template()
+};
+
+void LOP_RPRMaterialProperties::Register(OP_OperatorTable* table) {
+    auto opOperator = new OP_Operator(
+        "rpr_LOP_RPRMaterialProperties",
+        "RPR Material Properties",
+        [](OP_Network *net, const char *name, OP_Operator *op) -> OP_Node* {
+            return new LOP_RPRMaterialProperties(net, name, op);
+        },
+        g_templateList,
+        0u,
+        (unsigned)1);
+    opOperator->setIconName("RPR");
+
+    table->addOperator(opOperator);
+}
+
+LOP_RPRMaterialProperties::LOP_RPRMaterialProperties(OP_Network *net, const char *name, OP_Operator *op)
+    : LOP_Node(net, name, op) {
+
+}
+
+OP_ERROR LOP_RPRMaterialProperties::cookMyLop(OP_Context &context) {
+    if (cookModifyInput(context) >= UT_ERROR_FATAL) {
+        return error();
+    }
+
+    UT_String materialPath;
+    evalString(materialPath, g_materialPath.getToken(), 0, context.getTime());
+    HUSDmakeValidUsdPath(materialPath, true);
+
+    int id = evalInt(g_id.getToken(), 0, context.getTime());
+
+    if (!materialPath.isstring()) {
+        return error();
+    }
+    SdfPath materialSdfPath(HUSDgetSdfPath(materialPath));
+
+    HUSD_AutoWriteLock writelock(editableDataHandle());
+    HUSD_AutoLayerLock layerlock(writelock);
+
+    UsdStageRefPtr stage = writelock.data()->stage();
+
+    UsdPrim materialPrim = stage->GetPrimAtPath(materialSdfPath);
+    if (!materialPrim) {
+        addError(LOP_MESSAGE, TfStringPrintf("Material with %s path does not exist", materialPath.c_str()).c_str());
+        return error();
+    }
+
+    UsdShadeMaterial material(materialPrim);
+    if (!material) {
+        addError(LOP_MESSAGE, TfStringPrintf("Specified path does not point to a material: %s", materialPrim.GetPrimTypeInfo().GetTypeName().GetText()).c_str());
+        return error();
+    }
+
+    UsdShadeShader surfaceSource = material.ComputeSurfaceSource(RprUsdTokens->rpr);
+    if (surfaceSource) {
+        surfaceSource.CreateInput(RprUsdTokens->id, SdfValueTypeNames->Int).Set(id);
+    }
+
+    return error();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.h
+++ b/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.h
@@ -1,0 +1,37 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#ifndef RPR_LOP_RPRMATERIALPROPERTIES_H
+#define RPR_LOP_RPRMATERIALPROPERTIES_H
+
+#include "pxr/pxr.h"
+
+#include <LOP/LOP_Node.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// This node allows to set RPR specific properties on materials
+class LOP_RPRMaterialProperties : public LOP_Node {
+public:
+    LOP_RPRMaterialProperties(OP_Network *net, const char *name, OP_Operator *op);
+    ~LOP_RPRMaterialProperties() override = default;
+
+    static void Register(OP_OperatorTable *table);
+
+protected:
+    OP_ERROR cookMyLop(OP_Context &context) override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // RPR_LOP_RPRMATERIALPROPERTIES_H

--- a/pxr/imaging/plugin/rprHoudini/plugin.cpp
+++ b/pxr/imaging/plugin/rprHoudini/plugin.cpp
@@ -13,6 +13,7 @@ limitations under the License.
 
 #include "VOP_RPRMaterial.h"
 #include "LOP_RPRExportHelper.h"
+#include "LOP_RPRMaterialProperties.h"
 #include "pxr/imaging/rprUsd/materialRegistry.h"
 
 #include <OP/OP_OperatorTable.h>
@@ -34,4 +35,5 @@ void newVopOperator(OP_OperatorTable* io_table) {
 void newLopOperator(OP_OperatorTable *table) {
     PXR_NAMESPACE_USING_DIRECTIVE
     LOP_RPRExportHelper::Register(table);
+    LOP_RPRMaterialProperties::Register(table);
 }

--- a/pxr/imaging/rprUsd/CMakeLists.txt
+++ b/pxr/imaging/rprUsd/CMakeLists.txt
@@ -19,6 +19,7 @@ pxr_library(rprUsd
     PUBLIC_CLASSES
         util
         config
+        tokens
         contextHelpers
         coreImage
         debugCodes

--- a/pxr/imaging/rprUsd/materialRegistry.cpp
+++ b/pxr/imaging/rprUsd/materialRegistry.cpp
@@ -18,6 +18,8 @@ limitations under the License.
 #include "pxr/imaging/rprUsd/imageCache.h"
 #include "pxr/imaging/rprUsd/debugCodes.h"
 #include "pxr/imaging/rprUsd/material.h"
+#include "pxr/imaging/rprUsd/tokens.h"
+#include "pxr/imaging/rprUsd/error.h"
 #include "pxr/imaging/rprUsd/util.h"
 #include "pxr/base/tf/instantiateSingleton.h"
 #include "pxr/base/tf/staticTokens.h"
@@ -394,7 +396,8 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
         bool Finalize(RprUsd_MaterialBuilderContext& context,
             VtValue const& surfaceOutput,
             VtValue const& displacementOutput,
-            VtValue const& volumeOutput) {
+            VtValue const& volumeOutput,
+            int materialId) {
 
             auto getTerminalRprNode = [](VtValue const& terminalOutput) -> rpr::MaterialNode* {
                 if (!terminalOutput.IsEmpty()) {
@@ -416,6 +419,12 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
             m_isReflectionCatcher = context.isReflectionCatcher;
             m_uvPrimvarName = std::move(context.uvPrimvarName);
             m_displacementScale = std::move(context.displacementScale);
+
+            if (m_surfaceNode && materialId >= 0) {
+                // TODO: add C++ wrapper
+                auto apiHandle = rpr::GetRprObject(m_surfaceNode);
+                RPR_ERROR_CHECK(rprMaterialNodeSetID(apiHandle, rpr_uint(materialId)), "Failed to set material node id");
+            }
 
             return m_volumeNode || m_surfaceNode || m_displacementNode;
         }
@@ -525,7 +534,28 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
     auto surfaceOutput = getTerminalOutput(HdMaterialTerminalTokens->surface);
     auto displacementOutput = getTerminalOutput(HdMaterialTerminalTokens->displacement);
 
-    return out->Finalize(context, surfaceOutput, displacementOutput, volumeOutput) ? out.release() : nullptr;
+    int materialId = -1;
+
+    auto surfaceTerminalIt = network.terminals.find(HdMaterialTerminalTokens->surface);
+    if (surfaceTerminalIt != network.terminals.end()) {
+        auto& surfaceNodePath = surfaceTerminalIt->second.upstreamNode;
+
+        auto surfaceNodeIt = network.nodes.find(surfaceNodePath);
+        if (surfaceNodeIt != network.nodes.end()) {
+            auto& parameters = surfaceNodeIt->second.parameters;
+
+            auto idIt = parameters.find(RprUsdTokens->id);
+            if (idIt != parameters.end()) {
+                auto& value = idIt->second;
+
+                if (value.IsHolding<int>()) {
+                    materialId = value.UncheckedGet<int>();
+                }
+            }
+        }
+    }
+
+    return out->Finalize(context, surfaceOutput, displacementOutput, volumeOutput, materialId) ? out.release() : nullptr;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/tokens.cpp
+++ b/pxr/imaging/rprUsd/tokens.cpp
@@ -1,0 +1,21 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#include "pxr/imaging/rprUsd/tokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PUBLIC_TOKENS(RprUsdTokens, RPRUSD_TOKENS);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+

--- a/pxr/imaging/rprUsd/tokens.h
+++ b/pxr/imaging/rprUsd/tokens.h
@@ -1,0 +1,33 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#ifndef PXR_IMAGING_RPRUSD_TOKENS_H
+#define PXR_IMAGING_RPRUSD_TOKENS_H
+
+#include "pxr/pxr.h"
+#include "pxr/imaging/rprUsd/api.h"
+#include "pxr/base/tf/staticTokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+#define RPRUSD_TOKENS \
+    (rpr) \
+    /* UsdShadeShader */ \
+    ((id, "rpr:id"))
+
+
+TF_DECLARE_PUBLIC_TOKENS(RprUsdTokens, RPRUSD_API, RPRUSD_TOKENS);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif //PXR_IMAGING_RPRUSD_TOKENS_H


### PR DESCRIPTION
### PURPOSE
To allow the user to control the material ID that is rendered on the corresponding AOV.

### EFFECT OF CHANGE
Added new LOP node (`RPR Material Properties`) for overriding material ID.

### TECHNICAL STEPS
* New LOP node that sets required inputs on a material
* Query new inputs in material creation code
