### PR TITLE
Add a way to override mesh ID

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -361,6 +361,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
     }
 
     bool isVisibilityMaskDirty = false;
+    bool isIdDirty = false;
     if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
         HdRprGeometrySettings geomSettings = {};
         geomSettings.visibilityMask = kVisibleAll;
@@ -375,6 +376,11 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         if (m_visibilityMask != geomSettings.visibilityMask) {
             m_visibilityMask = geomSettings.visibilityMask;
             isVisibilityMaskDirty = true;
+        }
+
+        if (m_id != geomSettings.id) {
+            m_id = geomSettings.id;
+            isIdDirty = true;
         }
     }
 
@@ -420,7 +426,6 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
         if (m_geomSubsets.empty()) {
             if (auto rprMesh = rprApi->CreateMesh(m_points, m_faceVertexIndices, m_normals, m_normalIndices, m_uvs, m_uvIndices, m_faceVertexCounts, m_topology.GetOrientation())) {
-                rprApi->SetMeshId(rprMesh, GetPrimId());
                 m_rprMeshes.push_back(rprMesh);
             }
         } else {
@@ -524,7 +529,6 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                 }
 
                 if (auto rprMesh = rprApi->CreateMesh(subsetPoints, subsetIndexes, subsetNormals, subsetNormalIndices, subsetUv, subsetUvIndices, subsetVertexPerFace, m_topology.GetOrientation())) {
-                    rprApi->SetMeshId(rprMesh, GetPrimId());
                     m_rprMeshes.push_back(rprMesh);
                     ++it;
                 } else {
@@ -664,7 +668,6 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                                 int32_t meshId = GetPrimId();
                                 for (int j = meshInstances.size(); j < newNumInstances; ++j) {
                                     meshInstances.push_back(rprApi->CreateMeshInstance(m_rprMeshes[i]));
-                                    rprApi->SetMeshId(meshInstances.back(), meshId);
                                 }
                             }
                         }
@@ -692,6 +695,18 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                     for (auto& rprMesh : instances) {
                         rprApi->SetMeshVisibility(rprMesh, visibilityMask);
                     }
+                }
+            }
+        }
+
+        if (newMesh || isIdDirty) {
+            uint32_t id = m_id >= 0 ? uint32_t(m_id) : GetPrimId();
+            for (auto& rprMesh : m_rprMeshes) {
+                rprApi->SetMeshId(rprMesh, id);
+            }
+            for (auto& instances : m_rprMeshInstances) {
+                for (auto& rprMesh : instances) {
+                    rprApi->SetMeshId(rprMesh, id);
                 }
             }
         }

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -96,7 +96,8 @@ private:
     HdDisplayStyle m_displayStyle;
     int m_refineLevel = 0;
 
-    uint32_t m_visibilityMask;
+    uint32_t m_visibilityMask = 0;
+    int m_id = -1;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_PRIVATE_TOKENS(HdRprGeometryPrimvarTokens,
+    ((id, "rpr:id"))
     ((subdivisionLevel, "rpr:subdivisionLevel"))
     ((visibilityPrimary, "rpr:visibilityPrimary"))
     ((visibilityShadow, "rpr:visibilityShadow"))
@@ -49,7 +50,9 @@ void HdRprParseGeometrySettings(
     };
 
     for (auto& desc : constantPrimvarDescs) {
-        if (desc.name == HdRprGeometryPrimvarTokens->subdivisionLevel) {
+        if (desc.name == HdRprGeometryPrimvarTokens->id) {
+            HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->id, sceneDelegate, id, &geomSettings->id);
+        } else if (desc.name == HdRprGeometryPrimvarTokens->subdivisionLevel) {
             int subdivisionLevel;
             if (HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->subdivisionLevel, sceneDelegate, id, &subdivisionLevel)) {
                 geomSettings->subdivisionLevel = std::max(0, std::min(subdivisionLevel, 7));

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.h
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.h
@@ -38,6 +38,7 @@ bool HdRprIsValidPrimvarSize(
 struct HdRprGeometrySettings {
     uint32_t visibilityMask = 0;
     int subdivisionLevel = 0;
+    int id = -1;
 };
 
 void HdRprParseGeometrySettings(

--- a/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
@@ -24,6 +24,13 @@ geometry_settings = [
                 'defaultValue': 0,
                 'minValue': 0,
                 'maxValue': 7
+            },
+            {
+                'name': 'primvars:rpr:id',
+                'ui_name': 'ID',
+                'defaultValue': 0,
+                'minValue': 0,
+                'maxValue': 1 ** 16
             }
         ] + visibility_flag_settings
     }


### PR DESCRIPTION
### PURPOSE
To allow the user to control the object ID that is rendered on the corresponding AOV.

### EFFECT OF CHANGE
Added `ID` parameter to the `Render Geometry Settings` LOP node.

### TECHNICAL STEPS
Parse id from the constant primvars and if it's authored override `HdRprim::GetPrimId`.
