### PR TITLE
Reduce the number of python processes when generating files on build

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -29,7 +29,7 @@ endif(HoudiniUSD_FOUND)
 set(GEN_SCRIPT_PYTHON ${PYTHON_EXECUTABLE})
 set(GENERATION_SCRIPTS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/python)
 set(GEN_SCRIPT ${GENERATION_SCRIPTS_DIR}/generateFiles.py)
-set(GEN_SCRIPT_ARGS \"${GENERATION_SCRIPTS_DIR}\" \"${CMAKE_CURRENT_BINARY_DIR}\")
+set(GEN_SCRIPT_ARGS \"${CMAKE_CURRENT_BINARY_DIR}\")
 set(GENERATED_FILES
     ${CMAKE_CURRENT_BINARY_DIR}/config.h
     ${CMAKE_CURRENT_BINARY_DIR}/config.cpp)
@@ -39,7 +39,7 @@ set(GENERATION_DEPENDENT_FILES ${GEN_SCRIPT}
     ${GENERATION_SCRIPTS_DIR}/generateRenderSettingFiles.py
     ${GENERATION_SCRIPTS_DIR}/generateGeometrySettingFiles.py)
 if(HoudiniUSD_FOUND)
-    set(GEN_SCRIPT_ARGS --houdini_root \"${HOUDINI_ROOT}\" ${GEN_SCRIPT_ARGS})
+    set(GEN_SCRIPT_ARGS --for_houdini ${GEN_SCRIPT_ARGS})
     set(GENERATED_FILES ${GENERATED_FILES}
         ${CMAKE_CURRENT_BINARY_DIR}/HdRprPlugin_Light.ds
         ${CMAKE_CURRENT_BINARY_DIR}/HdRprPlugin_Global.ds
@@ -61,8 +61,6 @@ if(HoudiniUSD_FOUND)
         \\\"Includes\\\": [ \\\"../../../plugin/\\\" ]
     }\")")
 endif()
-
-set(GEN_SCRIPT_ARGS --python_exe "\"${GEN_SCRIPT_PYTHON}\"" ${GEN_SCRIPT_ARGS})
 
 add_custom_command(
     COMMAND ${GEN_SCRIPT_PYTHON} ${GEN_SCRIPT} ${GEN_SCRIPT_ARGS}

--- a/pxr/imaging/plugin/hdRpr/python/generateFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateFiles.py
@@ -9,22 +9,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # 
-import subprocess
 import argparse
 import os
 
+import generateGeometrySettingFiles
+import generateRenderSettingFiles
+import generateLightSettingFiles
+
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
-    p.add_argument('scripts_dir', help="Directory with scripts")
     p.add_argument("install", help="The install root for generated files.")
-    p.add_argument("--houdini_root", help="The install root for generated files.")
-    p.add_argument('--python_exe', help="Directory with scripts")
+    p.add_argument("--for_houdini", action="store_true")
     args = p.parse_args()
 
-    generate_ds_files = []
-    if args.houdini_root:
-        generate_ds_files = ['--generate_ds_files']
-
-    subprocess.check_call([args.python_exe, os.path.join(args.scripts_dir, 'generateLightSettingFiles.py'), args.install] + generate_ds_files)
-    subprocess.check_call([args.python_exe, os.path.join(args.scripts_dir, 'generateGeometrySettingFiles.py'), args.install] + generate_ds_files)
-    subprocess.check_call([args.python_exe, os.path.join(args.scripts_dir, 'generateRenderSettingFiles.py'), args.install] + generate_ds_files)
+    generateGeometrySettingFiles.generate(args.install, args.for_houdini)
+    generateRenderSettingFiles.generate(args.install, args.for_houdini)
+    generateLightSettingFiles.generate(args.install, args.for_houdini)

--- a/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
@@ -29,11 +29,6 @@ geometry_settings = [
     }
 ]
 
-if __name__ == "__main__":
-    p = argparse.ArgumentParser()
-    p.add_argument("install", help="The install root for generated files.")
-    p.add_argument("--generate_ds_files", default=False, action='store_true')
-    args = p.parse_args()
-
-    if args.generate_ds_files:
-        generate_houdini_ds(args.install, 'Geometry', geometry_settings)
+def generate(install, generate_ds_files):
+    if generate_ds_files:
+        generate_houdini_ds(install, 'Geometry', geometry_settings)

--- a/pxr/imaging/plugin/hdRpr/python/generateLightSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateLightSettingFiles.py
@@ -28,11 +28,6 @@ light_settings = [
     }
 ]
 
-if __name__ == "__main__":
-    p = argparse.ArgumentParser()
-    p.add_argument("install", help="The install root for generated files.")
-    p.add_argument("--generate_ds_files", default=False, action='store_true')
-    args = p.parse_args()
-
-    if args.generate_ds_files:
-        generate_houdini_ds(args.install, 'Light', light_settings)
+def generate(install, generate_ds_files):
+    if generate_ds_files:
+        generate_houdini_ds(install, 'Light', light_settings)

--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -739,10 +739,5 @@ void HdRprConfig::Set{name_title}({c_type} {name}) {{
         generate_houdini_ds(install_path, 'Global', render_setting_categories)
 
 
-if __name__ == "__main__":
-    p = argparse.ArgumentParser()
-    p.add_argument("install", help="The install root for generated files.")
-    p.add_argument("--generate_ds_files", default=False, action='store_true')
-    args = p.parse_args()
-
-    generate_render_setting_files(args.install, args.generate_ds_files)
+def generate(install, generate_ds_files):
+    generate_render_setting_files(install, generate_ds_files)


### PR DESCRIPTION
### PURPOSE
To speed up the build time.

### EFFECT OF CHANGE
Faster plugin building.

### TECHNICAL STEPS
Reduce the number of python processes when generating files on the build. Instead, execute generation code from the main python process.

### NOTES FOR REVIEWERS
On my machine, it gives a 13% improvement - the time of full build reduced from 78 seconds to 68.
