### PR TITLE
Create denoise AOVs lazily

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -248,6 +248,30 @@ render_setting_categories = [
                         '"uiicon" VIEW_display_denoise'
                     ]
                 }
+            },
+            {
+                'folder': 'Denoise Settings',
+                'houdini': {
+                    'hidewhen': 'enableDenoising == 0'
+                },
+                'settings': [
+                    {
+                        'name': 'denoiseMinIter',
+                        'ui_name': 'Denoise Min Iteration',
+                        'defaultValue': 4,
+                        'minValue': 1,
+                        'maxValue': 2 ** 16,
+                        'help': 'The first iteration on which denoising should be applied.'
+                    },
+                    {
+                        'name': 'denoiseIterStep',
+                        'ui_name': 'Denoise Iteration Step',
+                        'defaultValue': 32,
+                        'minValue': 1,
+                        'maxValue': 2 ** 16,
+                        'help': 'Denoise use frequency. To denoise on each iteration, set to 1.'
+                    }
+                ]
             }
         ]
     },

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -85,15 +85,16 @@ public:
 
     void SetOpacityAov(std::shared_ptr<HdRprApiAov> opacity);
 
-    void EnableAIDenoise(std::shared_ptr<HdRprApiAov> albedo,
+    void InitAIDenoise(std::shared_ptr<HdRprApiAov> albedo,
                          std::shared_ptr<HdRprApiAov> normal,
                          std::shared_ptr<HdRprApiAov> linearDepth);
-    void EnableEAWDenoise(std::shared_ptr<HdRprApiAov> albedo,
+    void InitEAWDenoise(std::shared_ptr<HdRprApiAov> albedo,
                           std::shared_ptr<HdRprApiAov> normal,
                           std::shared_ptr<HdRprApiAov> linearDepth,
                           std::shared_ptr<HdRprApiAov> objectId,
                           std::shared_ptr<HdRprApiAov> worldCoordinate);
-    void DisableDenoise(rif::Context* rifContext);
+    void DeinitDenoise(rif::Context* rifContext);
+    void SetDenoise(bool enable, HdRprApi const* rprApi, rif::Context* rifContext);
 
     struct TonemapParams {
         bool enable;
@@ -140,6 +141,7 @@ private:
     std::shared_ptr<HdRprApiAov> m_retainedRawColor;
     std::shared_ptr<HdRprApiAov> m_retainedOpacity;
     std::shared_ptr<HdRprApiAov> m_retainedDenoiseInputs[rif::MaxInput];
+    Filter m_denoiseFilterType = kFilterNone;
 
     Filter m_mainFilterType = kFilterNone;
     std::vector<std::pair<Filter, std::unique_ptr<rif::Filter>>> m_auxFilters;


### PR DESCRIPTION
### PURPOSE
For a better user experience, we were preallocating denoise AOVs in advance to allow the user to enable/disable denoising without resetting AOVs at any time. For Northstar, creating additional denoise AOVs (albedo, normal) critically affects its performance. For Tahoe, it was only memory overhead, the performance penalty was miserable. 

### EFFECT OF CHANGE
* Highly reduce time to first pixel for Full (RPR 2.0) render quality when denoise is not enabled.
* Change denoise usage.
    * Now when denoise is enabled/disabled we clear AOVs
    * Add two settings to control denoise behavior (like in RPR Blender plugin):
        * `Denoise Min Iteration` - the first iteration on which denoising should be applied.
        * `Denoise Iteration Step` - denoise use frequency. To denoise on each iteration, set to 1.

### TECHNICAL STEPS
* Create denoise AOVs lazily
* Add two new render settings to control denoise behavior

### NOTES FOR REVIEWERS
On my machine, these changes reduced first to pixel from 300 ms to 169 ms (43%). 
