### PR TITLE
Fix crash on resizing viewport when denoising enabled

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1873,6 +1873,15 @@ public:
     }
 
     void UpdateAovs(HdRprRenderParam* rprRenderParam, RenderSetting<bool> enableDenoise, RenderSetting<HdRprApiColorAov::TonemapParams> tonemap, bool clearAovs) {
+        auto colorAov = GetColorAov();
+        if (colorAov) {
+            UpdateDenoising(enableDenoise, colorAov);
+
+            if (tonemap.isDirty) {
+                colorAov->SetTonemap(tonemap.value);
+            }
+        }
+
         if (m_dirtyFlags & (ChangeTracker::DirtyAOVBindings | ChangeTracker::DirtyAOVRegistry)) {
             m_resolveData.rawAovs.clear();
             m_resolveData.computedAovs.clear();
@@ -1909,15 +1918,6 @@ public:
                     outputRb.mappedData = rprRenderBuffer->GetPointerForWriting();
                     outputRb.mappedDataSize = HdDataSizeOfFormat(rprRenderBuffer->GetFormat()) * rprRenderBuffer->GetWidth() * rprRenderBuffer->GetHeight();
                 }
-            }
-        }
-
-        auto colorAov = GetColorAov();
-        if (colorAov) {
-            UpdateDenoising(enableDenoise, colorAov);
-
-            if (tonemap.isDirty) {
-                colorAov->SetTonemap(tonemap.value);
             }
         }
 


### PR DESCRIPTION
### PURPOSE
Fix crash on resizing viewport when denoising enabled

### EFFECT OF CHANGE
None - changes that lead to this crash were not released yet.

### TECHNICAL STEPS
Change the order of AOVs updates - at first, create all required AOVs (denoise AOVs in this case) and only then resize if viewport was changed.
