### PR TITLE
Configure Houdini plugin for automatic renderer restart

### DIFF
--- a/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
+++ b/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
@@ -52,5 +52,6 @@ install(
 install(
     FILES
         ui/MainMenuCommon.xml
+        UsdRenderers.json
     DESTINATION
         houdini)

--- a/pxr/imaging/plugin/rprHoudini/UsdRenderers.json
+++ b/pxr/imaging/plugin/rprHoudini/UsdRenderers.json
@@ -1,0 +1,8 @@
+{
+    "HdRprPlugin" : {
+        "valid" : true,
+        "menulabel" : "RPR",
+        "menupriority" : 0,
+        "restartrendersettings" : ["renderQuality", "renderDevice"]
+    }
+}


### PR DESCRIPTION
### PURPOSE
To improve UX. When the user changes such render qualities as renderQuality and renderDevice, we need to resync the scene because changing these settings requires RPR context recreation. Previously, the user had to do it manually through Houdini UI.

### EFFECT OF CHANGE
No more need to restart render manually when changing render quality.

### TECHNICAL STEPS
Accordingly to this [new doc](https://www.sidefx.com/docs/hdk/_h_d_k__u_s_d_hydra.html#HDK_USDHydraConfiguration) we can put UsdRenderers.json config into HOUDINI_PATH to customize render delegate usage (see `restartrendersettings` key).
