### PR TITLE
Fix compilation for USD 19.11

### DIFF
--- a/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.cpp
+++ b/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.cpp
@@ -90,7 +90,7 @@ OP_ERROR LOP_RPRMaterialProperties::cookMyLop(OP_Context &context) {
 
     UsdShadeMaterial material(materialPrim);
     if (!material) {
-        addError(LOP_MESSAGE, TfStringPrintf("Specified path does not point to a material: %s", materialPrim.GetPrimTypeInfo().GetTypeName().GetText()).c_str());
+        addError(LOP_MESSAGE, TfStringPrintf("Specified path does not point to a material: %s", materialPath.c_str()).c_str());
         return error();
     }
 


### PR DESCRIPTION
### PURPOSE
Some users still want to compile hdRpr with USD 19.11. https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/410 introduced changes that can't be compiled with USD 19.11 - it uses `UsdPrim::GetPrimTypeInfo` that was introduced only in USD 20.08.

### EFFECT OF CHANGE
None, changes that lead to this issue were not released.
