### PR TITLE
Use displayColor with any interpolation

### DIFF
--- a/pxr/imaging/plugin/hdRpr/basisCurves.cpp
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.cpp
@@ -202,10 +202,14 @@ void HdRprBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
 
                 if (HdRprIsPrimvarExists(HdTokens->displayColor, primvarDescsPerInterpolation)) {
                     VtValue val = sceneDelegate->Get(id, HdTokens->displayColor);
-                    if (!val.IsEmpty() && val.IsHolding<VtVec3fArray>()) {
-                        auto colors = val.UncheckedGet<VtVec3fArray>();
-                        if (!colors.empty()) {
-                            color = colors[0];
+                    if (!val.IsEmpty()) {
+                        if (val.IsHolding<VtVec3fArray>()) {
+                            auto colors = val.UncheckedGet<VtVec3fArray>();
+                            if (!colors.empty()) {
+                                color = colors[0];
+                            }
+                        } else if (val.IsHolding<GfVec3f>()) {
+                            color = val.UncheckedGet<GfVec3f>();
                         }
                     }
                 }

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -126,19 +126,15 @@ RprUsdMaterial const* HdRprMesh::GetFallbackMaterial(
 
         GfVec3f color(0.18f);
 
-        auto constantPrimvarsIt = primvarDescsPerInterpolation.find(HdInterpolationConstant);
-        if (constantPrimvarsIt != primvarDescsPerInterpolation.end()) {
-            for (auto& pv : constantPrimvarsIt->second) {
-                if (pv.name == HdTokens->displayColor) {
-                    VtValue val = sceneDelegate->Get(GetId(), HdTokens->displayColor);
-                    if (val.IsHolding<VtVec3fArray>()) {
-                        auto colors = val.UncheckedGet<VtVec3fArray>();
-                        if (!colors.empty()) {
-                            color = colors[0];
-                        }
-                        break;
-                    }
+        if (HdRprIsPrimvarExists(HdTokens->displayColor, primvarDescsPerInterpolation)) {
+            VtValue val = sceneDelegate->Get(GetId(), HdTokens->displayColor);
+            if (val.IsHolding<VtVec3fArray>()) {
+                auto colors = val.UncheckedGet<VtVec3fArray>();
+                if (!colors.empty()) {
+                    color = colors[0];
                 }
+            } else if (val.IsHolding<GfVec3f>()) {
+                color = val.UncheckedGet<GfVec3f>();
             }
         }
 


### PR DESCRIPTION
### PURPOSE
Reported by Morgenrot Jp.
Though in hdRpr we don't support correctly displayColor due to the absence of primvar support, there is no reason to ignore displayColor with any interpolation except constant like it was before for meshes.

### EFFECT OF CHANGE
Use displayColor primvar with any interpolation (still limited to one color)
