### PR TITLE
Fix RPR trace generation

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -2915,8 +2915,7 @@ private:
 
         m_isRenderUpdateCallbackEnabled = false;
 
-        bool isTracingEnabled = RprUsdGetInfo<uint32_t>(m_rprContext.get(), RPR_CONTEXT_TRACING_ENABLED);
-        if (!isTracingEnabled) {
+        if (!RprUsdIsTracingEnabled()) {
             // We need it for correct rendering of ID AOVs (e.g. RPR_AOV_OBJECT_ID)
             // XXX: it takes approximately 32ms due to RPR API indirection,
             //      replace with rprContextSetAOVindexLookupRange when ready

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -104,7 +104,7 @@ std::string GetRprSdkPath() {
 }
 
 void SetupRprTracing() {
-    if (TfGetEnvSetting(RPRUSD_ENABLE_TRACING)) {
+    if (RprUsdIsTracingEnabled()) {
         RPR_ERROR_CHECK(rprContextSetParameterByKey1u(nullptr, RPR_CONTEXT_TRACING_ENABLED, 1), "Failed to set context tracing parameter");
 
         auto tracingDir = TfGetEnvSetting(RPRUSD_TRACING_DIR);
@@ -316,13 +316,13 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
         RPR_ERROR_CHECK(status, "Failed to create RPR context");
     }
 
-    if (TfGetEnvSetting(RPRUSD_ENABLE_TRACING)) {
-        RPR_ERROR_CHECK(context->SetParameter(RPR_CONTEXT_TRACING_ENABLED, 1), "Failed to set context tracing parameter");
-    }
-
     RPR_ERROR_CHECK(context->SetParameter(RPR_CONTEXT_TEXTURE_CACHE_PATH, config->GetTextureCacheDir().c_str()), "Failed to set texture cache path");
 
     return context;
+}
+
+bool RprUsdIsTracingEnabled() {
+    return TfGetEnvSetting(RPRUSD_ENABLE_TRACING);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/contextHelpers.h
+++ b/pxr/imaging/rprUsd/contextHelpers.h
@@ -25,6 +25,9 @@ struct RprUsdContextMetadata;
 RPRUSD_API
 rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata);
 
+RPRUSD_API
+bool RprUsdIsTracingEnabled();
+
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif // PXR_IMAGING_RPR_USD_CONTEXT_HELPERS_H


### PR DESCRIPTION
### PURPOSE
Recent changes (https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/379) lead to undesired behavior - RPR tracing had this line inside of it:
```
rprContextSetParameterByKey1u(context,RPR_CONTEXT_TRACING_ENABLED,(rpr_uint)1);  RPRTRACE_CHECK
```
It means that when you run the trace, the trace itself enables tracing.

So the purpose is to avoid leaking RPR_CONTEXT_TRACING_ENABLED into the trace.

### EFFECT OF CHANGE
None