### PR TITLE
Fix UsdPreviewSurface displacement defined with a constant

### DIFF
--- a/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
@@ -126,6 +126,7 @@ bool RprUsd_UsdPreviewSurface::SetInput(
         return SetRprInput(m_rprNode.get(), RPR_MATERIAL_INPUT_UBER_REFRACTION_IOR, value) == RPR_SUCCESS;
     } else if (UsdPreviewSurfaceTokens->displacement == inputId) {
         if (value.IsHolding<RprMaterialNodePtr>()) {
+            m_displaceNode = nullptr;
             m_displacementOutput = value;
         } else {
             auto vec = GetRprFloat(value);
@@ -135,7 +136,7 @@ bool RprUsd_UsdPreviewSurface::SetInput(
                 }
 
                 m_displaceNode->SetInput(RPR_MATERIAL_INPUT_VALUE, value);
-                m_displacementOutput = VtValue(m_displaceNode);
+                m_displacementOutput = m_displaceNode->GetOutput(TfToken());
             } else {
                 m_displaceNode = nullptr;
                 m_displacementOutput = VtValue();

--- a/pxr/imaging/rprUsd/materialNodes/usdNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.h
@@ -46,7 +46,7 @@ private:
     std::unique_ptr<RprUsd_RprArithmeticNode> m_normalMapBiasNode;
     std::unique_ptr<RprUsd_BaseRuntimeNode> m_normalMapNode;
 
-    std::shared_ptr<RprUsd_BaseRuntimeNode> m_displaceNode;
+    std::unique_ptr<RprUsd_BaseRuntimeNode> m_displaceNode;
     VtValue m_displacementOutput;
 };
 


### PR DESCRIPTION
### PURPOSE
To fix https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/issues/433

### EFFECT OF CHANGE
Fixed UsdPreviewSurface displacement defined with a constant

### TECHNICAL STEPS
Use the output of the displacement node instead of the displacement node itself as a displacement output of the UsdPreviewSurface node.
