### PR TITLE
Generate smooth normals for non-refined subdivision surface

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -386,9 +386,11 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         }
     }
 
-    m_smoothNormals = m_displayStyle.flatShadingEnabled;
+    m_smoothNormals = !m_displayStyle.flatShadingEnabled;
     // Don't compute smooth normals on a refined mesh. They are implicitly smooth.
-    m_smoothNormals = m_smoothNormals && !(m_enableSubdiv && m_refineLevel > 0);
+    if (m_enableSubdiv && m_refineLevel != 0) {
+        m_smoothNormals = false;
+    }
 
     if (!m_authoredNormals && m_smoothNormals) {
         if (!m_adjacencyValid) {


### PR DESCRIPTION
### PURPOSE
Resolve https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/issues/435

### EFFECT OF CHANGE
Non-refined subdivision surface visualized with smooth normals

At the same time, it's still possible to render subdivision surfaces with flat shading if needed by changing mesh display style.

### TECHNICAL STEPS
Generate smooth normals for non-refined subdivision surface

### NOTES FOR REVIEWERS

#### Full quality

##### Before
![kitchen_default](https://user-images.githubusercontent.com/22181845/105546745-6cb63700-5d06-11eb-9291-0ffbf4b47642.png)

##### After
![kitchen_smoothNormals](https://user-images.githubusercontent.com/22181845/105546765-75a70880-5d06-11eb-9c82-d81eba95e5ce.png)

##### Subdivision Level = 1 (for comparison)
![kitchen_subdivided_1](https://user-images.githubusercontent.com/22181845/105546931-a1c28980-5d06-11eb-824c-5999aa2f581b.png)


#### Low quality

##### Before
![kitchen_low_default](https://user-images.githubusercontent.com/22181845/105546920-9e2f0280-5d06-11eb-9b80-c18409a04a66.png)

##### After
![kitchen_low_smoothNormals](https://user-images.githubusercontent.com/22181845/105546950-a8e99780-5d06-11eb-8fce-41f5e8be838c.png)

