### PR TITLE
Update to USD 21.02

### DIFF
--- a/pxr/imaging/plugin/hdRpr/baseRprim.h
+++ b/pxr/imaging/plugin/hdRpr/baseRprim.h
@@ -15,6 +15,7 @@ limitations under the License.
 #define HDRPR_BASE_RPRIM_H
 
 #include "renderParam.h"
+#include "renderDelegate.h"
 
 #include "pxr/imaging/hd/sceneDelegate.h"
 
@@ -24,9 +25,9 @@ template <typename Base>
 class HdRprBaseRprim : public Base {
 public:
     HdRprBaseRprim(
-        SdfPath const& id,
-        SdfPath const& instancerId)
-        : Base(id, instancerId) {
+        SdfPath const& id
+        HDRPR_INSTANCER_ID_ARG_DECL)
+        : Base(id HDRPR_INSTANCER_ID_ARG) {
 
     }
     ~HdRprBaseRprim() override = default;

--- a/pxr/imaging/plugin/hdRpr/basisCurves.cpp
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.cpp
@@ -22,9 +22,9 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-HdRprBasisCurves::HdRprBasisCurves(SdfPath const& id,
-                                   SdfPath const& instancerId)
-    : HdRprBaseRprim(id, instancerId)
+HdRprBasisCurves::HdRprBasisCurves(SdfPath const& id
+                                   HDRPR_INSTANCER_ID_ARG_DECL)
+    : HdRprBaseRprim(id HDRPR_INSTANCER_ID_ARG)
     , m_visibilityMask(kVisibleAll) {
 
 }

--- a/pxr/imaging/plugin/hdRpr/basisCurves.h
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.h
@@ -32,8 +32,7 @@ class HdRprMaterial;
 class HdRprBasisCurves : public HdRprBaseRprim<HdBasisCurves> {
 
 public:
-    HdRprBasisCurves(SdfPath const& id,
-                     SdfPath const& instancerId);
+    HdRprBasisCurves(SdfPath const& id HDRPR_INSTANCER_ID_ARG_DECL);
 
     ~HdRprBasisCurves() override = default;
 

--- a/pxr/imaging/plugin/hdRpr/camera.h
+++ b/pxr/imaging/plugin/hdRpr/camera.h
@@ -22,8 +22,12 @@ limitations under the License.
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdRprCamera : public HdCamera {
-
 public:
+    enum Projection {
+        Perspective = 0,
+        Orthographic
+    };
+
     HdRprCamera(SdfPath const& id);
     ~HdRprCamera() override = default;
 
@@ -43,7 +47,7 @@ public:
     bool GetShutterOpen(double* value) const;
     bool GetShutterClose(double* value) const;
     bool GetClippingRange(GfRange1f* value) const;
-    bool GetProjectionType(TfToken* value) const;
+    bool GetProjection(Projection* value) const;
     HdTimeSampleArray<GfMatrix4d, 2> const& GetTransformSamples() const { return m_transform; }
     int GetApertureBlades() const { return m_apertureBlades; }
 
@@ -62,7 +66,7 @@ private:
     double m_shutterOpen;
     double m_shutterClose;
     GfRange1f m_clippingRange;
-    TfToken m_projectionType;
+    Projection m_projection = Perspective;
     HdTimeSampleArray<GfMatrix4d, 2> m_transform;
 
     mutable HdDirtyBits m_rprDirtyBits = HdCamera::AllDirty;

--- a/pxr/imaging/plugin/hdRpr/distantLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/distantLight.cpp
@@ -19,10 +19,13 @@ limitations under the License.
 #include "pxr/imaging/hd/light.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
 #include "pxr/usd/usdLux/blackbody.h"
-#include "pxr/usd/usdLux/tokens.h"
 #include "pxr/base/gf/matrix4d.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    (angle)
+);
 
 static float computeLightIntensity(float intensity, float exposure) {
     return intensity * exp2(exposure);
@@ -69,7 +72,7 @@ void HdRprDistantLight::Sync(HdSceneDelegate* sceneDelegate,
             }
         }
 
-        float angle = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->angle).Get<float>();
+        float angle = sceneDelegate->GetLightParamValue(id, _tokens->angle).Get<float>();
 
         rprApi->SetDirectionalLightAttributes(m_rprLight, color * computedIntensity, angle * (M_PI / 180.0));
 

--- a/pxr/imaging/plugin/hdRpr/instancer.h
+++ b/pxr/imaging/plugin/hdRpr/instancer.h
@@ -14,6 +14,8 @@ limitations under the License.
 #ifndef HDRPR_INSTANCER_H
 #define HDRPR_INSTANCER_H
 
+#include "renderDelegate.h"
+
 #include "pxr/imaging/hd/instancer.h"
 #include "pxr/imaging/hd/timeSampleArray.h"
 
@@ -32,9 +34,9 @@ class HdRprInstancer : public HdInstancer {
 public:
     HdRprInstancer(
         HdSceneDelegate* delegate,
-        SdfPath const& id,
-        SdfPath const& parentInstancerId) :
-        HdInstancer(delegate, id, parentInstancerId) {
+        SdfPath const& id
+        HDRPR_INSTANCER_ID_ARG_DECL) :
+        HdInstancer(delegate, id HDRPR_INSTANCER_ID_ARG) {
     }
 
     VtMatrix4dArray ComputeTransforms(SdfPath const& prototypeId);

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -34,8 +34,8 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-HdRprMesh::HdRprMesh(SdfPath const& id, SdfPath const& instancerId)
-    : HdRprBaseRprim(id, instancerId)
+HdRprMesh::HdRprMesh(SdfPath const& id HDRPR_INSTANCER_ID_ARG_DECL)
+    : HdRprBaseRprim(id HDRPR_INSTANCER_ID_ARG)
     , m_visibilityMask(kVisibleAll) {
 
 }

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -33,7 +33,7 @@ class HdRprMesh final : public HdRprBaseRprim<HdMesh> {
 public:
     HF_MALLOC_TAG_NEW("new HdRprMesh");
 
-    HdRprMesh(SdfPath const& id, SdfPath const& instancerId = SdfPath());
+    HdRprMesh(SdfPath const& id HDRPR_INSTANCER_ID_ARG_DECL);
     ~HdRprMesh() override = default;
 
     void Sync(HdSceneDelegate* sceneDelegate,

--- a/pxr/imaging/plugin/hdRpr/points.cpp
+++ b/pxr/imaging/plugin/hdRpr/points.cpp
@@ -22,8 +22,8 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-HdRprPoints::HdRprPoints(SdfPath const& id, SdfPath const& instancerId)
-    : HdPoints(id, instancerId)
+HdRprPoints::HdRprPoints(SdfPath const& id HDRPR_INSTANCER_ID_ARG_DECL)
+    : HdPoints(id HDRPR_INSTANCER_ID_ARG)
     , m_visibilityMask(kVisibleAll)
     , m_subdivisionLevel(0) {
 

--- a/pxr/imaging/plugin/hdRpr/points.h
+++ b/pxr/imaging/plugin/hdRpr/points.h
@@ -14,6 +14,8 @@ limitations under the License.
 #ifndef HDRPR_POINTS_H
 #define HDRPR_POINTS_H
 
+#include "renderDelegate.h"
+
 #include "pxr/imaging/hd/points.h"
 
 #include "pxr/base/gf/matrix4f.h"
@@ -26,7 +28,7 @@ class RprUsdMaterial;
 
 class HdRprPoints : public HdPoints {
 public:
-    HdRprPoints(SdfPath const& id, SdfPath const& instancerId);
+    HdRprPoints(SdfPath const& id HDRPR_INSTANCER_ID_ARG_DECL);
 
     ~HdRprPoints() override = default;
 

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -228,9 +228,9 @@ HdRenderPassSharedPtr HdRprDelegate::CreateRenderPass(HdRenderIndex* index,
 }
 
 HdInstancer* HdRprDelegate::CreateInstancer(HdSceneDelegate* delegate,
-                                            SdfPath const& id,
-                                            SdfPath const& instancerId) {
-    return new HdRprInstancer(delegate, id, instancerId);
+                                            SdfPath const& id
+                                            HDRPR_INSTANCER_ID_ARG_DECL) {
+    return new HdRprInstancer(delegate, id HDRPR_INSTANCER_ID_ARG);
 }
 
 void HdRprDelegate::DestroyInstancer(HdInstancer* instancer) {
@@ -238,14 +238,14 @@ void HdRprDelegate::DestroyInstancer(HdInstancer* instancer) {
 }
 
 HdRprim* HdRprDelegate::CreateRprim(TfToken const& typeId,
-                                    SdfPath const& rprimId,
-                                    SdfPath const& instancerId) {
+                                    SdfPath const& rprimId
+                                    HDRPR_INSTANCER_ID_ARG_DECL) {
     if (typeId == HdPrimTypeTokens->mesh) {
-        return new HdRprMesh(rprimId, instancerId);
+        return new HdRprMesh(rprimId HDRPR_INSTANCER_ID_ARG);
     } else if (typeId == HdPrimTypeTokens->basisCurves) {
-        return new HdRprBasisCurves(rprimId, instancerId);
+        return new HdRprBasisCurves(rprimId HDRPR_INSTANCER_ID_ARG);
     } else if (typeId == HdPrimTypeTokens->points) {
-        return new HdRprPoints(rprimId, instancerId);
+        return new HdRprPoints(rprimId HDRPR_INSTANCER_ID_ARG);
     }
 #ifdef USE_VOLUME
     else if (typeId == HdPrimTypeTokens->volume) {

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -21,6 +21,14 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+#if PXR_VERSION >= 2102
+#define HDRPR_INSTANCER_ID_ARG_DECL
+#define HDRPR_INSTANCER_ID_ARG
+#else
+#define HDRPR_INSTANCER_ID_ARG_DECL , SdfPath const& instancerId
+#define HDRPR_INSTANCER_ID_ARG , instancerId
+#endif
+
 class HdRprDiagnosticMgrDelegate;
 class HdRprRenderParam;
 class HdRprApi;
@@ -45,13 +53,13 @@ public:
                                            HdRprimCollection const& collection) override;
 
     HdInstancer* CreateInstancer(HdSceneDelegate* delegate,
-                                 SdfPath const& id,
-                                 SdfPath const& instancerId) override;
+                                 SdfPath const& id
+                                 HDRPR_INSTANCER_ID_ARG_DECL) override;
     void DestroyInstancer(HdInstancer* instancer) override;
 
     HdRprim* CreateRprim(TfToken const& typeId,
-                         SdfPath const& rprimId,
-                         SdfPath const& instancerId) override;
+                         SdfPath const& rprimId
+                         HDRPR_INSTANCER_ID_ARG_DECL) override;
     void DestroyRprim(HdRprim* rPrim) override;
 
     HdSprim* CreateSprim(TfToken const& typeId,

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -21,8 +21,6 @@ limitations under the License.
 #include "pxr/imaging/hd/renderPassState.h"
 #include "pxr/imaging/hd/renderIndex.h"
 
-#include <GL/glew.h>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 HdRprRenderPass::HdRprRenderPass(HdRenderIndex* index,

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1746,17 +1746,17 @@ public:
         float focalLength;
 
         GfVec2f apertureSize;
-        TfToken projectionType;
+        HdRprCamera::Projection projection;
         if (m_hdCamera->GetFocalLength(&focalLength) &&
             m_hdCamera->GetApertureSize(&apertureSize) &&
-            m_hdCamera->GetProjectionType(&projectionType)) {
+            m_hdCamera->GetProjection(&projection)) {
             ApplyAspectRatioPolicy(m_viewportSize, aspectRatioPolicy.value, apertureSize);
             sensorWidth = apertureSize[0];
             sensorHeight = apertureSize[1];
         } else {
             bool isOrthographic = round(m_cameraProjectionMatrix[3][3]) == 1.0;
             if (isOrthographic) {
-                projectionType = UsdGeomTokens->orthographic;
+                projection = HdRprCamera::Orthographic;
 
                 GfVec3f ndcTopLeft(-1.0f, 1.0f, 0.0f);
                 GfVec3f nearPlaneTrace = m_cameraProjectionMatrix.GetInverse().Transform(ndcTopLeft);
@@ -1764,7 +1764,7 @@ public:
                 sensorWidth = std::abs(nearPlaneTrace[0]) * 2.0;
                 sensorHeight = std::abs(nearPlaneTrace[1]) * 2.0;
             } else {
-                projectionType = UsdGeomTokens->perspective;
+                projection = HdRprCamera::Perspective;
 
                 sensorWidth = 1.0f;
                 sensorHeight = 1.0f / aspectRatio;
@@ -1772,7 +1772,7 @@ public:
             }
         }
 
-        if (projectionType == UsdGeomTokens->orthographic) {
+        if (projection == HdRprCamera::Orthographic) {
             RPR_ERROR_CHECK(m_camera->SetMode(RPR_CAMERA_MODE_ORTHOGRAPHIC), "Failed to set camera mode");
             RPR_ERROR_CHECK(m_camera->SetOrthoWidth(sensorWidth), "Failed to set camera ortho width");
             RPR_ERROR_CHECK(m_camera->SetOrthoHeight(sensorHeight), "Failed to set camera ortho height");

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -29,7 +29,7 @@ using json = nlohmann::json;
 #include "renderBuffer.h"
 #include "renderParam.h"
 
-#include "pxr/imaging/glf/glew.h"
+#include "pxr/imaging/rprUsd/util.h"
 #include "pxr/imaging/glf/uvTextureData.h"
 
 #include "pxr/imaging/rprUsd/config.h"
@@ -3350,38 +3350,31 @@ private:
             imageDesc.image_row_pitch = 0;
             imageDesc.image_slice_pitch = 0;
 
-            #if PXR_VERSION >= 2011
-                auto hioFormat = textureData->GetHioFormat();
-                GLenum glType = GlfGetGLType(hioFormat);
-                GLenum glFormat = GlfGetGLFormat(hioFormat);
-            #else
-                GLenum glType = textureData->GLType();
-                GLenum glFormat = textureData->GLFormat();
-            #endif
+            auto textureMetadata = RprUsdGetGlfTextureMetadata(&(*textureData));
 
             uint8_t bytesPerComponent;
-            if (glType == GL_UNSIGNED_BYTE) {
+            if (textureMetadata.glType == GL_UNSIGNED_BYTE) {
                 imageDesc.type = RIF_COMPONENT_TYPE_UINT8;
                 bytesPerComponent = 1;
-            } else if (glType == GL_HALF_FLOAT) {
+            } else if (textureMetadata.glType == GL_HALF_FLOAT) {
                 imageDesc.type = RIF_COMPONENT_TYPE_FLOAT16;
                 bytesPerComponent = 2;
-            } else if (glType == GL_FLOAT) {
+            } else if (textureMetadata.glType == GL_FLOAT) {
                 imageDesc.type = RIF_COMPONENT_TYPE_FLOAT32;
                 bytesPerComponent = 2;
             } else {
-                TF_RUNTIME_ERROR("\"%s\" image has unsupported pixel channel type: %#x", path.c_str(), glType);
+                TF_RUNTIME_ERROR("\"%s\" image has unsupported pixel channel type: %#x", path.c_str(), textureMetadata.glType);
                 return false;
             }
 
-            if (glFormat == GL_RGBA) {
+            if (textureMetadata.glFormat == GL_RGBA) {
                 imageDesc.num_components = 4;
-            } else if (glFormat == GL_RGB) {
+            } else if (textureMetadata.glFormat == GL_RGB) {
                 imageDesc.num_components = 3;
-            } else if (glFormat == GL_RED) {
+            } else if (textureMetadata.glFormat == GL_RED) {
                 imageDesc.num_components = 1;
             } else {
-                TF_RUNTIME_ERROR("\"%s\" image has unsupported pixel format: %#x", path.c_str(), glFormat);
+                TF_RUNTIME_ERROR("\"%s\" image has unsupported pixel format: %#x", path.c_str(), textureMetadata.glFormat);
                 return false;
             }
 

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -16,8 +16,8 @@ limitations under the License.
 #include "pxr/imaging/rprUsd/debugCodes.h"
 #include "pxr/imaging/rprUsd/config.h"
 #include "pxr/imaging/rprUsd/error.h"
+#include "pxr/imaging/rprUsd/util.h"
 
-#include "pxr/imaging/glf/glew.h"
 #include "pxr/base/arch/env.h"
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/envSetting.h"
@@ -266,8 +266,8 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
         if (metadata->renderDeviceType == RprUsdRenderDeviceType::CPU || metadata->pluginType == kPluginHybrid) {
             PRINT_CONTEXT_CREATION_DEBUG_INFO("GL interop could not be used with CPU rendering or Hybrid plugin");
             metadata->isGlInteropEnabled = false;
-        } else if (!GlfGlewInit()) {
-            PRINT_CONTEXT_CREATION_DEBUG_INFO("Failed to init GLEW. Disabling GL interop");
+        } else if (!RprUsdInitGLApi()) {
+            PRINT_CONTEXT_CREATION_DEBUG_INFO("Failed to init GL API. Disabling GL interop");
             metadata->isGlInteropEnabled = false;
         } else {
             metadata->isGlInteropEnabled = true;

--- a/pxr/imaging/rprUsd/coreImage.cpp
+++ b/pxr/imaging/rprUsd/coreImage.cpp
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ************************************************************************/
 
-#include "pxr/imaging/glf/glew.h"
+#include "pxr/imaging/rprUsd/util.h"
 
 #include "pxr/imaging/rprUsd/coreImage.h"
 #include "pxr/imaging/rprUsd/helpers.h"
@@ -132,16 +132,9 @@ std::unique_ptr<uint8_t[]> ConvertTexture(GlfUVTextureData* textureData, rpr::Im
 rpr::Image* CreateRprImage(rpr::Context* context, GlfUVTextureData* textureData, uint32_t numComponentsRequired) {
     rpr::ImageFormat format = {};
 
-#if PXR_VERSION >= 2011
-    auto hioFormat = textureData->GetHioFormat();
-    GLenum glType = GlfGetGLType(hioFormat);
-    GLenum glFormat = GlfGetGLFormat(hioFormat);
-#else
-    GLenum glType = textureData->GLType();
-    GLenum glFormat = textureData->GLFormat();
-#endif
+    auto imageMetadata = RprUsdGetGlfTextureMetadata(textureData);
 
-    switch (glType) {
+    switch (imageMetadata.glType) {
         case GL_UNSIGNED_BYTE:
             format.type = RPR_COMPONENT_TYPE_UINT8;
             break;
@@ -152,11 +145,11 @@ rpr::Image* CreateRprImage(rpr::Context* context, GlfUVTextureData* textureData,
             format.type = RPR_COMPONENT_TYPE_FLOAT32;
             break;
         default:
-            TF_RUNTIME_ERROR("Unsupported pixel data GLtype: %#x", glType);
+            TF_RUNTIME_ERROR("Unsupported pixel data GLtype: %#x", imageMetadata.glType);
             return nullptr;
     }
 
-    switch (glFormat) {
+    switch (imageMetadata.glFormat) {
         case GL_RED:
             format.num_components = 1;
             break;
@@ -167,7 +160,7 @@ rpr::Image* CreateRprImage(rpr::Context* context, GlfUVTextureData* textureData,
             format.num_components = 4;
             break;
         default:
-            TF_RUNTIME_ERROR("Unsupported pixel data GLformat: %#x", glFormat);
+            TF_RUNTIME_ERROR("Unsupported pixel data GLformat: %#x", imageMetadata.glFormat);
             return nullptr;
     }
     rpr::ImageDesc desc = GetRprImageDesc(format, textureData->ResizedWidth(), textureData->ResizedHeight());

--- a/pxr/imaging/rprUsd/imageCache.cpp
+++ b/pxr/imaging/rprUsd/imageCache.cpp
@@ -11,11 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ************************************************************************/
 
-#include "pxr/imaging/glf/glew.h"
+#include "pxr/imaging/rprUsd/util.h"
 #include "pxr/imaging/rprUsd/imageCache.h"
 #include "pxr/imaging/rprUsd/coreImage.h"
 #include "pxr/imaging/rprUsd/helpers.h"
-#include "pxr/imaging/rprUsd/util.h"
 #include "pxr/base/arch/fileSystem.h"
 #include "pxr/base/tf/diagnostic.h"
 
@@ -82,11 +81,7 @@ RprUsdImageCache::GetImage(
         // Assume that all tiles have the same colorspace
         //
         auto data = tiles[0].textureData;
-#if PXR_VERSION >= 2011
-        GLenum internalFormat = GlfGetGLInternalFormat(data->GetHioFormat());
-#else
-        GLenum internalFormat = data->GLInternalFormat();
-#endif
+        GLenum internalFormat = RprUsdGetGlfTextureMetadata(data).internalFormat;
         if (internalFormat == GL_SRGB ||
             internalFormat == GL_SRGB8 ||
             internalFormat == GL_SRGB_ALPHA ||

--- a/pxr/imaging/rprUsd/materialRegistry.cpp
+++ b/pxr/imaging/rprUsd/materialRegistry.cpp
@@ -11,16 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ************************************************************************/
 
-#include "pxr/imaging/glf/glew.h"
+#include "pxr/imaging/rprUsd/util.h"
 #include "pxr/imaging/glf/uvTextureData.h"
-#include "pxr/imaging/glf/image.h"
 #include "pxr/imaging/rprUsd/materialRegistry.h"
 #include "pxr/imaging/rprUsd/imageCache.h"
 #include "pxr/imaging/rprUsd/debugCodes.h"
 #include "pxr/imaging/rprUsd/material.h"
 #include "pxr/imaging/rprUsd/tokens.h"
 #include "pxr/imaging/rprUsd/error.h"
-#include "pxr/imaging/rprUsd/util.h"
 #include "pxr/base/tf/instantiateSingleton.h"
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/envSetting.h"

--- a/pxr/imaging/rprUsd/util.cpp
+++ b/pxr/imaging/rprUsd/util.cpp
@@ -14,6 +14,7 @@ limitations under the License.
 #include "util.h"
 
 #include "pxr/base/tf/staticTokens.h"
+#include "pxr/imaging/glf/utils.h"
 
 #include <cstring>
 
@@ -36,6 +37,33 @@ bool RprUsdGetUDIMFormatString(std::string const& filepath, std::string* out_for
     }
 
     return false;
+}
+
+bool RprUsdInitGLApi() {
+#if PXR_VERSION >= 2102
+    return GarchGLApiLoad();
+#else
+    return GlfGlewInit();
+#endif
+}
+
+RprUsdGlfTextureMetadata RprUsdGetGlfTextureMetadata(GlfUVTextureData* uvTextureData) {
+    RprUsdGlfTextureMetadata ret = {};
+#if PXR_VERSION >= 2011
+#   if PXR_VERSION >= 2102
+    auto hioFormat = uvTextureData->GetFormat();
+#   else
+    auto hioFormat = uvTextureData->GetHioFormat();
+#   endif
+    ret.glType = GlfGetGLType(hioFormat);
+    ret.glFormat = GlfGetGLFormat(hioFormat);
+    ret.internalFormat = GlfGetGLInternalFormat(hioFormat);
+#else
+    ret.internalFormat = uvTextureData->GLInternalFormat();
+    ret.glType = uvTextureData->GLType();
+    ret.glFormat = uvTextureData->GLFormat();
+#endif
+    return ret;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/util.h
+++ b/pxr/imaging/rprUsd/util.h
@@ -14,13 +14,34 @@ limitations under the License.
 #ifndef RPRUSD_UTIL_H
 #define RPRUSD_UTIL_H
 
-#include "pxr/pxr.h"
+#include "pxr/imaging/rprUsd/api.h"
+
+#if PXR_VERSION >= 2102
+#include "pxr/imaging/garch/glApi.h"
+#else
+#include "pxr/imaging/glf/glew.h"
+#endif
+
+#include "pxr/imaging/glf/uvTextureData.h"
 
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+RPRUSD_API
 bool RprUsdGetUDIMFormatString(std::string const& filepath, std::string* out_formatString);
+
+RPRUSD_API
+bool RprUsdInitGLApi();
+
+struct RprUsdGlfTextureMetadata {
+    GLenum glType;
+    GLenum glFormat;
+    GLenum internalFormat;
+};
+
+RPRUSD_API
+RprUsdGlfTextureMetadata RprUsdGetGlfTextureMetadata(GlfUVTextureData* uvTextureData);
 
 PXR_NAMESPACE_CLOSE_SCOPE
 


### PR DESCRIPTION
### PURPOSE
Update to USD 21.02

### EFFECT OF CHANGE
hdRpr is up to date with USD 21.02

### TECHNICAL STEPS
Fixed such USD 21.02 updates:
* removed instancerId from HdInstancer and HdRprim constructors
* removed angle token from UsdLuxTokens
* replaced GLEW with their own GL API loader
* changed GlfUvTextureData format API
* added new camera framing API
* changed projection underlying type from TfToken to HdCamera::Projection

### NOTES FOR REVIEWERS
hdRpr is still compatible with USD down to 19.11.
