### PR TITLE
CIS Houdini python3 workaround

### DIFF
--- a/cmake/modules/FindHoudiniUSD.cmake
+++ b/cmake/modules/FindHoudiniUSD.cmake
@@ -41,7 +41,7 @@ endif(APPLE)
 set(Houdini_Python_VARS Houdini_Python_INCLUDE_DIR Houdini_Python_LIB Houdini_Boostpython_LIB)
 list(APPEND HUSD_REQ_VARS ${Houdini_Python_VARS})
 
-foreach(python_major_minor "2;7" "3;7")
+foreach(python_major_minor "3;7" "2;7")
     list(GET python_major_minor 0 py_major)
     list(GET python_major_minor 1 py_minor)
 


### PR DESCRIPTION
For some reason, the Houdini Python3 installation on CIS contains both py2 and py3 includes. The easiest way to work around this by changing the order of checking for the python version.