### PR TITLE
Fix crash on material update

### DIFF
--- a/pxr/imaging/plugin/hdRpr/baseRprim.h
+++ b/pxr/imaging/plugin/hdRpr/baseRprim.h
@@ -54,8 +54,31 @@ protected:
         }
     }
 
+    void UpdateVisibility(HdSceneDelegate* sceneDelegate) {
+        // XXX (Hydra): HdRprim::CanSkipDirtyBitPropagationAndSync decides whether Rprim can be skipped from syncing.
+        // In short, when Rprim is invisible this function tells HdRenderIndex::SyncAll to skip the primitive.
+        // Ideally, that's what we want but not in the case of RPR. If the invisible Rprim has active material reference
+        // and the referenced material was changed we must resync the Rprim. As there is no way to change the behavior of
+        // HdRprim::CanSkipDirtyBitPropagationAndSync (it's not virtual) to not skip when material was changed,
+        // we make our Rprim to be always visible for this function - it uses HdRprim::IsVisible to check the visibility.
+        _sharedData.visible = true;
+
+        m_isVisible = sceneDelegate->GetVisible(Base::GetId());
+    }
+
+    uint32_t GetVisibilityMask() const {
+        if (!m_isVisible) {
+            // If Rprim is explicitly made invisible, ignore custom visibility mask
+            return kInvisible;
+        }
+
+        return m_visibilityMask;
+    }
+
 protected:
     SdfPath m_materialId;
+    bool m_isVisible = false;
+    uint32_t m_visibilityMask = 0;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/basisCurves.cpp
+++ b/pxr/imaging/plugin/hdRpr/basisCurves.cpp
@@ -137,7 +137,7 @@ void HdRprBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyVisibility) {
-        _sharedData.visible = sceneDelegate->GetVisible(id);
+        UpdateVisibility(sceneDelegate);
     }
 
     if (newCurve) {
@@ -224,12 +224,7 @@ void HdRprBasisCurves::Sync(HdSceneDelegate* sceneDelegate,
         }
 
         if (newCurve || ((*dirtyBits & HdChangeTracker::DirtyVisibility) || isVisibilityMaskDirty)) {
-            auto visibilityMask = m_visibilityMask;
-            if (!_sharedData.visible) {
-                // Override m_visibilityMask
-                visibilityMask = 0;
-            }
-            rprApi->SetCurveVisibility(m_rprCurve, visibilityMask);
+            rprApi->SetCurveVisibility(m_rprCurve, GetVisibilityMask());
         }
 
         if (newCurve || (*dirtyBits & HdChangeTracker::DirtyTransform)) {

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -148,15 +148,6 @@ RprUsdMaterial const* HdRprMesh::GetFallbackMaterial(
     return m_fallbackMaterial;
 }
 
-uint32_t HdRprMesh::GetVisibilityMask() const {
-    if (!_sharedData.visible) {
-        // If mesh is explicitly made invisible, ignore custom visibility mask
-        return kInvisible;
-    }
-
-    return m_visibilityMask;
-}
-
 void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                      HdRenderParam* renderParam,
                      HdDirtyBits* dirtyBits,
@@ -341,7 +332,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyVisibility) {
-        _sharedData.visible = sceneDelegate->GetVisible(id);
+        UpdateVisibility(sceneDelegate);
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -97,7 +97,6 @@ private:
     int m_refineLevel = 0;
 
     int m_id = -1;
-    uint32_t m_visibilityMask = 0;
     bool m_ignoreContour;
 };
 

--- a/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.cpp
+++ b/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.cpp
@@ -80,6 +80,12 @@ OP_ERROR LOP_RPRMaterialProperties::cookMyLop(OP_Context &context) {
     HUSD_AutoWriteLock writelock(editableDataHandle());
     HUSD_AutoLayerLock layerlock(writelock);
 
+    auto data = writelock.data();
+    if (!data) {
+        // This might be the case when there are errors in the current graph
+        return error();
+    }
+
     UsdStageRefPtr stage = writelock.data()->stage();
 
     UsdPrim materialPrim = stage->GetPrimAtPath(materialSdfPath);


### PR DESCRIPTION
### PURPOSE
Fix crashes

### EFFECT OF CHANGE
* Fixed crash after updating material when it's assigned to the invisible mesh.
* Fixed crash when Houdini's graph is in an invalid state (missing file, etc) and "RPR Material Properties" node present.

### TECHNICAL STEPS
* hardcode `_sharedData.visible=true`

### NOTES FOR REVIEWERS
`HdRprim::CanSkipDirtyBitPropagationAndSync` decides whether Rprim can be skipped from syncing. In short, when Rprim is invisible this function tells `HdRenderIndex::SyncAll` to skip the primitive. Ideally, that's what we want but not in the case of RPR. If the invisible Rprim has active material reference and the referenced material was changed we must resync the Rprim. As there is no way to change the behavior of `HdRprim::CanSkipDirtyBitPropagationAndSync` (it's not virtual) to not skip when the material was changed, we make our Rprim to be always visible for this function - it uses `HdRprim::IsVisible` to check the visibility.
