### PR TITLE
Fix computed AOV initialization

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -168,7 +168,7 @@ protected:
 class HdRprApiComputedAov : public HdRprApiAov {
 public:
     HdRprApiComputedAov(HdRprAovDescriptor const& aovDescriptor, int width, int height, HdFormat format)
-        : HdRprApiAov(aovDescriptor, format) {}
+        : HdRprApiAov(aovDescriptor, format), m_width(width), m_height(height) {}
     ~HdRprApiComputedAov() override = default;
 
     void Resize(int width, int height, HdFormat format) override final;


### PR DESCRIPTION
### PURPOSE
Fix invalid initialization of computed AOVs (mask id, depth).

### EFFECT OF CHANGE
None. This bug is from https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/440 that was not released yet.

