### PR TITLE
HdRprConfig invalidation on delegate destruction

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -619,6 +619,8 @@ public:
     void CleanDirtyFlag(ChangeTracker dirtyFlag);
     void ResetDirty();
 
+    void ResetRenderSettingsVersion();
+
 private:
     HdRprConfig() = default;
 
@@ -730,6 +732,10 @@ void HdRprConfig::CleanDirtyFlag(ChangeTracker dirtyFlag) {{
 
 void HdRprConfig::ResetDirty() {{
     m_dirtyFlags = Clean;
+}}
+
+void HdRprConfig::ResetRenderSettingsVersion() {{
+    m_lastRenderSettingsVersion = -1;
 }}
 
 HdRprConfig::PrefData::PrefData() {{

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -189,6 +189,12 @@ HdRprDelegate::HdRprDelegate(HdRenderSettingsMap const& renderSettings) {
 }
 
 HdRprDelegate::~HdRprDelegate() {
+    // Render settings version reset is required for valid recreation of HdRprDelgate
+    // Config singleton persists in memory after delegate destruction, therefore version must be invalidated
+    HdRprConfig* config;
+    auto configInstanceLock = HdRprConfig::GetInstance(&config);
+    config->ResetRenderSettingsVersion();
+
     g_rprApi = nullptr;
 }
 


### PR DESCRIPTION
### PURPOSE
PR is made for use-case when plugin being recreated with different render quality using RenderSettings

### EFFECT OF CHANGE
Improved stability of changing render plugin quality

### TECHNICAL STEPS
Added method to invalidate settings version inside HdRprConfig
Called this method inside destructor of render delegate

### NOTES FOR REVIEWERS
None
