### PR TITLE
Expose environment light background override

### DIFF
--- a/pxr/imaging/plugin/hdRpr/domeLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/domeLight.cpp
@@ -26,6 +26,10 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    ((backgroundOverride, "rpr:backgroundOverride"))
+);
+
 static void removeFirstSlash(std::string& string) {
     // Don't need this for *nix/Mac
 #ifdef _WIN32
@@ -71,6 +75,8 @@ void HdRprDomeLight::Sync(HdSceneDelegate* sceneDelegate,
             return;
         }
 
+        VtValue const& backgroundOverride = sceneDelegate->GetLightParamValue(id, _tokens->backgroundOverride);
+
         float intensity = sceneDelegate->GetLightParamValue(id, HdLightTokens->intensity).Get<float>();
         float exposure = sceneDelegate->GetLightParamValue(id, HdLightTokens->exposure).Get<float>();
         float computedIntensity = computeLightIntensity(intensity, exposure);
@@ -100,9 +106,9 @@ void HdRprDomeLight::Sync(HdSceneDelegate* sceneDelegate,
                 color[2] *= temperatureColor[2];
             }
 
-            m_rprLight = rprApi->CreateEnvironmentLight(color, computedIntensity);
+            m_rprLight = rprApi->CreateEnvironmentLight(color, computedIntensity, backgroundOverride);
         } else {
-            m_rprLight = rprApi->CreateEnvironmentLight(texturePath, computedIntensity);
+            m_rprLight = rprApi->CreateEnvironmentLight(texturePath, computedIntensity, backgroundOverride);
         }
 
         if (m_rprLight) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -71,8 +71,8 @@ public:
     HdRprApi(HdRprDelegate* delegate);
     ~HdRprApi();
 
-    HdRprApiEnvironmentLight* CreateEnvironmentLight(const std::string& pathTotexture, float intensity);
-    HdRprApiEnvironmentLight* CreateEnvironmentLight(GfVec3f color, float intensity);
+    HdRprApiEnvironmentLight* CreateEnvironmentLight(const std::string& pathTotexture, float intensity, VtValue const& backgroundOverride);
+    HdRprApiEnvironmentLight* CreateEnvironmentLight(GfVec3f color, float intensity, VtValue const& backgroundOverride);
     void SetTransform(HdRprApiEnvironmentLight* envLight, GfMatrix4f const& transform);
     void Release(HdRprApiEnvironmentLight* envLight);
 


### PR DESCRIPTION
### PURPOSE
Request from RPRViewer's devs

### EFFECT OF CHANGE
Allow the user to override the environment light background with a custom color by setting `rpr:backgroundOverride` attribute on a dome light object.

<img width="1920" alt="envMapOverridePreview" src="https://user-images.githubusercontent.com/22181845/114318304-41790200-9b15-11eb-87be-579f9a0d30ac.png">
