### PR TITLE
Allow dynamic change of session type

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -78,7 +78,7 @@ render_setting_categories = [
         'name': 'RenderMode',
         'settings': [
             {
-                'name': 'renderMode',
+                'name': 'coreRenderMode',
                 'ui_name': 'Render Mode',
                 'defaultValue': 'Global Illumination',
                 'values': [
@@ -101,13 +101,13 @@ render_setting_categories = [
                 'minValue': 0.0,
                 'maxValue': 100.0,
                 'houdini': {
-                    'hidewhen': 'renderMode != "AmbientOcclusion"'
+                    'hidewhen': 'coreRenderMode != "AmbientOcclusion"'
                 }
             },
             {
                 'folder': 'Contour Settings',
                 'houdini': {
-                    'hidewhen': 'renderMode != "Contour"'
+                    'hidewhen': 'coreRenderMode != "Contour"'
                 },
                 'settings': [
                     {
@@ -117,7 +117,7 @@ render_setting_categories = [
                         'minValue': 0.0,
                         'maxValue': 1.0,
                         'houdini': {
-                            'hidewhen': 'renderMode != "Contour"'
+                            'hidewhen': 'coreRenderMode != "Contour"'
                         }
                     },
                     {
@@ -126,7 +126,7 @@ render_setting_categories = [
                         'defaultValue': True,
                         'help': 'Whether to use geometry normals for edge detection or not',
                         'houdini': {
-                            'hidewhen': 'renderMode != "Contour"'
+                            'hidewhen': 'coreRenderMode != "Contour"'
                         }
                     },
                     {
@@ -137,7 +137,7 @@ render_setting_categories = [
                         'maxValue': 100.0,
                         'help': 'Linewidth of edges detected via normals',
                         'houdini': {
-                            'hidewhen': ['renderMode != "Contour"', 'contourUseNormal == 0']
+                            'hidewhen': ['coreRenderMode != "Contour"', 'contourUseNormal == 0']
                         }
                     },
                     {
@@ -147,7 +147,7 @@ render_setting_categories = [
                         'minValue': 0.0,
                         'maxValue': 180.0,
                         'houdini': {
-                            'hidewhen': ['renderMode != "Contour"', 'contourUseNormal == 0']
+                            'hidewhen': ['coreRenderMode != "Contour"', 'contourUseNormal == 0']
                         }
                     },
                     {
@@ -156,7 +156,7 @@ render_setting_categories = [
                         'defaultValue': True,
                         'help': 'Whether to use primitive Id for edge detection or not',
                         'houdini': {
-                            'hidewhen': 'renderMode != "Contour"'
+                            'hidewhen': 'coreRenderMode != "Contour"'
                         }
                     },
                     {
@@ -167,7 +167,7 @@ render_setting_categories = [
                         'maxValue': 100.0,
                         'help': 'Linewidth of edges detected via primitive Id',
                         'houdini': {
-                            'hidewhen': ['renderMode != "Contour"', 'contourUsePrimId == 0']
+                            'hidewhen': ['coreRenderMode != "Contour"', 'contourUsePrimId == 0']
                         }
                     },
                     {
@@ -176,7 +176,7 @@ render_setting_categories = [
                         'defaultValue': True,
                         'help': 'Whether to use material Id for edge detection or not',
                         'houdini': {
-                            'hidewhen': 'renderMode != "Contour"'
+                            'hidewhen': 'coreRenderMode != "Contour"'
                         }
                     },
                     {
@@ -187,7 +187,7 @@ render_setting_categories = [
                         'maxValue': 100.0,
                         'help': 'Linewidth of edges detected via material Id',
                         'houdini': {
-                            'hidewhen': ['renderMode != "Contour"', 'contourUseMaterialId == 0']
+                            'hidewhen': ['coreRenderMode != "Contour"', 'contourUseMaterialId == 0']
                         }
                     },
                     {
@@ -204,7 +204,7 @@ render_setting_categories = [
                                 ' * cyan - material Id + normal\\n'
                                 ' * black - all',
                         'houdini': {
-                            'hidewhen': 'renderMode != "Contour"'
+                            'hidewhen': 'coreRenderMode != "Contour"'
                         }
                     }
                 ]
@@ -573,6 +573,23 @@ render_setting_categories = [
             {
                 'name': 'rprExportUseImageCache',
                 'defaultValue': False
+            }
+        ]
+    },
+    {
+        'name': 'Session',
+        'settings': [
+            {
+                'name': 'renderMode',
+                'defaultValue': 'interactive',
+                'values': [
+                    SettingValue('batch'),
+                    SettingValue('interactive')
+                ]
+            },
+            {
+                'name': 'progressive',
+                'defaultValue': True
             }
         ]
     }

--- a/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderBuffer.cpp
@@ -92,7 +92,7 @@ void HdRprRenderBuffer::_Deallocate() {
 }
 
 void* HdRprRenderBuffer::Map() {
-    m_rprApi->Resolve();
+    m_rprApi->Resolve(GetId());
 
 #ifdef ENABLE_MULTITHREADED_RENDER_BUFFER
     std::unique_lock<std::mutex> lock(m_mapMutex);

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -118,9 +118,6 @@ private:
 TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (openvdbAsset) \
     (percentDone) \
-    (renderMode) \
-    (batch) \
-    (progressive) \
     (RPR)
 );
 
@@ -157,8 +154,6 @@ HdRprDelegate::HdRprDelegate(HdRenderSettingsMap const& renderSettings) {
         SetRenderSetting(entry.first, entry.second);
     }
 
-    m_isBatch = GetRenderSetting(_tokens->renderMode) == _tokens->batch;
-    m_isProgressive = GetRenderSetting(_tokens->progressive).GetWithDefault(true);
 
     m_rprApi.reset(new HdRprApi(this));
     g_rprApi = m_rprApi.get();

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -94,16 +94,10 @@ public:
     void SetDrivers(HdDriverVector const& drivers) override;
 #endif // PXR_VERSION >= 2005
 
-    bool IsBatch() const { return m_isBatch; }
-    bool IsProgressive() const { return m_isProgressive; }
-
 private:
     static const TfTokenVector SUPPORTED_RPRIM_TYPES;
     static const TfTokenVector SUPPORTED_SPRIM_TYPES;
     static const TfTokenVector SUPPORTED_BPRIM_TYPES;
-
-    bool m_isBatch;
-    bool m_isProgressive;
 
     std::unique_ptr<HdRprApi> m_rprApi;
     std::unique_ptr<HdRprRenderParam> m_renderParam;

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -75,6 +75,12 @@ TF_DEFINE_ENV_SETTING(HDRPR_RENDER_QUALITY_OVERRIDE, "",
 
 namespace {
 
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    (batch)
+    (renderMode)
+    (progressive)
+);
+
 TfToken GetRenderQuality(HdRprConfig const& config) {
     std::string renderQualityOverride = TfGetEnvSetting(HDRPR_RENDER_QUALITY_OVERRIDE);
 
@@ -1475,15 +1481,15 @@ public:
 
     rpr_uint GetRprRenderMode(TfToken const& mode) {
         static std::map<TfToken, rpr_render_mode> s_mapping = {
-            {HdRprRenderModeTokens->GlobalIllumination, RPR_RENDER_MODE_GLOBAL_ILLUMINATION},
-            {HdRprRenderModeTokens->DirectIllumination, RPR_RENDER_MODE_DIRECT_ILLUMINATION},
-            {HdRprRenderModeTokens->Wireframe, RPR_RENDER_MODE_WIREFRAME},
-            {HdRprRenderModeTokens->MaterialIndex, RPR_RENDER_MODE_MATERIAL_INDEX},
-            {HdRprRenderModeTokens->Position, RPR_RENDER_MODE_POSITION},
-            {HdRprRenderModeTokens->Normal, RPR_RENDER_MODE_NORMAL},
-            {HdRprRenderModeTokens->Texcoord, RPR_RENDER_MODE_TEXCOORD},
-            {HdRprRenderModeTokens->AmbientOcclusion, RPR_RENDER_MODE_AMBIENT_OCCLUSION},
-            {HdRprRenderModeTokens->Diffuse, RPR_RENDER_MODE_DIFFUSE},
+            {HdRprCoreRenderModeTokens->GlobalIllumination, RPR_RENDER_MODE_GLOBAL_ILLUMINATION},
+            {HdRprCoreRenderModeTokens->DirectIllumination, RPR_RENDER_MODE_DIRECT_ILLUMINATION},
+            {HdRprCoreRenderModeTokens->Wireframe, RPR_RENDER_MODE_WIREFRAME},
+            {HdRprCoreRenderModeTokens->MaterialIndex, RPR_RENDER_MODE_MATERIAL_INDEX},
+            {HdRprCoreRenderModeTokens->Position, RPR_RENDER_MODE_POSITION},
+            {HdRprCoreRenderModeTokens->Normal, RPR_RENDER_MODE_NORMAL},
+            {HdRprCoreRenderModeTokens->Texcoord, RPR_RENDER_MODE_TEXCOORD},
+            {HdRprCoreRenderModeTokens->AmbientOcclusion, RPR_RENDER_MODE_AMBIENT_OCCLUSION},
+            {HdRprCoreRenderModeTokens->Diffuse, RPR_RENDER_MODE_DIFFUSE},
         };
 
         auto it = s_mapping.find(mode);
@@ -1497,10 +1503,10 @@ public:
         }
         m_dirtyFlags |= ChangeTracker::DirtyScene;
 
-        auto& renderMode = preferences.GetRenderMode();
+        auto& renderMode = preferences.GetCoreRenderMode();
 
         if (m_rprContextMetadata.pluginType == kPluginNorthstar) {
-            if (renderMode == HdRprRenderModeTokens->Contour) {
+            if (renderMode == HdRprCoreRenderModeTokens->Contour) {
                 if (!m_contourAovs) {
                     m_contourAovs = std::make_unique<ContourRenderModeAovs>();
                     m_contourAovs->normal = CreateAov(HdAovTokens->normal);
@@ -1536,7 +1542,7 @@ public:
         }
 
         RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_RENDER_MODE, GetRprRenderMode(renderMode)), "Failed to set render mode");
-        if (renderMode == HdRprRenderModeTokens->AmbientOcclusion) {
+        if (renderMode == HdRprCoreRenderModeTokens->AmbientOcclusion) {
             RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_AO_RAY_LENGTH, preferences.GetAoRadius()), "Failed to set ambient occlusion radius");
         }
     }
@@ -1672,6 +1678,16 @@ public:
             m_isAlphaEnabled = preferences.GetEnableAlpha();
 
             UpdateColorAlpha(m_colorAov.get());
+        }
+
+        if (preferences.IsDirty(HdRprConfig::DirtySession) || force) {
+            m_isProgressive = preferences.GetProgressive();
+            bool isBatch = preferences.GetRenderMode() == HdRprRenderModeTokens->batch;
+            if (m_isBatch != isBatch) {
+                m_isBatch = isBatch;
+                m_batchREM = isBatch ? std::make_unique<BatchRenderEventManager>() : nullptr;
+                m_dirtyFlags |= ChangeTracker::DirtyScene;
+            }
         }
     }
 
@@ -2071,23 +2087,19 @@ public:
             return;
         }
 
-        if (!m_batchREM) {
-            m_batchREM = std::make_unique<BatchRenderEventManager>();
-        }
         auto renderScope = m_batchREM->EnterRenderScope();
 
         EnableRenderUpdateCallback(BatchRenderUpdateCallback);
 
-        // In a batch session, we disable resolving of all samples except the first and last.
-        // Also, if the user will keep progressive mode on, we support snapshoting (resolving intermediate renders)
-
-        // User might decide to completely disable progress updates to maximize performance.
-        // In this case, snapshoting is not available.
-        const bool isProgressive = m_delegate->IsProgressive();
-
         // Also, we try to maximize the number of samples rendered with one rprContextRender call.
         bool isMaximizingContextIterations = false;
-        if (isProgressive) {
+
+        // In a batch session, we disable resolving of all samples except the first and last.
+        // Also, if the user will keep progressive mode on, we support snapshoting (resolving intermediate renders)
+        //
+        // User might decide to completely disable progress updates to maximize performance.
+        // In this case, snapshoting is not available.
+        if (m_isProgressive) {
             // We can keep the ability to log progress and do snapshots
             // while maximizing RPR_CONTEXT_ITERATIONS, only if RUC is supported.
             if (m_isRenderUpdateCallbackEnabled) {
@@ -2391,7 +2403,7 @@ public:
 
         if (m_state == kStateRender) {
             try {
-                if (m_delegate->IsBatch()) {
+                if (m_isBatch) {
                     BatchRenderImpl(renderThread);
                 } else {
                     if (m_rprContextMetadata.pluginType == RprUsdPluginType::kPluginHybrid &&
@@ -2643,7 +2655,7 @@ Don't show this message again?
         RprUsdMaterialRegistry::GetInstance().CommitResources(m_imageCache.get());
     }
 
-    void Resolve() {
+    void Resolve(SdfPath const& aovId) {
         // hdRpr's rendering is implemented asynchronously - rprContextRender spins in the background thread.
         //
         // Resolve works differently depending on the current rendering session type:
@@ -2652,9 +2664,8 @@ Don't show this message again?
         //   * In an interactive session, it simply does nothing because we always resolve
         //      data to HdRenderBuffer as fast as possible. It might change in the future though.
         //
-        if (m_batchREM) {
-            m_batchREM->OnResolveRequest();
-            m_batchREM->WaitUntilNextRenderEvent();
+        if (m_isBatch) {
+            m_batchREM->WaitForResolve(aovId);
         }
     }
 
@@ -3541,32 +3552,37 @@ private:
 
     class BatchRenderEventManager {
     public:
-        void WaitUntilNextRenderEvent() {
+        void WaitForResolve(SdfPath const& aovId) {
+            if (m_signalingAovId.IsEmpty()) {
+                m_signalingAovId = aovId;
+            } else if (m_signalingAovId != aovId) {
+                // When there is more than one bound aov,
+                // we want to avoid blocking resolve for each of them separately.
+                // Instead, block only on the first one only.
+                return;
+            }
+
+            m_isResolveRequested.store(true);
             std::unique_lock<std::mutex> lock(m_renderEventMutex);
             m_renderEventCV.wait(lock, [this]() -> bool { return !m_isRenderInProgress || !m_isResolveRequested; });
         }
 
         class RenderScopeGuard {
         public:
-            RenderScopeGuard(std::atomic<bool>* isRenderInProgress, std::condition_variable* renderEventCV)
-                : m_isRenderInProgress(isRenderInProgress), m_renderEventCV(renderEventCV) {
-                m_isRenderInProgress->store(true);
-                m_renderEventCV->notify_one();
+            RenderScopeGuard(BatchRenderEventManager* rem) : m_rem(rem) {
+                m_rem->m_signalingAovId = SdfPath::EmptyPath();
+                m_rem->m_isRenderInProgress.store(true);
+                m_rem->m_renderEventCV.notify_one();
             }
             ~RenderScopeGuard() {
-                m_isRenderInProgress->store(false);
-                m_renderEventCV->notify_one();
+                m_rem->m_isRenderInProgress.store(false);
+                m_rem->m_renderEventCV.notify_one();
             }
 
         private:
-            std::atomic<bool>* m_isRenderInProgress;
-            std::condition_variable* m_renderEventCV;
+            BatchRenderEventManager* m_rem;
         };
-        RenderScopeGuard EnterRenderScope() { return RenderScopeGuard(&m_isRenderInProgress, &m_renderEventCV); }
-
-        void OnResolveRequest() {
-            m_isResolveRequested.store(true);
-        }
+        RenderScopeGuard EnterRenderScope() { return RenderScopeGuard(this); }
 
         bool IsResolveRequested() const {
             return m_isResolveRequested;
@@ -3582,8 +3598,11 @@ private:
         std::condition_variable m_renderEventCV;
         std::atomic<bool> m_isRenderInProgress{false};
         std::atomic<bool> m_isResolveRequested{false};
+        SdfPath m_signalingAovId;
     };
     std::unique_ptr<BatchRenderEventManager> m_batchREM;
+    std::atomic<bool> m_isBatch{false};
+    bool m_isProgressive;
 
     struct ResolveData {
         struct AovEntry {
@@ -3904,8 +3923,8 @@ void HdRprApi::CommitResources() {
     m_impl->CommitResources();
 }
 
-void HdRprApi::Resolve() {
-    m_impl->Resolve();
+void HdRprApi::Resolve(SdfPath const& aovId) {
+    m_impl->Resolve(aovId);
 }
 
 void HdRprApi::Render(HdRprRenderThread* renderThread) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -158,7 +158,7 @@ public:
     RenderStats GetRenderStats() const;
 
     void CommitResources();
-    void Resolve();
+    void Resolve(SdfPath const& aovId);
     void Render(HdRprRenderThread* renderThread);
     void AbortRender();
 


### PR DESCRIPTION
### PURPOSE
Optimize final rendering in RPRViewer.

### EFFECT OF CHANGE
* Speed up rendering via husk in case of multiple render products
* Allow dynamic change of session type (batch/interactive)

### NOTES FOR REVIEWERS
Previously, it was possible to enter batch session only at the time of render delegate initialization.
These changes move the handling of the corresponding render setting to HdRprConfig thus allowing interactive change of the session type. Also, fixed the case when there are few AOVs to resolve - previously each resolve call would block separately.

As a side effect, it was required to rename renderMode render setting that controlled rpr_render_mode to coreRenderMode to avoid conflicts with Houdini's renderMode render settings that control session type.
