### PR TITLE
Fix crash on macOS when using RPR Material Library and simplify its installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,12 @@ Launch either usdview or Houdini's Solaris viewport and select RPR as the render
 *   `HDRPR_TRACING_DIR`
 
     To change the default directory, add the environment variable `HDRPR_TRACING_DIR` pointing to the location in which you wish the trace files to be recorded. For example, set `HDRPR_TRACING_DIR=C:\folder\` to activate the tracing in `C:\folder\`.
+
+Houdini
+-----------------------------
+
+##### RPR Material Library
+
+1. Download [.mtlx version of RPR Material Library](https://drive.google.com/file/d/1i5jdYGS7gmrxw_Y0y7uotx4gxXVr8cMB/view?usp=sharing).
+
+2. Follow instructions from INSTALL.md shipped with the material library.

--- a/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
+++ b/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
@@ -25,14 +25,29 @@ GroupSources(RPR_for_Houdini)
 houdini_configure_target(RPR_for_Houdini "INSTDIR" "${CMAKE_INSTALL_PREFIX}/houdini/dso")
 
 set(HOUDINI_MAJOR_MINOR_VERSION "${Houdini_VERSION_MAJOR}.${Houdini_VERSION_MINOR}")
-configure_file(activateHoudiniPlugin.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/activateHoudiniPlugin.cpp)
-add_executable(activateHoudiniPlugin ${CMAKE_CURRENT_BINARY_DIR}/activateHoudiniPlugin.cpp)
-set_property(TARGET activateHoudiniPlugin PROPERTY CXX_STANDARD 11)
-target_link_libraries(activateHoudiniPlugin PRIVATE ghc_filesystem)
-target_compile_definitions(activateHoudiniPlugin PRIVATE GHC_WIN_WSTRING_STRING_TYPE)
-install(
-    TARGETS activateHoudiniPlugin
-    RUNTIME DESTINATION .)
+configure_file(houdiniPluginActivator.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/houdiniPluginActivator.cpp)
+
+function(add_plugin_activator name)
+    add_executable(${name} ${name}.cpp)
+    set_property(TARGET ${name} PROPERTY CXX_STANDARD 11)
+    target_link_libraries(${name} PRIVATE ghc_filesystem)
+    target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+    target_compile_definitions(${name} PRIVATE GHC_WIN_WSTRING_STRING_TYPE)
+endfunction()
+
+add_plugin_activator(activateHoudiniPlugin)
+install(TARGETS activateHoudiniPlugin RUNTIME DESTINATION .)
+
+if(RPR_INSTALL_MATLIB_PACKAGE)
+    add_plugin_activator(activateMatlibPlugin)
+    install(TARGETS activateMatlibPlugin RUNTIME DESTINATION MaterialLibrary)
+
+    install(
+        FILES ${CMAKE_CURRENT_SOURCE_DIR}/MatLib_INSTALL.md
+        DESTINATION MaterialLibrary
+        RENAME INSTALL.md)
+endif()
+
 install(
     FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/hda/rpr_exportRpr1.hda

--- a/pxr/imaging/plugin/rprHoudini/MatLib_INSTALL.md
+++ b/pxr/imaging/plugin/rprHoudini/MatLib_INSTALL.md
@@ -1,0 +1,25 @@
+## Installation
+
+### Automatic
+
+Run `activateMatlibPlugin`. It will find your houdini preference dir and add material library package that will point to the current directory.
+
+### Manual
+
+Add a new Houdini package with such configuration json:
+```
+{
+    "env":[
+        {
+            "RPR_MTLX_MATERIAL_LIBRARY_PATH":"path-to-the-package"
+        }
+    ]
+}
+```
+where `path-to-the-package` depends on where do you unzip the material library package and should point to the directory that contains INSTALL.md (this file)
+
+More info here https://www.sidefx.com/docs/houdini/ref/plugins.html
+
+## Feedback
+
+In case you encounter any issues or would like to make a feature request, please post an "issue" on our official [GitHub repository](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/issues)

--- a/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp
+++ b/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp
@@ -1,0 +1,18 @@
+#include "houdiniPluginActivator.cpp"
+
+int main() {
+    int exitCode = ActivateHoudiniPlugin("RPR_for_Houdini", {
+        {"RPR", ""},
+        {"HOUDINI_PATH", "/houdini"},
+        {"PYTHONPATH", "/lib/python"},
+#if defined(_WIN32) || defined(_WIN64)
+        {"PATH", "/lib"}
+#endif
+    });
+
+#if defined(_WIN32) || defined(_WIN64)
+    system("pause");
+#endif
+
+    return exitCode;
+}

--- a/pxr/imaging/plugin/rprHoudini/activateMatlibPlugin.cpp
+++ b/pxr/imaging/plugin/rprHoudini/activateMatlibPlugin.cpp
@@ -1,0 +1,13 @@
+#include "houdiniPluginActivator.cpp"
+
+int main() {
+    int exitCode = ActivateHoudiniPlugin("RPR_MaterialLibrary", {
+    	{"RPR_MTLX_MATERIAL_LIBRARY_PATH", ""}
+    });
+
+#if defined(_WIN32) || defined(_WIN64)
+    system("pause");
+#endif
+
+    return exitCode;
+}

--- a/pxr/imaging/plugin/rprHoudini/houdiniPluginActivator.cpp.in
+++ b/pxr/imaging/plugin/rprHoudini/houdiniPluginActivator.cpp.in
@@ -186,7 +186,7 @@ fs::path GetHoudiniUserPrefDir(const char* hver) {
     return {};
 }
 
-int ActivateHoudiniPlugin() {
+int ActivateHoudiniPlugin(std::string const& pluginName, std::vector<std::pair<const char*, const char*>> const& env) {
     auto houdiniUserPrefDir = GetHoudiniUserPrefDir("@HOUDINI_MAJOR_MINOR_VERSION@");
     if (houdiniUserPrefDir.empty()) {
         std::cout << "Can not determine HOUDINI_USER_PREF_DIR. Please check your environment and specify HOUDINI_USER_PREF_DIR" << std::endl;
@@ -200,28 +200,19 @@ int ActivateHoudiniPlugin() {
         return EXIT_FAILURE;
     }
 
-    auto rprPath = executablePath.parent_path().string();
-    std::replace(rprPath.begin(), rprPath.end(), '\\', '/');
-    std::cout << "RPR path: " << rprPath << std::endl;
+    auto package = executablePath.parent_path().lexically_normal().string();
+    std::replace(package.begin(), package.end(), '\\', '/');
+    std::cout << "Package path: " << package << std::endl;
 
     auto packagesDir = houdiniUserPrefDir / "packages";
     fs::create_directories(packagesDir);
 
-    auto packageJsonFilepath = packagesDir / "RPR_for_Houdini.json";
+    auto packageJsonFilepath = packagesDir / (pluginName + ".json");
     std::ofstream packageJson(packageJsonFilepath);
     if (!packageJson.is_open()) {
         std::cout << "Failed to open output file: " << packageJsonFilepath << std::endl;
         return EXIT_FAILURE;
     }
-
-    std::vector<std::pair<const char*, const char*>> env = {
-        {"RPR", ""},
-        {"HOUDINI_PATH", "/houdini"},
-        {"PYTHONPATH", "/lib/python"},
-#if defined(_WIN32) || defined(_WIN64)
-        {"PATH", "/lib"}
-#endif
-    };
 
     packageJson << '{';
     packageJson << '\"' << "env" << '\"';
@@ -232,7 +223,7 @@ int ActivateHoudiniPlugin() {
         packageJson << '\"' << it->first << '\"';
         packageJson << ':';
         packageJson << '\"';
-        packageJson << rprPath << it->second;
+        packageJson << package << it->second;
         packageJson << '\"';
         packageJson << '}';
         if (std::next(it) != env.end()) {
@@ -247,16 +238,6 @@ int ActivateHoudiniPlugin() {
         return EXIT_FAILURE;
     }
 
-    std::cout << "Successfully activated RPR plugin" << std::endl;
+    std::cout << "Successfully activated the plugin" << std::endl;
     return EXIT_SUCCESS;
-}
-
-int main() {
-    int exitCode = ActivateHoudiniPlugin();
-
-#if defined(_WIN32) || defined(_WIN64)
-    system("pause");
-#endif
-
-    return exitCode;
 }


### PR DESCRIPTION
### PURPOSE
Resolve #453

### EFFECT OF CHANGE
Fixed crash on macOS on first use of the RPR Material Library.

### NOTES FOR REVIEWERS
The exact reason of the crash is not clear to me. I localized it to the usage of HTML in QMessageBox that displayed installation steps.
So to minimize HTML usage here I reworked the installation process a bit.
