### PR TITLE
Fixed cyrillic typos in some .mtlx files.

### DIFF
--- a/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Shaders/rpr_blend.mtlx
+++ b/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Shaders/rpr_blend.mtlx
@@ -4,7 +4,7 @@
       <input name="color0" type="surfaceshader" uiname="Shader 1."/>
       <input name="color1" type="surfaceshader" uiname="Shader 2."/>
       <input name="weight" type="float" value="0" uimin="0" uimax="1" uiname="Weight" doc="Weight of blend."/>
-      <input name="transmission_color" type="color3" value="1,1,1" uimin="0,0,0" uimax="1,1,1" uiname="Color" doc="Transmission color between сolor0 and сolor1."/>
+      <input name="transmission_color" type="color3" value="1,1,1" uimin="0,0,0" uimax="1,1,1" uiname="Color" doc="Transmission color between color0 and color1."/>
       <input name="thickness" type="float" value="0.5" uimin="0" uimax="1" uiname="Thickness" doc="Thickness of transmission layer between color0 and color1."/>
       <output name="surface" type="surfaceshader" />
   </nodedef>

--- a/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Shaders/rpr_orennayar.mtlx
+++ b/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Shaders/rpr_orennayar.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <materialx version="1.37">
-  <nodedef name="ND_rpr_orennayar" node="rpr_orennayar" uiname="RPR Oren–Nayar" doc="Represents rough diffuse surfaces, used for materials like sand, concrete, etc.">
+  <nodedef name="ND_rpr_orennayar" node="rpr_orennayar" uiname="RPR Oren-Nayar" doc="Represents rough diffuse surfaces, used for materials like sand, concrete, etc.">
       <input name="color" type="color3" value="1,1,1" uimin="0,0,0" uimax="1,1,1" uiname="Color" doc="Diffuse color."/>
       <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" doc="Normal direction used for shading."/>
       <input name="roughness" type="float" value="0" uimin="0" uimax="1" uiname="Roughness" doc="Diffuse Rougness"/>

--- a/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Shaders/rpr_refraction.mtlx
+++ b/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Shaders/rpr_refraction.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <materialx version="1.37">
-  <nodedef name="ND_rpr_refraction" node="rpr_refraction" uiname="RPR Refraction" doc="Represents perfectly smooth refractive materials which allow light to transmit through and bend due to Snell’s law, like glass.">
+  <nodedef name="ND_rpr_refraction" node="rpr_refraction" uiname="RPR Refraction" doc="Represents perfectly smooth refractive materials which allow light to transmit through and bend due to Snell's law, like glass.">
       <input name="color" type="color3" value="1,1,1" uimin="0,0,0" uimax="1,1,1" uiname="Color" doc="Refraction color. White is perfectly transparent."/>
       <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" doc="Normal direction used for shading."/>
       <input name="ior" type="float" value="1.5" uimin="1" uisoftmax="5" uiname="IOR" doc="Index of refraction, usually 1-5."/>


### PR DESCRIPTION
### PURPOSE
There are several typos with cyrillic characters in some .mtlx files. They were found during importing RPR MaterialX nodes into Blender USD plugin.

### EFFECT OF CHANGE
Fixed typos with cyrillic characters in some .mtlx files

