### PR TITLE
Update MaterialX to 1.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Provide USD in one of two ways:
 ##### MaterialX Component
 
 By default, MaterialX library will be compiled from the sources located under a MaterialX submodule `deps/MaterialX`.
-You can override this behavior by providing a complete build of MaterialX to cmake. Please note, on Linux for Houdini plugin, MaterialX should be compiled with `-D_GLIBCXX_USE_CXX11_ABI=0` definition as it is required by Houdini.
+You can override this behavior by providing a complete build of MaterialX to cmake. Please note, on Linux for Houdini plugin, MaterialX should be compiled with `-D_GLIBCXX_USE_CXX11_ABI=0` definition as it is required by Houdini. Currently supported version of MaterialX is v1.38.
 
 ##### Optional Components
 

--- a/deps/rprMtlxLoader/rprMtlxLoader.cpp
+++ b/deps/rprMtlxLoader/rprMtlxLoader.cpp
@@ -650,7 +650,7 @@ bool StringStartsWith(std::string const& string, const char(&prefix)[N]) {
 
 mx::NodeGraphPtr GetNodeGraphImpl(mx::NodeDef* nodeDef) {
     static std::string universal("universal");
-    if (auto impl = nodeDef->getImplementation(mx::EMPTY_STRING, universal)) {
+    if (auto impl = nodeDef->getImplementation()) {
         return impl->asA<mx::NodeGraph>();
     }
     return nullptr;
@@ -1310,9 +1310,9 @@ Node::Ptr Node::Create(mx::Node* mtlxNode, LoaderContext* context) {
         // TODO: implement healthy man swizzle
 
         std::string channels;
-        if (auto channelsParam = mtlxNode->getActiveParameter("channels")) {
-            auto& valueString = channelsParam->getValueString();
-            if (channelsParam->getType() == "string" &&
+        if (auto channelsInput = mtlxNode->getActiveInput("channels")) {
+            auto& valueString = channelsInput->getValueString();
+            if (channelsInput->getType() == "string" &&
                 !valueString.empty()) {
                 channels = valueString;
             }
@@ -1751,9 +1751,8 @@ bool GetInputF(mx::TypedElement* downstreamElement, mx::ValueElement* upstreamEl
         dst[0] = dst[1] = dst[2] = value;
         dst[3] = 0.0f;
     } else if (
-        valueType == "vector2" ||
-        valueType == "color2") {
-        auto value = mx::fromValueString<mx::Color2>(valueString);
+        valueType == "vector2") {
+        auto value = mx::fromValueString<mx::Vector2>(valueString);
         dst[0] = value[0];
         dst[1] = value[1];
         dst[2] = dst[3] = 0.0f;
@@ -2137,38 +2136,22 @@ bool IsRenderableType(std::string const& mtlxTypeString) {
 // Returned boolean controls whether ForEachOutput should continue traversing
 template <typename F>
 void ForEachOutput(mx::ElementPtr const& element, F&& func) {
-    if (auto material = element->asA<mx::Material>()) {
-        for (auto& shaderRef : material->getShaderRefs()) {
-            if (auto nodeDef = shaderRef->getNodeDef()) {
-                if (IsSupportedTarget(nodeDef->getTarget())) {
-                    if (auto nodeGraph = GetNodeGraphImpl(nodeDef.get())) {
-                        for (auto& child : nodeGraph->getChildren()) {
-                            if (auto output = child->asA<mx::Output>()) {
-                                if (!func(output, shaderRef)) {
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    } else if (auto nodeGraph = element->asA<mx::NodeGraph>()) {
+    if (auto nodeGraph = element->asA<mx::NodeGraph>()) {
         for (auto& child : nodeGraph->getChildren()) {
             if (auto output = child->asA<mx::Output>()) {
-                if (!func(output, nullptr)) {
+                if (!func(output)) {
                     return;
                 }
             }
         }
     } else if (auto output = element->asA<mx::Output>()) {
-        func(output, nullptr);
+        func(output);
     } else if (auto node = element->asA<mx::Node>()) {
         auto processShaderNode = [&func](mx::NodePtr const& shaderNode) {
             auto referenceOutput = std::make_shared<mx::Output>(shaderNode->getParent(), "out");
             referenceOutput->setNodeName(shaderNode->getName());
             referenceOutput->setType(shaderNode->getType());
-            return func(referenceOutput, nullptr);
+            return func(referenceOutput);
         };
 
         auto& nodeType = node->getType();
@@ -2192,19 +2175,6 @@ void ForEachOutput(mx::ElementPtr const& element, F&& func) {
             }
         }
     }
-}
-
-bool IsMaterialHasRenderableOutputs(mx::MaterialPtr const& material) {
-    bool hasRenderableOutput = false;
-    ForEachOutput(material,
-        [&hasRenderableOutput](mx::OutputPtr const& output, mx::ShaderRefPtr const&) {
-        if (IsRenderableType(output->getType())) {
-            hasRenderableOutput = true;
-        }
-        // Keep iterating untill we find a renderable output
-        return !hasRenderableOutput;
-    });
-    return hasRenderableOutput;
 }
 
 // Alternative to mx::Element::getChildrenOfType. This function avoids using std::vector.
@@ -2236,32 +2206,32 @@ void ForEachRenderableElement(mx::Document const* mtlxDocument, S&& shouldStop, 
                 }
             }
         );
-    });
+        });
 
-    ForEachChildrenOfType<mx::Material>(mtlxDocument, shouldStop,
-        [&func](auto const& material) {
-            if (IsMaterialHasRenderableOutputs(material)) {
-                func(material);
+    ForEachChildrenOfType<mx::Node>(mtlxDocument, shouldStop,
+        [&func](auto const& node) {
+            if (node->getType() == "material") {
+
             }
         }
     );
 
-    auto mtlxVersion = mtlxDocument->getVersionIntegers();
-    if (mtlxVersion.first >= 1 && mtlxVersion.second >= 38) {
-        // Iterate over all global shader nodes
-        //
-        ForEachChildrenOfType<mx::Node>(mtlxDocument, shouldStop,
-            [&func, &mtlxDocument](auto const& node) {
-                if (!node->hasSourceUri()) {
-                    if (auto typeDef = mtlxDocument->getTypeDef(node->getType())) {
-                        if (typeDef->getSemantic() == mx::SHADER_SEMANTIC) {
-                            func(node);
-                        }
+    // Iterate over all global shader nodes
+    //
+    ForEachChildrenOfType<mx::Node>(mtlxDocument, shouldStop,
+        [&func, &mtlxDocument](auto const& node) {
+            if (!node->hasSourceUri()) {
+                auto& type = node->getType();
+                if (type == "material") {
+                    func(node);
+                } else if (auto typeDef = mtlxDocument->getTypeDef(type)) {
+                    if (typeDef->getSemantic() == mx::SHADER_SEMANTIC) {
+                        func(node);
                     }
                 }
             }
-        );
-    }
+        }
+    );
 
     ForEachChildrenOfType<mx::NodeGraph>(mtlxDocument, shouldStop,
         [&func](auto const& nodeGraph) {
@@ -2311,17 +2281,15 @@ void TraverseNode(Node* node, F&& cb) {
 
 struct GraphNodesKey {
     mx::GraphElement const* nodeGraph;
-    mx::ShaderRef const* shaderRef;
 
     struct Hash {
         size_t operator()(GraphNodesKey const& key) const {
-            return GetHash(key.nodeGraph) ^ GetHash(key.shaderRef);
+            return GetHash(key.nodeGraph);
         }
     };
 
     bool operator==(GraphNodesKey const& rhs) const {
-        return nodeGraph == rhs.nodeGraph &&
-               shaderRef == rhs.shaderRef;
+        return nodeGraph == rhs.nodeGraph;
     }
 };
 struct GraphNodesValue {
@@ -2377,7 +2345,7 @@ RPRMtlxLoader::RenderableElements RPRMtlxLoader::GetRenderableElements(mx::Docum
             processedElements.insert(mtlxElement.get());
 
             bool elementOutputTypes[kOutputsTotal] = {};
-            ForEachOutput(mtlxElement, [&elementOutputTypes](mx::OutputPtr const& output, mx::ShaderRefPtr const&) {
+            ForEachOutput(mtlxElement, [&elementOutputTypes](mx::OutputPtr const& output) {
                 auto outputType = ToOutputType(output->getType());
                 if (outputType != kOutputNone) {
                     elementOutputTypes[outputType] = true;
@@ -2454,8 +2422,8 @@ RPRMtlxLoader::Result RPRMtlxLoader::Load(
                 return;
             }
 
-            ForEachOutput(element, [this, outputType](mx::OutputPtr const& output, mx::ShaderRefPtr const& shaderRef) {
-                _Add(outputType, output, shaderRef);
+            ForEachOutput(element, [this, outputType](mx::OutputPtr const& output) {
+                _Add(outputType, output);
 
                 // Keep iterating until we find renderable element
                 return !Exists(outputType);
@@ -2464,7 +2432,7 @@ RPRMtlxLoader::Result RPRMtlxLoader::Load(
 
         void Disable(RPRMtlxLoader::OutputType outputType) {
             _activeElementsBits |= 1u << outputType;
-            _elements[outputType] = {};
+            _outputs[outputType] = {};
         }
 
         bool IsEmpty() const {
@@ -2482,14 +2450,10 @@ RPRMtlxLoader::Result RPRMtlxLoader::Load(
             return _activeElementsBits & (1u << outputType);
         }
 
-        struct Element {
-            mx::OutputPtr output;
-            mx::ShaderRefPtr shaderRef;
-        };
-        Element const& Get(RPRMtlxLoader::OutputType type) const { return _elements[type]; }
+        mx::OutputPtr const& Get(RPRMtlxLoader::OutputType type) const { return _outputs[type]; }
 
     private:
-        void _Add(RPRMtlxLoader::OutputType outputType, mx::OutputPtr const& output, mx::ShaderRefPtr const& shaderRef) {
+        void _Add(RPRMtlxLoader::OutputType outputType, mx::OutputPtr const& output) {
             // Validate output type
             //
             auto actualOutputType = ToOutputType(output->getType());
@@ -2505,14 +2469,14 @@ RPRMtlxLoader::Result RPRMtlxLoader::Load(
 
                 uint8_t outputTypeBit = 1u << actualOutputType;
                 if ((_activeElementsBits & outputTypeBit) == 0) {
-                    _elements[actualOutputType] = {output, shaderRef};
+                    _outputs[actualOutputType] = output;
                     _activeElementsBits |= outputTypeBit;
                 }
             }
         }
 
     private:
-        Element _elements[RPRMtlxLoader::kOutputsTotal];
+        mx::OutputPtr _outputs[RPRMtlxLoader::kOutputsTotal];
 
         uint8_t _activeElementsBits = 0u;
         enum { kAllElementsBits = (1u << RPRMtlxLoader::kOutputsTotal) - 1 };
@@ -2563,25 +2527,13 @@ RPRMtlxLoader::Result RPRMtlxLoader::Load(
     for (int i = 0; i < kOutputsTotal; ++i) {
         auto outputType = static_cast<OutputType>(i);
 
-        auto& element = renderableElements.Get(outputType);
-        if (!element.output) {
-            continue;
-        }
-
-        mx::ConstGraphElementPtr nodeGraph;
-        if (element.shaderRef) {
-            if (auto nodeDef = element.shaderRef->getNodeDef()) {
-                nodeGraph = GetNodeGraphImpl(nodeDef.get());
+        if (auto& output = renderableElements.Get(outputType)) {
+            if (auto nodeGraph = output->getParent()->asA<mx::GraphElement>()) {
+                GraphNodesKey graphNodesKey{nodeGraph.get()};
+                graphNodes[graphNodesKey].outputTypes.push_back(outputType);
             }
-        } else {
-            nodeGraph = element.output->getParent()->asA<mx::GraphElement>();
         }
-        if (!nodeGraph) {
-            continue;
-        }
-
-        GraphNodesKey graphNodesKey{nodeGraph.get(), element.shaderRef.get()};
-        graphNodes[graphNodesKey].outputTypes.push_back(outputType);
+        
     }
 
     // Create MtlxNodeGraphNode for each nodeGraph-shaderRef pair
@@ -2591,33 +2543,13 @@ RPRMtlxLoader::Result RPRMtlxLoader::Load(
     for (auto& entry : graphNodes) {
         std::vector<mx::OutputPtr> requiredOutputs;
         for (auto outputType : entry.second.outputTypes) {
-            requiredOutputs.push_back(renderableElements.Get(outputType).output);
+            requiredOutputs.push_back(renderableElements.Get(outputType));
         }
 
         try {
             auto nodeGraph = entry.first.nodeGraph->getSelf()->asA<mx::GraphElement>();
 
             entry.second.node = std::make_unique<MtlxNodeGraphNode>(nodeGraph, requiredOutputs, &ctx);
-
-            if (entry.first.shaderRef) {
-                ForEachChildrenOfType<mx::BindInput>(entry.first.shaderRef,
-                    []() { return false; },
-                    [&ctx, node=entry.second.node.get()](mx::BindInputPtr const& bindInput) {
-                        if (ctx.ConnectToGlobalOutput(bindInput.get(), node)) {
-                            return;
-                        }
-
-                        auto& valueStr = bindInput->getValueString();
-                        if (!valueStr.empty()) {
-                            auto& type = bindInput->getType();
-
-                            LOG(&ctx, "Bindinput %s: %s (%s)", bindInput->getName().c_str(), valueStr.c_str(), type.c_str());
-
-                            node->SetInput(bindInput.get(), bindInput.get(), &ctx);
-                        }
-                    }
-                );
-            }
         } catch (MtlxNodeGraphNode::NoOutputsError&) {
             continue;
         }


### PR DESCRIPTION
### PURPOSE
To include the latest fixes to mtlx stdlib and other stuff in hdRpr.

### EFFECT OF CHANGE
MaterialX 1.37 is not supported anymore. See [changelist](https://www.materialx.org/assets/MaterialX.v1.38.Changelist.pdf).

