### PR TITLE
Add toon shader node

### DIFF
--- a/pxr/imaging/rprUsd/CMakeLists.txt
+++ b/pxr/imaging/rprUsd/CMakeLists.txt
@@ -61,6 +61,7 @@ target_sources(rprUsd PRIVATE
     materialNodes/rpr/baseNode.h
     materialNodes/rpr/baseNode.cpp
     materialNodes/rpr/nodeInfo.h
+    materialNodes/rpr/toonNode.cpp
     materialNodes/rpr/catcherNode.cpp
     materialNodes/rpr/displaceNode.cpp
     materialNodes/rpr/materialXNode.cpp

--- a/pxr/imaging/rprUsd/materialNodes/rpr/arithmeticNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/arithmeticNode.cpp
@@ -9,6 +9,13 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    (color0)
+    (color1)
+    (color2)
+    (color3)
+);
+
 template<typename T>
 RprUsd_MaterialNode* RprUsd_CreateRprNode(
     RprUsd_MaterialBuilderContext* ctx,
@@ -33,7 +40,7 @@ RprUsd_RprNodeInfo* GetNodeInfo() {
 
     for (int i = 0; i < Node::kArity; ++i) {
         RprUsd_RprNodeInput input(RprUsd_RprNodeInput::kColor3);
-        input.name = TfStringPrintf("color%d", i);
+        input.name = _tokens->allTokens[i];
         input.uiName = TfStringPrintf("Color %d", i);
         input.valueString = "0,0,0";
         input.uiSoftMin = "0";

--- a/pxr/imaging/rprUsd/materialNodes/rpr/catcherNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/catcherNode.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(RprUsdRprCatcherNodeTokens,
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (in)
     (enable)
 );
@@ -49,10 +49,10 @@ public:
     bool SetInput(
         TfToken const& inputId,
         VtValue const& value) override {
-        if (inputId == RprUsdRprCatcherNodeTokens->in) {
+        if (inputId == _tokens->in) {
             m_output = value;
             return true;
-        } else if (inputId == RprUsdRprCatcherNodeTokens->enable) {
+        } else if (inputId == _tokens->enable) {
             if (value.IsHolding<int>()) {
                 *m_catcherToggle = value.UncheckedGet<int>() != 0;
                 return true;
@@ -72,11 +72,11 @@ public:
         nodeInfo.name = "rpr_" + catcherType + "_catcher";
 
         RprUsd_RprNodeInput in(RprUsdMaterialNodeElement::kSurfaceShader);
-        in.name = "in";
+        in.name = _tokens->in;
         nodeInfo.inputs.push_back(in);
 
         RprUsd_RprNodeInput enable(RprUsdMaterialNodeElement::kBoolean);
-        enable.name = "enable";
+        enable.name = _tokens->enable;
         enable.uiName = "Enable";
         enable.valueString = "true";
         nodeInfo.inputs.push_back(enable);

--- a/pxr/imaging/rprUsd/materialNodes/rpr/combineShadersNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/combineShadersNode.cpp
@@ -72,17 +72,17 @@ public:
         nodeInfo.uiFolder = "Shaders";
 
         RprUsd_RprNodeInput surfaceInput(RprUsdMaterialNodeElement::kSurfaceShader);
-        surfaceInput.name = "surface";
+        surfaceInput.name = HdMaterialTerminalTokens->surface;
         surfaceInput.uiName = "Surface Shader";
         nodeInfo.inputs.push_back(surfaceInput);
 
         RprUsd_RprNodeInput displacementInput(RprUsdMaterialNodeElement::kDisplacementShader);
-        displacementInput.name = "displacement";
+        displacementInput.name = HdMaterialTerminalTokens->displacement;
         displacementInput.uiName = "Displacement Shader";
         nodeInfo.inputs.push_back(displacementInput);
 
         RprUsd_RprNodeInput volumeInput(RprUsdMaterialNodeElement::kVolumeShader);
-        volumeInput.name = "volume";
+        volumeInput.name = HdMaterialTerminalTokens->volume;
         volumeInput.uiName = "Volume Shader";
         nodeInfo.inputs.push_back(volumeInput);
 

--- a/pxr/imaging/rprUsd/materialNodes/rpr/displaceNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/displaceNode.cpp
@@ -20,7 +20,7 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(RprUsdRprDisplaceNodeTokens,
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (minscale)
     (maxscale)
     (in)
@@ -54,7 +54,7 @@ public:
     bool SetInput(
         TfToken const& inputId,
         VtValue const& value) override {
-        if (inputId == RprUsdRprDisplaceNodeTokens->minscale) {
+        if (inputId == _tokens->minscale) {
             if (value.IsHolding<float>()) {
                 m_displacementScale[0] = value.UncheckedGet<float>();
             } else {
@@ -62,7 +62,7 @@ public:
                 m_displacementScale[0] = 0.0f;
                 return false;
             }
-        } else if (inputId == RprUsdRprDisplaceNodeTokens->maxscale) {
+        } else if (inputId == _tokens->maxscale) {
             if (value.IsHolding<float>()) {
                 m_displacementScale[1] = value.UncheckedGet<float>();
             } else {
@@ -70,7 +70,7 @@ public:
                 m_displacementScale[1] = 1.0f;
                 return false;
             }
-        } else if (inputId == RprUsdRprDisplaceNodeTokens->in) {
+        } else if (inputId == _tokens->in) {
             if (value.IsHolding<std::shared_ptr<rpr::MaterialNode>>()) {
                 m_output = value;
             } else {
@@ -104,16 +104,16 @@ public:
         input.uiSoftMin = "0";
         input.uiSoftMax = "1";
 
-        input.name = "in";
+        input.name = _tokens->in;
         input.uiName = "Displacement";
         input.valueString = "0";
         nodeInfo.inputs.push_back(input);
 
-        input.name = "minscale";
+        input.name = _tokens->minscale;
         input.uiName = "Minimum Scale";
         nodeInfo.inputs.push_back(input);
 
-        input.name = "maxscale";
+        input.name = _tokens->maxscale;
         input.uiName = "Maximum Scale";
         input.valueString = "1";
         nodeInfo.inputs.push_back(input);

--- a/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
@@ -367,33 +367,33 @@ public:
         nodeInfo.uiFolder = "Shaders";
 
         RprUsd_RprNodeInput fileInput(RprUsdMaterialNodeElement::kFilepath);
-        fileInput.name = RprUsdRprMaterialXNodeTokens->file.GetText();
+        fileInput.name = RprUsdRprMaterialXNodeTokens->file;
         fileInput.uiName = "File";
         nodeInfo.inputs.push_back(fileInput);
 
         RprUsd_RprNodeInput stringInput(RprUsdMaterialNodeElement::kString);
-        stringInput.name = RprUsdRprMaterialXNodeTokens->string.GetText();
+        stringInput.name = RprUsdRprMaterialXNodeTokens->string;
         stringInput.uiName = ""; // hide from UI
         nodeInfo.inputs.push_back(stringInput);
 
         RprUsd_RprNodeInput basePathInput(RprUsdMaterialNodeElement::kString);
-        basePathInput.name = RprUsdRprMaterialXNodeTokens->basePath.GetText();
+        basePathInput.name = RprUsdRprMaterialXNodeTokens->basePath;
         basePathInput.uiName = ""; // hide from UI
         nodeInfo.inputs.push_back(basePathInput);
 
         RprUsd_RprNodeInput stPrimvarNameInput(RprUsdMaterialNodeElement::kString);
-        stPrimvarNameInput.name = RprUsdRprMaterialXNodeTokens->stPrimvarName.GetText();
+        stPrimvarNameInput.name = RprUsdRprMaterialXNodeTokens->stPrimvarName;
         stPrimvarNameInput.uiName = "UV Primvar Name";
         stPrimvarNameInput.valueString = "st";
         nodeInfo.inputs.push_back(stPrimvarNameInput);
 
         RprUsd_RprNodeInput surfaceElementInput(RprUsdMaterialNodeElement::kString);
-        surfaceElementInput.name = RprUsdRprMaterialXNodeTokens->surfaceElement.GetText();
+        surfaceElementInput.name = RprUsdRprMaterialXNodeTokens->surfaceElement;
         surfaceElementInput.uiName = "Surface Element";
         nodeInfo.inputs.push_back(surfaceElementInput);
 
         RprUsd_RprNodeInput displacementElementInput(RprUsdMaterialNodeElement::kString);
-        displacementElementInput.name = RprUsdRprMaterialXNodeTokens->displacementElement.GetText();
+        displacementElementInput.name = RprUsdRprMaterialXNodeTokens->displacementElement;
         displacementElementInput.uiName = "Displacement Element";
         nodeInfo.inputs.push_back(displacementElementInput);
 

--- a/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
@@ -1,0 +1,172 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#include "baseNode.h"
+#include "nodeInfo.h"
+
+#include "pxr/imaging/rprUsd/materialHelpers.h"
+#include "pxr/base/arch/attributes.h"
+#include "pxr/base/gf/vec3f.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    (roughness)
+    (normal)
+    (shadowColor)
+    (midLevel)
+    (midLevelMix)
+    (midColor)
+    (highlightLevel)
+    (highlightLevelMix)
+    (highlightColor)
+    (interpolationMode)
+    (Linear)
+    (None)
+);
+
+template <typename ExpectedType, typename SmartPtr>
+bool ProcessInput(TfToken const& inputId, VtValue const& inputValue, SmartPtr const& rprNode, rpr::MaterialNodeInput rprInput) {
+    if (inputValue.IsHolding<ExpectedType>() ||
+        inputValue.IsHolding<RprMaterialNodePtr>()) {
+        return SetRprInput(rprNode.get(), rprInput, inputValue) == RPR_SUCCESS;
+    }
+    TF_RUNTIME_ERROR("Input `%s` has invalid type: %s, expected - %s", inputId.GetText(), inputValue.GetTypeName().c_str(), TfType::Find<ExpectedType>().GetTypeName().c_str());
+    return false;
+}
+
+/// \class RprUsd_RprToonNode
+///
+/// The node that wraps RPR nodes required to setup correct RPR toon shader.
+///
+class RprUsd_RprToonNode : public RprUsd_MaterialNode {
+public:
+    RprUsd_RprToonNode(RprUsd_MaterialBuilderContext* ctx) {
+
+        rpr::Status status;
+        m_toonClosureNode.reset(ctx->rprContext->CreateMaterialNode(RPR_MATERIAL_NODE_TOON_CLOSURE, &status));
+        if (!m_toonClosureNode) {
+            throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to create toon closure node", ctx->rprContext));
+        }
+        m_rampNode.reset(ctx->rprContext->CreateMaterialNode(RPR_MATERIAL_NODE_TOON_RAMP, &status));
+        if (!m_rampNode) {
+            throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to create toon ramp node", ctx->rprContext));
+        }
+        status = m_toonClosureNode->SetInput(RPR_MATERIAL_INPUT_DIFFUSE_RAMP, m_rampNode.get());
+        if (status != RPR_SUCCESS) {
+            throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to set ramp node input of closure node", ctx->rprContext));
+        }
+    }
+    ~RprUsd_RprToonNode() override = default;
+
+    VtValue GetOutput(TfToken const& outputId) override {
+        return VtValue(m_toonClosureNode);
+    }
+
+    bool SetInput(
+        TfToken const& id,
+        VtValue const& value) override {
+        if (id == _tokens->shadowColor) {
+            return ProcessInput<GfVec3f>(id, value, m_rampNode, RPR_MATERIAL_INPUT_SHADOW);
+        } else if (id == _tokens->midLevel) {
+            return ProcessInput<float>(id, value, m_rampNode, RPR_MATERIAL_INPUT_POSITION1);
+        } else if (id == _tokens->midLevelMix) {
+            return ProcessInput<float>(id, value, m_rampNode, RPR_MATERIAL_INPUT_RANGE1);
+        } else if (id == _tokens->midColor) {
+            return ProcessInput<GfVec3f>(id, value, m_rampNode, RPR_MATERIAL_INPUT_MID);
+        } else if (id == _tokens->highlightLevel) {
+            return ProcessInput<float>(id, value, m_rampNode, RPR_MATERIAL_INPUT_POSITION2);
+        } else if (id == _tokens->highlightLevelMix) {
+            return ProcessInput<float>(id, value, m_rampNode, RPR_MATERIAL_INPUT_RANGE2);
+        } else if (id == _tokens->highlightColor) {
+            return ProcessInput<GfVec3f>(id, value, m_rampNode, RPR_MATERIAL_INPUT_HIGHLIGHT);
+        } else if (id == _tokens->interpolationMode) {
+            if (value.IsHolding<int>()) {
+                int interpolationModeInt = value.UncheckedGet<int>();
+                auto interpolationMode =  !interpolationModeInt ? RPR_INTERPOLATION_MODE_NONE : RPR_INTERPOLATION_MODE_LINEAR;
+                return m_rampNode->SetInput(RPR_MATERIAL_INPUT_INTERPOLATION, interpolationMode) == RPR_SUCCESS;
+            }
+            TF_RUNTIME_ERROR("Input `%s` has invalid type: %s, expected - `Token`", id.GetText(), value.GetTypeName().c_str());
+            return false;
+        } else if (id == _tokens->roughness) {
+            return ProcessInput<float>(id, value, m_toonClosureNode, RPR_MATERIAL_INPUT_ROUGHNESS);
+        } else if (id == _tokens->normal) {
+            return ProcessInput<GfVec3f>(id, value, m_toonClosureNode, RPR_MATERIAL_INPUT_NORMAL);
+        }
+
+        TF_RUNTIME_ERROR("Unknown input `%s` for RPR Toon node", id.GetText());
+        return false;
+    }
+
+    static RprUsd_RprNodeInfo* GetInfo() {
+        static RprUsd_RprNodeInfo* ret = nullptr;
+        if (ret) {
+            return ret;
+        }
+
+        ret = new RprUsd_RprNodeInfo;
+        auto& nodeInfo = *ret;
+
+        nodeInfo.name = "rpr_toon";
+        nodeInfo.uiName = "RPR Toon";
+        nodeInfo.uiFolder = "Shaders";
+
+        nodeInfo.inputs.emplace_back(_tokens->shadowColor, GfVec3f(0.0f));
+
+        nodeInfo.inputs.emplace_back(_tokens->midLevel, 0.5f);
+        nodeInfo.inputs.emplace_back(_tokens->midLevelMix, 0.05f);
+        nodeInfo.inputs.emplace_back(_tokens->midColor, GfVec3f(0.4f));
+        nodeInfo.inputs.emplace_back(_tokens->highlightLevel, 0.8f);
+        nodeInfo.inputs.emplace_back(_tokens->highlightLevelMix, 0.05f);
+        nodeInfo.inputs.emplace_back(_tokens->highlightColor, GfVec3f(0.8f));
+
+        RprUsd_RprNodeInput interpolationModeInput(_tokens->interpolationMode, _tokens->None);
+        interpolationModeInput.value = VtValue(0);
+        interpolationModeInput.tokenValues = {_tokens->None, _tokens->Linear};
+        nodeInfo.inputs.push_back(interpolationModeInput);
+
+        nodeInfo.inputs.emplace_back(_tokens->roughness, 1.0f);
+        nodeInfo.inputs.emplace_back(_tokens->normal, GfVec3f(0.0f), RprUsdMaterialNodeElement::kVector3, "");
+
+        RprUsd_RprNodeOutput output(RprUsdMaterialNodeElement::kSurfaceShader);
+        output.name = "surface";
+        nodeInfo.outputs.push_back(output);
+
+        return ret;
+    }
+
+private:
+    std::unique_ptr<rpr::MaterialNode> m_rampNode;
+    std::shared_ptr<rpr::MaterialNode> m_toonClosureNode;
+};
+
+ARCH_CONSTRUCTOR(RprUsd_InitDisplaceNode, 255, void) {
+    auto nodeInfo = RprUsd_RprToonNode::GetInfo();
+    RprUsdMaterialRegistry::GetInstance().Register(
+        TfToken(nodeInfo->name, TfToken::Immortal),
+        [](RprUsd_MaterialBuilderContext* context, std::map<TfToken, VtValue> const& parameters) {
+            auto node = new RprUsd_RprToonNode(context);
+            for (auto& input : RprUsd_RprToonNode::GetInfo()->inputs) {
+                auto it = parameters.find(input.name);
+                if (it == parameters.end()) {
+                    node->SetInput(input.name, input.value);
+                } else {
+                    node->SetInput(input.name, it->second);
+                }
+            }
+            return node;
+        },
+        nodeInfo);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### PURPOSE
Adds a toon shader node for users

### EFFECT OF CHANGE
Users can create toon shader looks. 

### NOTES FOR REVIEWERS
Currently, there is no way to easily implement dynamic UI like in the blender - such functionality is simply not available and should be implemented on our own. So this PR adds an analog of the toon shader from the blender in an advanced mode with all parameters always visible. I've added dynamic UI functionality to my TODO list but obviously it requires time, of which I don't have enough right now.