### PR TITLE
Add support of deformation motion blur

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -73,43 +73,6 @@ void HdRprMesh::_InitRepr(TfToken const& reprName,
     // No-op
 }
 
-template <typename T>
-bool HdRprMesh::GetPrimvarData(TfToken const& name,
-                               HdSceneDelegate* sceneDelegate,
-                               std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation,
-                               VtArray<T>& out_data,
-                               VtIntArray& out_indices) {
-    out_data.clear();
-    out_indices.clear();
-
-    for (auto& primvarDescsEntry : primvarDescsPerInterpolation) {
-        for (auto& pv : primvarDescsEntry.second) {
-            if (pv.name == name) {
-                auto value = GetPrimvar(sceneDelegate, name);
-                if (value.IsHolding<VtArray<T>>()) {
-                    out_data = value.UncheckedGet<VtArray<T>>();
-                    if (primvarDescsEntry.first == HdInterpolationFaceVarying) {
-                        out_indices.reserve(m_faceVertexIndices.size());
-                        for (int i = 0; i < m_faceVertexIndices.size(); ++i) {
-                            out_indices.push_back(i);
-                        }
-                    } else if (primvarDescsEntry.first == HdInterpolationConstant) {
-                        out_indices = VtIntArray(m_faceVertexIndices.size(), 0);
-                    }
-                    return true;
-                }
-
-                TF_RUNTIME_ERROR("Failed to load %s primvar data: unexpected underlying type - %s", name.GetText(), value.GetTypeName().c_str());
-                return false;
-            }
-        }
-    }
-
-    return false;
-}
-template bool HdRprMesh::GetPrimvarData<GfVec2f>(TfToken const&, HdSceneDelegate*, std::map<HdInterpolation, HdPrimvarDescriptorVector> const&, VtArray<GfVec2f>&, VtIntArray&);
-template bool HdRprMesh::GetPrimvarData<GfVec3f>(TfToken const&, HdSceneDelegate*, std::map<HdInterpolation, HdPrimvarDescriptorVector> const&, VtArray<GfVec3f>&, VtIntArray&);
-
 RprUsdMaterial const* HdRprMesh::GetFallbackMaterial(
     HdSceneDelegate* sceneDelegate,
     HdRprApi* rprApi,
@@ -163,6 +126,56 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
     bool newMesh = false;
 
+    std::map<HdInterpolation, HdPrimvarDescriptorVector> primvarDescsPerInterpolation;
+
+    bool isRefineLevelDirty = false;
+    if (*dirtyBits & HdChangeTracker::DirtyDisplayStyle) {
+        m_displayStyle = sceneDelegate->GetDisplayStyle(id);
+        if (m_refineLevel != m_displayStyle.refineLevel) {
+            isRefineLevelDirty = true;
+            m_refineLevel = m_displayStyle.refineLevel;
+        }
+    }
+
+    bool isIgnoreContourDirty = false;
+    bool isVisibilityMaskDirty = false;
+    bool isIdDirty = false;
+    if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
+        HdRprGeometrySettings geomSettings = {};
+        geomSettings.visibilityMask = kVisibleAll;
+        HdRprFillPrimvarDescsPerInterpolation(sceneDelegate, id, &primvarDescsPerInterpolation);
+        HdRprParseGeometrySettings(sceneDelegate, id, primvarDescsPerInterpolation, &geomSettings);
+
+        if (m_refineLevel != geomSettings.subdivisionLevel) {
+            m_refineLevel = geomSettings.subdivisionLevel;
+            isRefineLevelDirty = true;
+        }
+
+        if (m_visibilityMask != geomSettings.visibilityMask) {
+            m_visibilityMask = geomSettings.visibilityMask;
+            isVisibilityMaskDirty = true;
+        }
+
+        if (m_id != geomSettings.id) {
+            m_id = geomSettings.id;
+            isIdDirty = true;
+        }
+
+        if (m_ignoreContour != geomSettings.ignoreContour) {
+            m_ignoreContour = geomSettings.ignoreContour;
+            isIgnoreContourDirty = true;
+        }
+
+        if (m_cryptomatteName != geomSettings.cryptomatteName) {
+            m_cryptomatteName = geomSettings.cryptomatteName;
+        }
+
+        if (m_numGeometrySamples != geomSettings.numGeometrySamples) {
+            m_numGeometrySamples = geomSettings.numGeometrySamples;
+            *dirtyBits |= HdChangeTracker::DirtyPoints | HdChangeTracker::DirtyNormals;
+        }
+    }
+
     bool pointsIsComputed = false;
     auto extComputationDescs = sceneDelegate->GetExtComputationPrimvarDescriptors(id, HdInterpolationVertex);
     for (auto& desc : extComputationDescs) {
@@ -171,10 +184,11 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         }
 
         if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, desc.name)) {
+            // TODO: deformation motion blur for UsdSkel
             auto valueStore = HdExtComputationUtils::GetComputedPrimvarValues({desc}, sceneDelegate);
             auto pointValueIt = valueStore.find(desc.name);
             if (pointValueIt != valueStore.end()) {
-                m_points = pointValueIt->second.Get<VtVec3fArray>();
+                m_pointSamples = {pointValueIt->second.Get<VtVec3fArray>()};
                 m_normalsValid = false;
                 pointsIsComputed = true;
 
@@ -187,10 +201,11 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
     if (!pointsIsComputed &&
         HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->points)) {
-        VtValue pointsValue = sceneDelegate->Get(id, HdTokens->points);
-        m_points = pointsValue.Get<VtVec3fArray>();
-        m_normalsValid = false;
+        if (!HdRprSamplePrimvar(id, HdTokens->points, sceneDelegate, m_numGeometrySamples, &m_pointSamples)) {
+            m_pointSamples.clear();
+        }
 
+        m_normalsValid = false;
         newMesh = true;
     }
 
@@ -279,11 +294,16 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         newMesh = true;
     }
 
-    std::map<HdInterpolation, HdPrimvarDescriptorVector> primvarDescsPerInterpolation;
-
     if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->normals)) {
         HdRprFillPrimvarDescsPerInterpolation(sceneDelegate, id, &primvarDescsPerInterpolation);
-        m_authoredNormals = GetPrimvarData(HdTokens->normals, sceneDelegate, primvarDescsPerInterpolation, m_normals, m_normalIndices);
+        HdInterpolation interpolation;
+        m_authoredNormals = HdRprSamplePrimvar(id, HdTokens->normals, sceneDelegate, primvarDescsPerInterpolation, m_numGeometrySamples, &m_normalSamples, &interpolation);
+        if (m_authoredNormals) {
+            HdRprGetPrimvarIndices(interpolation, m_faceVertexIndices, &m_normalIndices);
+        } else {
+            m_normalSamples.clear();
+            m_normalIndices.clear();
+        }
 
         newMesh = true;
     }
@@ -323,7 +343,14 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
         if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, *uvPrimvarName)) {
             HdRprFillPrimvarDescsPerInterpolation(sceneDelegate, id, &primvarDescsPerInterpolation);
-            GetPrimvarData(*uvPrimvarName, sceneDelegate, primvarDescsPerInterpolation, m_uvs, m_uvIndices);
+
+            HdInterpolation interpolation;
+            if (HdRprSamplePrimvar(id, *uvPrimvarName, sceneDelegate, primvarDescsPerInterpolation, m_numGeometrySamples, &m_uvSamples, &interpolation)) {
+                HdRprGetPrimvarIndices(interpolation, m_faceVertexIndices, &m_uvIndices);
+            } else {
+                m_uvSamples.clear();
+                m_uvIndices.clear();
+            }
 
             newMesh = true;
         }
@@ -335,51 +362,6 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
     ////////////////////////////////////////////////////////////////////////
     // 2. Resolve drawstyles
-
-    bool isRefineLevelDirty = false;
-    if (*dirtyBits & HdChangeTracker::DirtyDisplayStyle) {
-        m_displayStyle = sceneDelegate->GetDisplayStyle(id);
-        if (m_refineLevel != m_displayStyle.refineLevel) {
-            isRefineLevelDirty = true;
-            m_refineLevel = m_displayStyle.refineLevel;
-        }
-    }
-
-    bool isIgnoreContourDirty = false;
-    bool isVisibilityMaskDirty = false;
-    bool isIdDirty = false;
-    if (*dirtyBits & HdChangeTracker::DirtyPrimvar) {
-        HdRprGeometrySettings geomSettings = {};
-        geomSettings.visibilityMask = kVisibleAll;
-        HdRprFillPrimvarDescsPerInterpolation(sceneDelegate, id, &primvarDescsPerInterpolation);
-        HdRprParseGeometrySettings(sceneDelegate, id, primvarDescsPerInterpolation, &geomSettings);
-
-        if (m_refineLevel != geomSettings.subdivisionLevel) {
-            m_refineLevel = geomSettings.subdivisionLevel;
-            isRefineLevelDirty = true;
-        }
-
-        if (m_visibilityMask != geomSettings.visibilityMask) {
-            m_visibilityMask = geomSettings.visibilityMask;
-            isVisibilityMaskDirty = true;
-        }
-
-        if (m_id != geomSettings.id) {
-            m_id = geomSettings.id;
-            isIdDirty = true;
-        }
-
-        if (m_ignoreContour != geomSettings.ignoreContour) {
-            m_ignoreContour = geomSettings.ignoreContour;
-            isIgnoreContourDirty = true;
-        }
-
-        if (m_cryptomatteName != geomSettings.cryptomatteName) {
-            m_cryptomatteName = geomSettings.cryptomatteName;
-        }
-    }
-
-    isIdDirty |= *dirtyBits & HdChangeTracker::DirtyPrimID;
 
     m_smoothNormals = !m_displayStyle.flatShadingEnabled;
     // Don't compute smooth normals on a refined mesh. They are implicitly smooth.
@@ -395,7 +377,10 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         }
 
         if (!m_normalsValid) {
-            m_normals = Hd_SmoothNormals::ComputeSmoothNormals(&m_adjacency, m_points.size(), m_points.cdata());
+            m_normalSamples.clear();
+            for (auto& points : m_pointSamples) {
+                m_normalSamples.push_back(Hd_SmoothNormals::ComputeSmoothNormals(&m_adjacency, points.size(), points.cdata()));
+            }
             m_normalsValid = true;
 
             newMesh = true;
@@ -424,7 +409,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         m_rprMeshes.clear();
 
         if (m_geomSubsets.empty()) {
-            if (auto rprMesh = rprApi->CreateMesh(m_points, m_faceVertexIndices, m_normals, m_normalIndices, m_uvs, m_uvIndices, m_faceVertexCounts, m_topology.GetOrientation())) {
+            if (auto rprMesh = rprApi->CreateMesh(m_pointSamples, m_faceVertexIndices, m_normalSamples, m_normalIndices, m_uvSamples, m_uvIndices, m_faceVertexCounts, m_topology.GetOrientation())) {
                 m_rprMeshes.push_back(rprMesh);
             }
         } else {
@@ -450,24 +435,24 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                     continue;
                 }
 
-                VtVec3fArray subsetPoints;
-                VtVec3fArray subsetNormals;
-                VtVec2fArray subsetUv;
+                VtArray<VtVec3fArray> subsetPointSamples(m_pointSamples.size());
+                VtArray<VtVec3fArray> subsetNormalSamples(m_normalSamples.size());
+                VtArray<VtVec2fArray> subsetUvSamples(m_uvSamples.size());
                 VtIntArray subsetNormalIndices;
                 VtIntArray subsetUvIndices;
                 VtIntArray subsetIndexes;
                 VtIntArray subsetVertexPerFace;
                 subsetVertexPerFace.reserve(subset.indices.size());
 
-                vertexIndexRemapping.reserve(m_points.size());
-                std::fill(vertexIndexRemapping.begin(), vertexIndexRemapping.begin() + m_points.size(), -1);
+                vertexIndexRemapping.reserve(m_pointSamples.front().size());
+                std::fill(vertexIndexRemapping.begin(), vertexIndexRemapping.begin() + m_pointSamples.front().size(), -1);
                 if (!m_normalIndices.empty()) {
-                    normalIndexRemapping.reserve(m_normals.size());
-                    std::fill(normalIndexRemapping.begin(), normalIndexRemapping.begin() + m_normals.size(), -1);
+                    normalIndexRemapping.reserve(m_normalSamples.front().size());
+                    std::fill(normalIndexRemapping.begin(), normalIndexRemapping.begin() + m_normalSamples.front().size(), -1);
                 }
                 if (!m_uvIndices.empty()) {
-                    uvIndexRemapping.reserve(m_uvs.size());
-                    std::fill(uvIndexRemapping.begin(), uvIndexRemapping.begin() + m_uvs.size(), -1);
+                    uvIndexRemapping.reserve(m_uvSamples.front().size());
+                    std::fill(uvIndexRemapping.begin(), uvIndexRemapping.begin() + m_uvSamples.front().size(), -1);
                 }
 
                 for (auto faceIndex : subset.indices) {
@@ -482,44 +467,54 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
                         bool newPoint = subsetPointIndex == -1;
                         if (newPoint) {
-                            subsetPointIndex = static_cast<int>(subsetPoints.size());
+                            subsetPointIndex = static_cast<int>(subsetPointSamples.front().size());
                             vertexIndexRemapping[pointIndex] = subsetPointIndex;
 
-                            subsetPoints.push_back(m_points[pointIndex]);
+                            for (int sampleIndex = 0; sampleIndex < m_pointSamples.size(); ++sampleIndex) {
+                                subsetPointSamples[sampleIndex].push_back(m_pointSamples[sampleIndex][pointIndex]);
+                            }
                         }
                         subsetIndexes.push_back(subsetPointIndex);
 
-                        if (!m_normals.empty()) {
+                        if (!m_normalSamples.empty()) {
                             if (m_normalIndices.empty()) {
                                 if (newPoint) {
-                                    subsetNormals.push_back(m_normals[pointIndex]);
+                                    for (int sampleIndex = 0; sampleIndex < m_normalSamples.size(); ++sampleIndex) {
+                                        subsetNormalSamples[sampleIndex].push_back(m_normalSamples[sampleIndex][pointIndex]);
+                                    }
                                 }
                             } else {
                                 const int normalIndex = m_normalIndices[faceIndexesOffset + i];
                                 int subsetNormalIndex = normalIndexRemapping[normalIndex];
                                 if (subsetNormalIndex == -1) {
-                                    subsetNormalIndex = static_cast<int>(subsetNormals.size());
+                                    subsetNormalIndex = static_cast<int>(subsetNormalSamples.front().size());
                                     normalIndexRemapping[normalIndex] = subsetNormalIndex;
 
-                                    subsetNormals.push_back(m_normals[normalIndex]);
+                                    for (int sampleIndex = 0; sampleIndex < m_normalSamples.size(); ++sampleIndex) {
+                                        subsetNormalSamples[sampleIndex].push_back(m_normalSamples[sampleIndex][normalIndex]);
+                                    }
                                 }
                                 subsetNormalIndices.push_back(subsetNormalIndex);
                             }
                         }
 
-                        if (!m_uvs.empty()) {
+                        if (!m_uvSamples.empty()) {
                             if (m_uvIndices.empty()) {
                                 if (newPoint) {
-                                    subsetUv.push_back(m_uvs[pointIndex]);
+                                    for (int sampleIndex = 0; sampleIndex < m_uvSamples.size(); ++sampleIndex) {
+                                        subsetUvSamples[sampleIndex].push_back(m_uvSamples[sampleIndex][pointIndex]);
+                                    }
                                 }
                             } else {
                                 const int uvIndex = m_uvIndices[faceIndexesOffset + i];
                                 int subsetuvIndex = uvIndexRemapping[uvIndex];
                                 if (subsetuvIndex == -1) {
-                                    subsetuvIndex = static_cast<int>(subsetUv.size());
+                                    subsetuvIndex = static_cast<int>(subsetUvSamples.front().size());
                                     uvIndexRemapping[uvIndex] = subsetuvIndex;
 
-                                    subsetUv.push_back(m_uvs[uvIndex]);
+                                    for (int sampleIndex = 0; sampleIndex < m_uvSamples.size(); ++sampleIndex) {
+                                        subsetUvSamples[sampleIndex].push_back(m_uvSamples[sampleIndex][uvIndex]);
+                                    }
                                 }
                                 subsetUvIndices.push_back(subsetuvIndex);
                             }
@@ -527,7 +522,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                     }
                 }
 
-                if (auto rprMesh = rprApi->CreateMesh(subsetPoints, subsetIndexes, subsetNormals, subsetNormalIndices, subsetUv, subsetUvIndices, subsetVertexPerFace, m_topology.GetOrientation())) {
+                if (auto rprMesh = rprApi->CreateMesh(subsetPointSamples, subsetIndexes, subsetNormalSamples, subsetNormalIndices, subsetUvSamples, subsetUvIndices, subsetVertexPerFace, m_topology.GetOrientation())) {
                     m_rprMeshes.push_back(rprMesh);
                     ++it;
                 } else {

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -51,13 +51,6 @@ protected:
     void _InitRepr(TfToken const& reprName, HdDirtyBits* dirtyBits) override;
 
 private:
-    template <typename T>
-    bool GetPrimvarData(TfToken const& name,
-                        HdSceneDelegate* sceneDelegate,
-                        std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation,
-                        VtArray<T>& out_data,
-                        VtIntArray& out_indices);
-
     RprUsdMaterial const* GetFallbackMaterial(
         HdSceneDelegate* sceneDelegate,
         HdRprApi* rprApi,
@@ -74,7 +67,7 @@ private:
 
     HdMeshTopology m_topology;
     HdGeomSubsets m_geomSubsets;
-    VtVec3fArray m_points;
+    VtArray<VtVec3fArray> m_pointSamples;
     VtIntArray m_faceVertexCounts;
     VtIntArray m_faceVertexIndices;
     bool m_enableSubdiv = false;
@@ -82,13 +75,13 @@ private:
     Hd_VertexAdjacency m_adjacency;
     bool m_adjacencyValid = false;
 
-    VtVec3fArray m_normals;
+    VtArray<VtVec3fArray> m_normalSamples;
     VtIntArray m_normalIndices;
     bool m_normalsValid = false;
     bool m_authoredNormals = false;
     bool m_smoothNormals = false;
 
-    VtVec2fArray m_uvs;
+    VtArray<VtVec2fArray> m_uvSamples;
     VtIntArray m_uvIndices;
 
     HdDisplayStyle m_displayStyle;
@@ -97,6 +90,7 @@ private:
     int m_id = -1;
     bool m_ignoreContour;
     std::string m_cryptomatteName;
+    size_t m_numGeometrySamples = 1;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
@@ -21,6 +21,7 @@ TF_DEFINE_PRIVATE_TOKENS(HdRprGeometryPrimvarTokens,
     ((subdivisionLevel, "rpr:subdivisionLevel"))
     ((ignoreContour, "rpr:ignoreContour"))
     ((cryptomatteName, "rpr:cryptomatteName"))
+    ((geomSamples, "rpr:geomSamples"))
     ((visibilityPrimary, "rpr:visibilityPrimary"))
     ((visibilityShadow, "rpr:visibilityShadow"))
     ((visibilityReflection, "rpr:visibilityReflection"))
@@ -63,6 +64,9 @@ void HdRprParseGeometrySettings(
             HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->ignoreContour, sceneDelegate, id, &geomSettings->ignoreContour);
         } else if (desc.name == HdRprGeometryPrimvarTokens->cryptomatteName) {
             HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->cryptomatteName, sceneDelegate, id, &geomSettings->cryptomatteName);
+        } else if (desc.name == HdRprGeometryPrimvarTokens->geomSamples) {
+            HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->geomSamples, sceneDelegate, id, &geomSettings->numGeometrySamples);
+            geomSettings->numGeometrySamples = std::max(0, geomSettings->numGeometrySamples);
         } else if (desc.name == HdRprGeometryPrimvarTokens->visibilityPrimary) {
             setVisibilityFlag(HdRprGeometryPrimvarTokens->visibilityPrimary, kVisiblePrimary);
         } else if (desc.name == HdRprGeometryPrimvarTokens->visibilityShadow) {

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
@@ -66,7 +66,7 @@ void HdRprParseGeometrySettings(
             HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->cryptomatteName, sceneDelegate, id, &geomSettings->cryptomatteName);
         } else if (desc.name == HdRprGeometryPrimvarTokens->geomSamples) {
             HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->geomSamples, sceneDelegate, id, &geomSettings->numGeometrySamples);
-            geomSettings->numGeometrySamples = std::max(0, geomSettings->numGeometrySamples);
+            geomSettings->numGeometrySamples = std::max(1, geomSettings->numGeometrySamples);
         } else if (desc.name == HdRprGeometryPrimvarTokens->visibilityPrimary) {
             setVisibilityFlag(HdRprGeometryPrimvarTokens->visibilityPrimary, kVisiblePrimary);
         } else if (desc.name == HdRprGeometryPrimvarTokens->visibilityShadow) {

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.h
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.h
@@ -81,23 +81,15 @@ bool HdRprSamplePrimvar(
     HdSceneDelegate* sceneDelegate,
     size_t maxSampleCount,
     VtArray<T>* sampleValuesPtr) {
-    /// A user might specify `maxSampleCount==0` to get all authored samples from the scene delegate.
-    /// Currently, we can query the actual amount of authored samples only by specifying maxSampleCount minimum to 1.
-    size_t querySampleCount = std::max(size_t(1), maxSampleCount);
+    std::vector<float> sampleTimes(maxSampleCount);
+    std::vector<VtValue> sampleVtValues(maxSampleCount);
 
-    std::vector<float> sampleTimes(querySampleCount);
-    std::vector<VtValue> sampleVtValues(querySampleCount);
-
-    size_t authoredSampleCount = sceneDelegate->SamplePrimvar(id, key, querySampleCount, sampleTimes.data(), sampleVtValues.data());
+    size_t authoredSampleCount = sceneDelegate->SamplePrimvar(id, key, maxSampleCount, sampleTimes.data(), sampleVtValues.data());
     if (!authoredSampleCount) {
         return false;
     }
 
-    if (!maxSampleCount && authoredSampleCount > querySampleCount) {
-        sampleTimes.resize(authoredSampleCount);
-        sampleVtValues.resize(authoredSampleCount);
-        querySampleCount = sceneDelegate->SamplePrimvar(id, key, authoredSampleCount, sampleTimes.data(), sampleVtValues.data());
-    } else if (authoredSampleCount < querySampleCount) {
+    if (authoredSampleCount < maxSampleCount) {
         sampleTimes.resize(authoredSampleCount);
         sampleVtValues.resize(authoredSampleCount);
     }

--- a/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
@@ -46,6 +46,14 @@ geometry_settings = [
                 'help': 'String used to generate cryptomatte ID. If not specified, the path to a primitive used.'
             },
             {
+                'name': 'primvars:rpr:geomSamples',
+                'ui_name': 'Geometry Time Samples',
+                'defaultValue': 1,
+                'minValue': 0,
+                'maxValue': 1 ** 16,
+                'help': 'The number of sub-frame samples to compute when rendering deformation motion blur over the shutter open time. The default is 1 (sample only at the start of the shutter time), giving no deformation blur by default. If you want rapidly deforming geometry to blur properly, you must increase this value to 2 or more. Note that this value is limited by the number of sub-samples available in the USD file being rendered. Set to 0 to get all sub-samples available in the USD file.'
+            },
+            {
                 'folder': 'Visibility Settings',
                 'settings': visibility_flag_settings
             }

--- a/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
@@ -49,9 +49,9 @@ geometry_settings = [
                 'name': 'primvars:rpr:geomSamples',
                 'ui_name': 'Geometry Time Samples',
                 'defaultValue': 1,
-                'minValue': 0,
+                'minValue': 1,
                 'maxValue': 1 ** 16,
-                'help': 'The number of sub-frame samples to compute when rendering deformation motion blur over the shutter open time. The default is 1 (sample only at the start of the shutter time), giving no deformation blur by default. If you want rapidly deforming geometry to blur properly, you must increase this value to 2 or more. Note that this value is limited by the number of sub-samples available in the USD file being rendered. Set to 0 to get all sub-samples available in the USD file.'
+                'help': 'The number of sub-frame samples to compute when rendering deformation motion blur over the shutter open time. The default is 1 (sample only at the start of the shutter time), giving no deformation blur by default. If you want rapidly deforming geometry to blur properly, you must increase this value to 2 or more. Note that this value is limited by the number of sub-samples available in the USD file being rendered.'
             },
             {
                 'folder': 'Visibility Settings',

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -114,7 +114,8 @@ public:
     RprUsdMaterial* CreateDiffuseMaterial(GfVec3f const& color);
     void Release(RprUsdMaterial* material);
 
-    rpr::Shape* CreateMesh(const VtVec3fArray& points, const VtIntArray& pointIndexes, const VtVec3fArray& normals, const VtIntArray& normalIndexes, const VtVec2fArray& uv, const VtIntArray& uvIndexes, const VtIntArray& vpf, TfToken const& polygonWinding);
+    rpr::Shape* CreateMesh(VtVec3fArray const& points, VtIntArray const& pointIndexes, VtVec3fArray const& normals, VtIntArray const& normalIndexes, VtVec2fArray const& uvs, VtIntArray const& uvIndexes, VtIntArray const& vpf, TfToken const& polygonWinding);
+    rpr::Shape* CreateMesh(VtArray<VtVec3fArray> const& pointSamples, VtIntArray const& pointIndexes, VtArray<VtVec3fArray> const& normalSamples, VtIntArray const& normalIndexes, VtArray<VtVec2fArray> const& uvSamples, VtIntArray const& uvIndexes, VtIntArray const& vpf, TfToken const& polygonWinding);
     rpr::Shape* CreateMeshInstance(rpr::Shape* prototypeMesh);
     void SetMeshRefineLevel(rpr::Shape* mesh, int level);
     void SetMeshVertexInterpolationRule(rpr::Shape* mesh, TfToken boundaryInterpolation);


### PR DESCRIPTION
### PURPOSE
Adds support of deformation motion blur

### EFFECT OF CHANGE
* Added support of deformation motion blur in the Full quality.
* New geometry render setting introduced - "Geometry Time Samples". The number of sub-frame samples to compute when rendering deformation motion blur over the shutter open time. The default is 1 (sample only at the start of the shutter time), giving no deformation blur by default. If you want rapidly deforming geometry to blur properly, you must increase this value to 2 or more. Note that this value is limited by the number of sub-samples available in the USD stage being rendered. Set to 0 to get all sub-samples available in the USD stage.

### TECHNICAL STEPS
* Use `HdSceneDelegate::SamplePrimvar` instead of `HdSceneDelegate::Get` to query the required amount of time samples from the scene delegate.
* Add new geometry setting - `rpr:geomSamples`.

### NOTES FOR REVIEWERS
Support for UsdSkel deformation blur can be quite easily added for USD 21.05+ only. Because there was no appropriate API to get few samples for a `HdComputation` before. It was only recently implemented and merged - https://github.com/PixarAnimationStudios/USD/pull/1455.

So I plan to open this pull request and move on to adding support of USD 21.05 in our plugin (there are many changes actually). After that, I will implement the UsdSkel deformation motion blur support.
