### PR TITLE
Update to USD 21.05

### DIFF
--- a/pxr/imaging/plugin/hdRpr/light.cpp
+++ b/pxr/imaging/plugin/hdRpr/light.cpp
@@ -31,6 +31,16 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+#if PXR_VERSION >= 2105
+#define USD_LUX_TOKEN_SHAPING_IES_FILE UsdLuxTokens->inputsShapingIesFile
+#define USD_LUX_TOKEN_SHAPING_CONE_ANGLE UsdLuxTokens->inputsShapingConeAngle
+#define USD_LUX_TOKEN_SHAPING_CONE_SOFTNESS UsdLuxTokens->inputsShapingConeSoftness
+#else
+#define USD_LUX_TOKEN_SHAPING_IES_FILE UsdLuxTokens->shapingIesFile
+#define USD_LUX_TOKEN_SHAPING_CONE_ANGLE UsdLuxTokens->shapingConeAngle
+#define USD_LUX_TOKEN_SHAPING_CONE_SOFTNESS UsdLuxTokens->shapingConeSoftness
+#endif
+
 namespace {
 
 float GetDiskLightNormalization(GfMatrix4f const& transform, float radius) {
@@ -401,7 +411,7 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
         }
 
         bool newLight = false;
-        auto iesFile = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->shapingIesFile);
+        auto iesFile = sceneDelegate->GetLightParamValue(id, USD_LUX_TOKEN_SHAPING_IES_FILE);
         if (iesFile.IsHolding<SdfAssetPath>()) {
             auto& path = iesFile.UncheckedGet<SdfAssetPath>();
             if (!path.GetResolvedPath().empty()) {
@@ -411,8 +421,8 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
                 }
             }
         } else {
-            auto coneAngle = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->shapingConeAngle);
-            auto coneSoftness = sceneDelegate->GetLightParamValue(id, UsdLuxTokens->shapingConeSoftness);
+            auto coneAngle = sceneDelegate->GetLightParamValue(id, USD_LUX_TOKEN_SHAPING_CONE_ANGLE);
+            auto coneSoftness = sceneDelegate->GetLightParamValue(id, USD_LUX_TOKEN_SHAPING_CONE_SOFTNESS);
             if (coneAngle.IsHolding<float>() && coneSoftness.IsHolding<float>()) {
                 if (auto light = rprApi->CreateSpotLight(coneAngle.UncheckedGet<float>(), coneSoftness.UncheckedGet<float>())) {
                     m_light = light;

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -30,8 +30,6 @@ using json = nlohmann::json;
 #include "renderParam.h"
 
 #include "pxr/imaging/rprUsd/util.h"
-#include "pxr/imaging/glf/uvTextureData.h"
-
 #include "pxr/imaging/rprUsd/config.h"
 #include "pxr/imaging/rprUsd/error.h"
 #include "pxr/imaging/rprUsd/helpers.h"
@@ -3405,16 +3403,16 @@ private:
             return false;
         }
 
-        auto textureData = GlfUVTextureData::New(path, INT_MAX, 0, 0, 0, 0);
-        if (textureData && textureData->Read(0, false)) {
+        auto textureData = RprUsdTextureData::New(path);
+        if (textureData) {
             rif_image_desc imageDesc = {};
-            imageDesc.image_width = textureData->ResizedWidth();
-            imageDesc.image_height = textureData->ResizedHeight();
+            imageDesc.image_width = textureData->GetWidth();
+            imageDesc.image_height = textureData->GetHeight();
             imageDesc.image_depth = 1;
             imageDesc.image_row_pitch = 0;
             imageDesc.image_slice_pitch = 0;
 
-            auto textureMetadata = RprUsdGetGlfTextureMetadata(&(*textureData));
+            auto textureMetadata = textureData->GetGLMetadata();
 
             uint8_t bytesPerComponent;
             if (textureMetadata.glType == GL_UNSIGNED_BYTE) {
@@ -3449,7 +3447,7 @@ private:
                 return false;
             }
             size_t imageSize = bytesPerComponent * imageDesc.num_components * imageDesc.image_width * imageDesc.image_height;
-            std::memcpy(mappedData, textureData->GetRawBuffer(), imageSize);
+            std::memcpy(mappedData, textureData->GetData(), imageSize);
             RIF_ERROR_CHECK(rifImageUnmap(rifImage->GetHandle(), mappedData), "Failed to unmap rif image");
 
             auto colorRb = static_cast<HdRprRenderBuffer*>(colorOutputRb->aovBinding->renderBuffer);

--- a/pxr/imaging/rprUsd/coreImage.h
+++ b/pxr/imaging/rprUsd/coreImage.h
@@ -15,7 +15,7 @@ limitations under the License.
 #define PXR_IMAGING_RPR_USD_CORE_IMAGE_H
 
 #include "pxr/imaging/rprUsd/api.h"
-#include "pxr/imaging/glf/uvTextureData.h"
+#include "pxr/imaging/rprUsd/util.h"
 
 #include <RadeonProRender.hpp>
 
@@ -30,9 +30,9 @@ public:
 
     struct UDIMTile {
         uint32_t id;
-        GlfUVTextureData* textureData;
+        RprUsdTextureData* textureData;
 
-        UDIMTile(uint32_t id, GlfUVTextureData* textureData) : id(id), textureData(textureData) {}
+        UDIMTile(uint32_t id, RprUsdTextureData* textureData) : id(id), textureData(textureData) {}
     };
     RPRUSD_API
     static RprUsdCoreImage* Create(rpr::Context* context, std::vector<UDIMTile> const& textureData, uint32_t numComponentsRequired);

--- a/pxr/imaging/rprUsd/imageCache.cpp
+++ b/pxr/imaging/rprUsd/imageCache.cpp
@@ -81,7 +81,7 @@ RprUsdImageCache::GetImage(
         // Assume that all tiles have the same colorspace
         //
         auto data = tiles[0].textureData;
-        GLenum internalFormat = RprUsdGetGlfTextureMetadata(data).internalFormat;
+        GLenum internalFormat = data->GetGLMetadata().internalFormat;
         if (internalFormat == GL_SRGB ||
             internalFormat == GL_SRGB8 ||
             internalFormat == GL_SRGB_ALPHA ||

--- a/pxr/imaging/rprUsd/materialRegistry.cpp
+++ b/pxr/imaging/rprUsd/materialRegistry.cpp
@@ -12,7 +12,6 @@ limitations under the License.
 ************************************************************************/
 
 #include "pxr/imaging/rprUsd/util.h"
-#include "pxr/imaging/glf/uvTextureData.h"
 #include "pxr/imaging/rprUsd/materialRegistry.h"
 #include "pxr/imaging/rprUsd/imageCache.h"
 #include "pxr/imaging/rprUsd/debugCodes.h"
@@ -133,7 +132,7 @@ void RprUsdMaterialRegistry::CommitResources(
         std::string path;
         uint32_t udimTileId;
 
-        GlfUVTextureDataRefPtr data;
+        RprUsdTextureDataRefPtr data;
 
         UniqueTextureInfo(std::string const& path, uint32_t udimTileId)
             : path(path), udimTileId(udimTileId), data(nullptr) {}
@@ -180,8 +179,7 @@ void RprUsdMaterialRegistry::CommitResources(
     WorkParallelForN(uniqueTextures.size(),
         [&uniqueTextures](size_t begin, size_t end) {
             for (size_t i = begin; i < end; ++i) {
-                auto textureData = GlfUVTextureData::New(uniqueTextures[i].path, INT_MAX, 0, 0, 0, 0);
-                if (textureData && textureData->Read(0, false)) {
+                if (auto textureData = RprUsdTextureData::New(uniqueTextures[i].path)) {
                     uniqueTextures[i].data = textureData;
                 } else {
                     TF_RUNTIME_ERROR("Failed to load %s texture", uniqueTextures[i].path.c_str());

--- a/pxr/imaging/rprUsd/util.cpp
+++ b/pxr/imaging/rprUsd/util.cpp
@@ -47,23 +47,163 @@ bool RprUsdInitGLApi() {
 #endif
 }
 
-RprUsdGlfTextureMetadata RprUsdGetGlfTextureMetadata(GlfUVTextureData* uvTextureData) {
-    RprUsdGlfTextureMetadata ret = {};
 #if PXR_VERSION >= 2011
-#   if PXR_VERSION >= 2102
-    auto hioFormat = uvTextureData->GetFormat();
-#   else
-    auto hioFormat = uvTextureData->GetHioFormat();
-#   endif
-    ret.glType = GlfGetGLType(hioFormat);
-    ret.glFormat = GlfGetGLFormat(hioFormat);
-    ret.internalFormat = GlfGetGLInternalFormat(hioFormat);
-#else
-    ret.internalFormat = uvTextureData->GLInternalFormat();
-    ret.glType = uvTextureData->GLType();
-    ret.glFormat = uvTextureData->GLFormat();
-#endif
+
+static const RprUsdTextureData::GLMetadata g_GLMetadata[HioFormatCount] =
+{
+    // glFormat, glType,        glInternatFormat  // HioFormat
+    {GL_RED,  GL_UNSIGNED_BYTE, GL_R8          }, // UNorm8
+    {GL_RG,   GL_UNSIGNED_BYTE, GL_RG8         }, // UNorm8Vec2
+    {GL_RGB,  GL_UNSIGNED_BYTE, GL_RGB8        }, // UNorm8Vec3
+    {GL_RGBA, GL_UNSIGNED_BYTE, GL_RGBA8       }, // UNorm8Vec4
+
+    {GL_RED,  GL_BYTE,          GL_R8_SNORM    }, // SNorm8
+    {GL_RG,   GL_BYTE,          GL_RG8_SNORM   }, // SNorm8Vec2
+    {GL_RGB,  GL_BYTE,          GL_RGB8_SNORM  }, // SNorm8Vec3
+    {GL_RGBA, GL_BYTE,          GL_RGBA8_SNORM }, // SNorm8Vec4
+
+    {GL_RED,  GL_HALF_FLOAT,    GL_R16F        }, // Float16
+    {GL_RG,   GL_HALF_FLOAT,    GL_RG16F       }, // Float16Vec2
+    {GL_RGB,  GL_HALF_FLOAT,    GL_RGB16F      }, // Float16Vec3
+    {GL_RGBA, GL_HALF_FLOAT,    GL_RGBA16F     }, // Float16Vec4
+
+    {GL_RED,  GL_FLOAT,         GL_R32F        }, // Float32
+    {GL_RG,   GL_FLOAT,         GL_RG32F       }, // Float32Vec2
+    {GL_RGB,  GL_FLOAT,         GL_RGB32F      }, // Float32Vec3
+    {GL_RGBA, GL_FLOAT,         GL_RGBA32F     }, // Float32Vec4
+
+    {GL_RED,  GL_DOUBLE,        GL_RED         }, // Double64
+    {GL_RG,   GL_DOUBLE,        GL_RG          }, // Double64Vec2
+    {GL_RGB,  GL_DOUBLE,        GL_RGB         }, // Double64Vec3
+    {GL_RGBA, GL_DOUBLE,        GL_RGBA        }, // Double64Vec4
+
+    {GL_RED,  GL_UNSIGNED_SHORT,GL_R16UI       }, // UInt16
+    {GL_RG,   GL_UNSIGNED_SHORT,GL_RG16UI      }, // UInt16Vec2
+    {GL_RGB,  GL_UNSIGNED_SHORT,GL_RGB16UI     }, // UInt16Vec3
+    {GL_RGBA, GL_UNSIGNED_SHORT,GL_RGBA16UI    }, // UInt16Vec4
+
+    {GL_RED,  GL_SHORT,         GL_R16I        }, // Int16
+    {GL_RG,   GL_SHORT,         GL_RG16I       }, // Int16Vec2
+    {GL_RGB,  GL_SHORT,         GL_RGB16I      }, // Int16Vec3
+    {GL_RGBA, GL_SHORT,         GL_RGBA16I     }, // Int16Vec4
+
+    {GL_RED,  GL_UNSIGNED_INT,  GL_R32UI       }, // UInt32
+    {GL_RG,   GL_UNSIGNED_INT,  GL_RG32UI      }, // UInt32Vec2
+    {GL_RGB,  GL_UNSIGNED_INT,  GL_RGB32UI     }, // UInt32Vec3
+    {GL_RGBA, GL_UNSIGNED_INT,  GL_RGBA32UI    }, // UInt32Vec4
+
+    {GL_RED,  GL_INT,           GL_R32I        }, // Int32
+    {GL_RG,   GL_INT,           GL_RG32I       }, // Int32Vec2
+    {GL_RGB,  GL_INT,           GL_RGB32I      }, // Int32Vec3
+    {GL_RGBA, GL_INT,           GL_RGBA32I     }, // Int32Vec4
+
+    {GL_NONE, GL_NONE, GL_NONE }, // UNorm8srgb - not supported by OpenGL
+    {GL_NONE, GL_NONE, GL_NONE }, // UNorm8Vec2srgb - not supported by OpenGL
+    {GL_RGB,  GL_UNSIGNED_BYTE, GL_SRGB8,       },  // UNorm8Vec3srgb
+    {GL_RGBA, GL_UNSIGNED_BYTE, GL_SRGB8_ALPHA8 }, // UNorm8Vec4sRGB
+
+    {GL_RGB,  GL_FLOAT,
+              GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT   }, // BC6FloatVec3
+    {GL_RGB,  GL_FLOAT,
+              GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT }, // BC6UFloatVec3
+    {GL_RGBA, GL_UNSIGNED_BYTE,
+              GL_COMPRESSED_RGBA_BPTC_UNORM         }, // BC7UNorm8Vec4
+    {GL_RGBA, GL_UNSIGNED_BYTE,
+              GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM   }, // BC7UNorm8Vec4srgb
+    {GL_RGBA, GL_UNSIGNED_BYTE,
+              GL_COMPRESSED_RGBA_S3TC_DXT1_EXT       }, // BC1UNorm8Vec4
+    {GL_RGBA, GL_UNSIGNED_BYTE,
+              GL_COMPRESSED_RGBA_S3TC_DXT5_EXT      }, // BC3UNorm8Vec4
+};
+
+#endif // PXR_VERSION >= 2011
+
+#if PXR_VERSION >= 2105
+
+std::shared_ptr<RprUsdTextureData> RprUsdTextureData::New(std::string const& filepath) {
+    auto ret = std::make_unique<RprUsdTextureData>();
+    auto hioImage = HioImage::OpenForReading(filepath);
+    if (!hioImage) {
+        return nullptr;
+    }
+
+    ret->_hioStorageSpec.width = hioImage->GetWidth();
+    ret->_hioStorageSpec.height = hioImage->GetHeight();
+    ret->_hioStorageSpec.depth = 1;
+    ret->_hioStorageSpec.format = hioImage->GetFormat();
+    ret->_hioStorageSpec.flipped = false;
+
+    size_t dataSize = ret->_hioStorageSpec.width * ret->_hioStorageSpec.height * HioGetDataSizeOfFormat(ret->_hioStorageSpec.format);
+    ret->_data = std::make_unique<uint8_t[]>(dataSize);
+    ret->_hioStorageSpec.data = ret->_data.get();
+
+    if (!hioImage->Read(ret->_hioStorageSpec)) {
+        return nullptr;
+    }
+
     return ret;
 }
+
+uint8_t* RprUsdTextureData::GetData() const {
+    return _data.get();
+}
+
+int RprUsdTextureData::GetWidth() const {
+    return _hioStorageSpec.width;
+}
+
+int RprUsdTextureData::GetHeight() const {
+    return _hioStorageSpec.height;
+}
+
+RprUsdTextureData::GLMetadata RprUsdTextureData::GetGLMetadata() const {
+    return g_GLMetadata[_hioStorageSpec.format];
+}
+
+#else // PXR_VERSION < 2105
+
+std::shared_ptr<RprUsdTextureData> RprUsdTextureData::New(std::string const& filepath) {
+    auto ret = std::make_unique<RprUsdTextureData>();
+
+    ret->_uvTextureData = GlfUVTextureData::New(filepath, INT_MAX, 0, 0, 0, 0);
+    if (!ret->_uvTextureData || !ret->_uvTextureData->Read(0, false)) {
+        return nullptr;
+    }
+
+    return ret;
+}
+
+uint8_t* RprUsdTextureData::GetData() const {
+    return _uvTextureData->GetRawBuffer();
+}
+
+int RprUsdTextureData::GetWidth() const {
+    return _uvTextureData->ResizedWidth();
+}
+
+int RprUsdTextureData::GetHeight() const {
+    return _uvTextureData->ResizedHeight();
+}
+
+RprUsdTextureData::GLMetadata RprUsdTextureData::GetGLMetadata() const {
+#if PXR_VERSION >= 2011
+
+# if PXR_VERSION >= 2102
+    HioFormat hioFormat = _uvTextureData->GetFormat();
+# else // PXR_VERSION < 2102
+    HioFormat hioFormat = _uvTextureData->GetHioFormat();
+# endif // PXR_VERSION >= 2102
+    return g_GLMetadata[hioFormat];
+
+#else // PXR_VERSION < 2011
+    RprUsdTextureData::GLMetadata ret;
+    ret.internalFormat = _uvTextureData->GLInternalFormat();
+    ret.glType = _uvTextureData->GLType();
+    ret.glFormat = _uvTextureData->GLFormat();
+    return ret;
+#endif // PXR_VERSION >= 2011
+}
+
+#endif // PXR_VERSION >= 2105
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/util.h
+++ b/pxr/imaging/rprUsd/util.h
@@ -22,26 +22,47 @@ limitations under the License.
 #include "pxr/imaging/glf/glew.h"
 #endif
 
+#if PXR_VERSION >= 2105
+#include "pxr/imaging/hio/image.h"
+#else
 #include "pxr/imaging/glf/uvTextureData.h"
+#endif
 
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+class RPRUSD_API RprUsdTextureData {
+public:
+    static std::shared_ptr<RprUsdTextureData> New(std::string const& filepath);
+
+    uint8_t* GetData() const;
+    int GetWidth() const;
+    int GetHeight() const;
+
+    struct GLMetadata {
+        GLenum glFormat;
+        GLenum glType;
+        GLenum internalFormat;
+    };
+    GLMetadata GetGLMetadata() const;
+
+private:
+#if PXR_VERSION >= 2105
+    HioImage::StorageSpec _hioStorageSpec;
+    std::unique_ptr<uint8_t[]> _data;
+#else // PXR_VERSION < 2105
+    GlfUVTextureDataRefPtr _uvTextureData;
+#endif
+};
+
+using RprUsdTextureDataRefPtr = std::shared_ptr<RprUsdTextureData>;
 
 RPRUSD_API
 bool RprUsdGetUDIMFormatString(std::string const& filepath, std::string* out_formatString);
 
 RPRUSD_API
 bool RprUsdInitGLApi();
-
-struct RprUsdGlfTextureMetadata {
-    GLenum glType;
-    GLenum glFormat;
-    GLenum internalFormat;
-};
-
-RPRUSD_API
-RprUsdGlfTextureMetadata RprUsdGetGlfTextureMetadata(GlfUVTextureData* uvTextureData);
 
 PXR_NAMESPACE_CLOSE_SCOPE
 


### PR DESCRIPTION
### PURPOSE
To support USD 21.05 builds.

### EFFECT OF CHANGE
Added support of USD 21.05.

### TECHNICAL STEPS
* Replace GlfUvTextureData usage with RprUsdTextureData that hides USD version differences:
    - GlfUvTextureData is removed in 21.05 and fully replaced with HioImage
* Workaround UsdLuxTokens changes

