### PR TITLE
Update prim id on DirtyPrimId

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -378,6 +378,8 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         }
     }
 
+    isIdDirty |= *dirtyBits & HdChangeTracker::DirtyPrimID;
+
     m_smoothNormals = !m_displayStyle.flatShadingEnabled;
     // Don't compute smooth normals on a refined mesh. They are implicitly smooth.
     if (m_enableSubdiv && m_refineLevel != 0) {


### PR DESCRIPTION
### PURPOSE
In some cases we have mismatch between hdrpr mesh id and usd prim id, this fix should resolve issue

### EFFECT OF CHANGE
Fixed prim id update logic

### TECHNICAL STEPS
Set prim id in case DirtyPrimId

### NOTES FOR REVIEWERS
None
