### PR TITLE
Extend cryptomatte support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "deps/ghc_filesystem"]
 	path = deps/ghc_filesystem
 	url = https://github.com/gulrak/filesystem
+[submodule "deps/murmurhash"]
+	path = deps/murmurhash
+	url = https://github.com/aappleby/smhasher

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -99,20 +99,16 @@ else()
     find_package(OpenVDB QUIET)
 endif()
 
-if(OpenVDB_FOUND)
-    if(HoudiniUSD_FOUND)
-        find_package(OpenEXR QUIET COMPONENTS Half_sidefx)
-    endif()
+if(HoudiniUSD_FOUND)
+    find_package(OpenEXR QUIET COMPONENTS Half_sidefx IlmImf_sidefx Iex_sidefx)
+endif()
 
-    if(NOT OpenEXR_FOUND)
-        find_package(OpenEXR QUIET COMPONENTS Half)
-    endif()
+if(NOT OpenEXR_FOUND)
+    find_package(OpenEXR QUIET COMPONENTS Half IlmImf Iex)
+endif()
 
-    if(NOT OpenEXR_FOUND)
-        message(FATAL_ERROR "Failed to find Half library")
-    endif()
-else()
-    message(STATUS "Skipping OpenVDB support")
+if(NOT OpenEXR_FOUND)
+    message(FATAL_ERROR "Failed to find Half library")
 endif()
 
 # ----------------------------------------------

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -99,13 +99,29 @@ else()
     find_package(OpenVDB QUIET)
 endif()
 
-if(HoudiniUSD_FOUND)
-    find_package(OpenEXR QUIET COMPONENTS Half_sidefx IlmImf_sidefx Iex_sidefx)
+macro(find_exr)
+    if(NOT OpenEXR_FOUND)
+        set(SIDEFX_COMPONENTS ${ARGV})
+        list(TRANSFORM SIDEFX_COMPONENTS APPEND "_sidefx")
+
+        if(HoudiniUSD_FOUND)
+            find_package(OpenEXR QUIET COMPONENTS ${SIDEFX_COMPONENTS})
+        endif()
+
+        if(NOT OpenEXR_FOUND)
+            find_package(OpenEXR QUIET COMPONENTS ${ARGV})
+        endif()
+    endif()
+endmacro()
+
+find_exr(Half IlmImf Iex)
+
+set(RPR_EXR_EXPORT_ENABLED TRUE)
+if(NOT OpenEXR_FOUND)
+    set(RPR_EXR_EXPORT_ENABLED FALSE)
 endif()
 
-if(NOT OpenEXR_FOUND)
-    find_package(OpenEXR QUIET COMPONENTS Half IlmImf Iex)
-endif()
+find_exr(Half)
 
 if(NOT OpenEXR_FOUND)
     message(FATAL_ERROR "Failed to find Half library")

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -74,4 +74,13 @@ if(HoudiniUSD_FOUND)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ghc_filesystem)
 endif()
 
+# Murmurhash
+# ----------------------------------------------
+
+set(MURMURHASH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/murmurhash/src)
+add_library(murmurhash STATIC
+    ${MURMURHASH_DIR}/MurmurHash3.h
+    ${MURMURHASH_DIR}/MurmurHash3.cpp)
+target_include_directories(murmurhash PUBLIC ${MURMURHASH_DIR})
+
 # ----------------------------------------------

--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -98,6 +98,7 @@ pxr_plugin(hdRpr
         cameraUtil
         rprUsd
         json
+        murmurhash
         ${RIF_LIBRARY}
         ${OPENEXR_LIBRARIES}
 

--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -152,6 +152,10 @@ pxr_plugin(hdRpr
         ndrParserPlugin.cpp
 )
 
+if(RPR_EXR_EXPORT_ENABLED)
+    target_compile_definitions(hdRpr PRIVATE -DRPR_EXR_EXPORT_ENABLED)
+endif()
+
 target_sources(hdRpr PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/notify/message.h)
 if(APPLE)

--- a/pxr/imaging/plugin/hdRpr/material.cpp
+++ b/pxr/imaging/plugin/hdRpr/material.cpp
@@ -41,7 +41,7 @@ void HdRprMaterial::Sync(HdSceneDelegate* sceneDelegate,
         VtValue vtMat = sceneDelegate->GetMaterialResource(GetId());
         if (vtMat.IsHolding<HdMaterialNetworkMap>()) {
             auto& networkMap = vtMat.UncheckedGet<HdMaterialNetworkMap>();
-            m_rprMaterial = rprApi->CreateMaterial(sceneDelegate, networkMap);
+            m_rprMaterial = rprApi->CreateMaterial(GetId(), sceneDelegate, networkMap);
         }
 
         if (!m_rprMaterial) {
@@ -69,7 +69,7 @@ void HdRprMaterial::Sync(HdSceneDelegate* sceneDelegate,
                     networkMap.map[HdMaterialTerminalTokens->displacement] = network;
                     networkMap.terminals.push_back(mtlxNode.path);
 
-                    m_rprMaterial = rprApi->CreateMaterial(sceneDelegate, networkMap);
+                    m_rprMaterial = rprApi->CreateMaterial(GetId(), sceneDelegate, networkMap);
                 }
             }
         }

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -140,10 +140,7 @@ RprUsdMaterial const* HdRprMesh::GetFallbackMaterial(
         }
 
         m_fallbackMaterial = rprApi->CreateDiffuseMaterial(color);
-
-        if (RprUsdIsLeakCheckEnabled()) {
-            rprApi->SetName(m_fallbackMaterial, GetId().GetText());
-        }
+        rprApi->SetName(m_fallbackMaterial, GetId().GetText());
     }
 
     return m_fallbackMaterial;
@@ -376,6 +373,10 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
             m_ignoreContour = geomSettings.ignoreContour;
             isIgnoreContourDirty = true;
         }
+
+        if (m_cryptomatteName != geomSettings.cryptomatteName) {
+            m_cryptomatteName = geomSettings.cryptomatteName;
+        }
     }
 
     m_smoothNormals = !m_displayStyle.flatShadingEnabled;
@@ -535,11 +536,9 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
     }
 
     if (!m_rprMeshes.empty()) {
-        if (newMesh && RprUsdIsLeakCheckEnabled()) {
-            auto name = id.GetText();
-            for (auto& rprMesh : m_rprMeshes) {
-                rprApi->SetName(rprMesh, name);
-            }
+        auto name = m_cryptomatteName.empty() ? id.GetText() : m_cryptomatteName.c_str();
+        for (auto& rprMesh : m_rprMeshes) {
+            rprApi->SetName(rprMesh, name);
         }
 
         if (newMesh || (*dirtyBits & HdChangeTracker::DirtySubdivTags)) {

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -96,6 +96,7 @@ private:
 
     int m_id = -1;
     bool m_ignoreContour;
+    std::string m_cryptomatteName;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
@@ -20,6 +20,7 @@ TF_DEFINE_PRIVATE_TOKENS(HdRprGeometryPrimvarTokens,
     ((id, "rpr:id"))
     ((subdivisionLevel, "rpr:subdivisionLevel"))
     ((ignoreContour, "rpr:ignoreContour"))
+    ((cryptomatteName, "rpr:cryptomatteName"))
     ((visibilityPrimary, "rpr:visibilityPrimary"))
     ((visibilityShadow, "rpr:visibilityShadow"))
     ((visibilityReflection, "rpr:visibilityReflection"))
@@ -60,6 +61,8 @@ void HdRprParseGeometrySettings(
             }
         } else if (desc.name == HdRprGeometryPrimvarTokens->ignoreContour) {
             HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->ignoreContour, sceneDelegate, id, &geomSettings->ignoreContour);
+        } else if (desc.name == HdRprGeometryPrimvarTokens->cryptomatteName) {
+            HdRprGetConstantPrimvar(HdRprGeometryPrimvarTokens->cryptomatteName, sceneDelegate, id, &geomSettings->cryptomatteName);
         } else if (desc.name == HdRprGeometryPrimvarTokens->visibilityPrimary) {
             setVisibilityFlag(HdRprGeometryPrimvarTokens->visibilityPrimary, kVisiblePrimary);
         } else if (desc.name == HdRprGeometryPrimvarTokens->visibilityShadow) {

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.h
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.h
@@ -40,6 +40,7 @@ struct HdRprGeometrySettings {
     int subdivisionLevel = 0;
     uint32_t visibilityMask = 0;
     bool ignoreContour = false;
+    std::string cryptomatteName;
 };
 
 void HdRprParseGeometrySettings(

--- a/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateGeometrySettingFiles.py
@@ -39,6 +39,13 @@ geometry_settings = [
                 'help': 'Whether to extract contour for a mesh or not'
             },
             {
+                'name': 'primvars:rpr:cryptomatteName',
+                'ui_name': 'Cryptomatte Name',
+                'defaultValue': '',
+                'c_type': 'std::string',
+                'help': 'String used to generate cryptomatte ID. If not specified, the path to a primitive used.'
+            },
+            {
                 'folder': 'Visibility Settings',
                 'settings': visibility_flag_settings
             }

--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -546,6 +546,47 @@ render_setting_categories = [
         ]
     },
     {
+        'name': 'Cryptomatte',
+        'settings': [
+            {
+                'name': 'cryptomatteOutputPath',
+                'ui_name': 'Cryptomatte Output Path',
+                'defaultValue': '',
+                'c_type': 'std::string',
+                'help': 'Controls where cryptomatte should be saved. Use \'Cryptomatte Output Mode\' to control when cryptomatte is saved.',
+                'houdini': {
+                    'type': 'file'
+                }
+            },
+            {
+                'name': 'cryptomatteOutputMode',
+                'ui_name': 'Cryptomatte Output Mode',
+                'defaultValue': 'Batch',
+                'values': [
+                    SettingValue('Batch'),
+                    SettingValue('Interactive')
+                ],
+                'help': 'Batch - save cryptomatte only in the batch rendering mode (USD Render ROP, husk). Interactive - same as the Batch but also save cryptomatte in the non-batch rendering mode. Cryptomatte always saved after \'Max Samples\' is reached.',
+                'houdini': {
+                    'hidewhen': 'cryptomatteOutputPath == ""',
+                }
+            },
+            {
+                'name': 'cryptomattePreviewLayer',
+                'ui_name': 'Cryptomatte Add Preview Layer',
+                'defaultValue': False,
+                'help': 'Whether to generate cryptomatte preview layer or not. Whether you need it depends on the software you are planning to use cryptomatte in. For example, Houdini\'s COP Cryptomatte requires it, Nuke, on contrary, does not.',
+                'houdini': {
+                    'hidewhen': 'cryptomatteOutputPath == ""',
+                }
+
+            }
+        ],
+        'houdini': {
+            'hidewhen': hidewhen_not_northstar
+        }
+    },
+    {
         'name': 'UsdNativeCamera',
         'settings': [
             {

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -54,11 +54,17 @@ using json = nlohmann::json;
 #include "pxr/base/tf/envSetting.h"
 #include "pxr/base/tf/fileUtils.h"
 #include "pxr/base/tf/getenv.h"
+#include "pxr/base/work/loops.h"
 
 #include "notify/message.h"
 
 #include <RadeonProRender_Baikal.h>
 #include <RprLoadStore.h>
+
+#include <MurmurHash3.h>
+#include <ImfOutputFile.h>
+#include <ImfChannelList.h>
+#include <ImfStringAttribute.h>
 
 #ifdef BUILD_AS_HOUDINI_PLUGIN
 #include <HOM/HOM_Module.h>
@@ -113,6 +119,29 @@ RprUsdRenderDeviceType ToRprUsd(TfToken const& configDeviceType) {
     } else {
         return RprUsdRenderDeviceType::Invalid;
     }
+}
+
+bool CreateIntermediateDirectories(std::string const& filePath) {
+    auto dir = TfGetPathName(filePath);
+    if (!dir.empty()) {
+        return TfMakeDirs(dir, -1, true);
+    }
+    return true;
+}
+
+template <typename T>
+void UnalignedRead(void const* src, size_t* offset, T* dst) {
+    std::memcpy(dst, (uint8_t const*)src + *offset, sizeof(T));
+    *offset += sizeof(T);
+}
+
+GfVec4f ColorizeId(uint32_t id) {
+    return {
+        (float)(id & 0xFF) / 0xFF,
+        (float)((id & 0xFF00) >> 8) / 0xFF,
+        (float)((id & 0xFF0000) >> 16) / 0xFF,
+        1.0f
+    };
 }
 
 } // namespace anonymous
@@ -1011,13 +1040,13 @@ public:
         m_dirtyFlags |= ChangeTracker::DirtyScene;
     }
 
-    RprUsdMaterial* CreateMaterial(HdSceneDelegate* sceneDelegate, HdMaterialNetworkMap const& materialNetwork) {
+    RprUsdMaterial* CreateMaterial(SdfPath const& materialId, HdSceneDelegate* sceneDelegate, HdMaterialNetworkMap const& materialNetwork) {
         if (!m_rprContext) {
             return nullptr;
         }
 
         LockGuard rprLock(m_rprContext->GetMutex());
-        return RprUsdMaterialRegistry::GetInstance().CreateMaterial(sceneDelegate, materialNetwork, m_rprContext.get(), m_imageCache.get());
+        return RprUsdMaterialRegistry::GetInstance().CreateMaterial(materialId, sceneDelegate, materialNetwork, m_rprContext.get(), m_imageCache.get());
     }
 
     RprUsdMaterial* CreatePointsMaterial(VtVec3fArray const& colors) {
@@ -1648,6 +1677,11 @@ public:
                 RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_OCIO_RENDERING_COLOR_SPACE, preferences.GetOcioRenderingColorSpace().c_str()), "Faled to set OCIO rendering color space");
                 m_dirtyFlags |= ChangeTracker::DirtyScene;
             }
+
+            if (preferences.IsDirty(HdRprConfig::DirtyCryptomatte) || force) {
+                m_cryptomatteOutputPath = preferences.GetCryptomatteOutputPath();
+                m_cryptomattePreviewLayer = preferences.GetCryptomattePreviewLayer();
+            }
         }
     }
 
@@ -1698,6 +1732,32 @@ public:
                 m_isBatch = isBatch;
                 m_batchREM = isBatch ? std::make_unique<BatchRenderEventManager>() : nullptr;
                 m_dirtyFlags |= ChangeTracker::DirtyScene;
+            }
+        }
+
+        if (preferences.IsDirty(HdRprConfig::DirtySession) || preferences.IsDirty(HdRprConfig::DirtyCryptomatte) || force) {
+            if (!m_cryptomatteOutputPath.empty() &&
+                (m_isBatch || preferences.GetCryptomatteOutputMode() == HdRprCryptomatteOutputModeTokens->Interactive) &&
+                m_rprContextMetadata.pluginType == kPluginNorthstar) {
+                if (!m_cryptomatteAovs) {
+                    auto cryptomatteAovs = std::make_unique<CryptomatteAovs>();
+                    cryptomatteAovs->obj.aov[0] = CreateAov(HdRprAovTokens->cryptomatteObj0);
+                    cryptomatteAovs->obj.aov[1] = CreateAov(HdRprAovTokens->cryptomatteObj1);
+                    cryptomatteAovs->obj.aov[2] = CreateAov(HdRprAovTokens->cryptomatteObj2);
+                    cryptomatteAovs->mat.aov[0] = CreateAov(HdRprAovTokens->cryptomatteMat0);
+                    cryptomatteAovs->mat.aov[1] = CreateAov(HdRprAovTokens->cryptomatteMat1);
+                    cryptomatteAovs->mat.aov[2] = CreateAov(HdRprAovTokens->cryptomatteMat2);
+                    for (int i = 0; i < 3; ++i) {
+                        if (!cryptomatteAovs->obj.aov[i] ||
+                            !cryptomatteAovs->mat.aov[i]) {
+                            cryptomatteAovs = nullptr;
+                            break;
+                        }
+                    }
+                    m_cryptomatteAovs = std::move(cryptomatteAovs);
+                }
+            } else {
+                m_cryptomatteAovs = nullptr;
             }
         }
     }
@@ -2093,6 +2153,186 @@ public:
         return true;
     }
 
+    uint32_t cryptomatte_avoid_bad_float_hash(uint32_t hash) {
+        // from Cryptomatte Specification version 1.2.0
+        // This is for avoiding nan, inf, subnormals
+        // 
+        // if all exponent bits are 0 (subnormals, +zero, -zero) set exponent to 1
+        // if all exponent bits are 1 (NaNs, +inf, -inf) set exponent to 254
+        uint32_t exponent = hash >> 23 & 255; // extract exponent (8 bits)
+        if (exponent == 0 || exponent == 255) {
+            hash ^= 1 << 23; // toggle bit
+        }
+        return hash;
+    }
+    std::string cryptomatte_hash_name(const char* name, size_t size) {
+        uint32_t m3hash = 0;
+        MurmurHash3_x86_32(name, size, 0, &m3hash);
+        m3hash = cryptomatte_avoid_bad_float_hash(m3hash);
+        return TfStringPrintf("%08x", m3hash);
+    }
+    template <size_t size>
+    std::string cryptomatte_hash_name(char (&name)[size]) {
+        return cryptomatte_hash_name(name, size);
+    }
+    std::string cryptomatte_hash_name(std::string const& name) {
+        return cryptomatte_hash_name(name.c_str(), name.size());
+    }
+
+    void SaveCryptomatte() {
+        if (m_cryptomatteAovs &&
+            m_numSamples == m_maxSamples) {
+
+            std::string outputPath = m_cryptomatteOutputPath;
+            std::string filename = TfGetBaseName(outputPath);
+            if (filename.empty()) {
+                TF_WARN("Cryptomatte output path should be a path to .exr file");
+                outputPath = TfStringCatPaths(outputPath, "cryptomatte.exr");
+            } else if (!TfStringEndsWith(outputPath, ".exr")) {
+                TF_WARN("Cryptomatte output path should be a path to .exr file");
+                outputPath += ".exr";
+            }
+
+            if (!CreateIntermediateDirectories(outputPath)) {
+                fprintf(stderr, "Failed to save cryptomatte aov: cannot create intermediate directories - %s\n", outputPath.c_str());
+                return;
+            }
+
+            // Generate manifests
+            std::string objectManifestEncoded;
+            std::string materialManifestEncoded;
+
+            if (auto shapes = RprUsdGetListInfo<rpr_shape>(m_rprContext.get(), RPR_CONTEXT_LIST_CREATED_SHAPES)) {
+                json objectManifest;
+                json materialManifest;
+                for (size_t iShape = 0; iShape < shapes.size; ++iShape) {
+                    auto shape = RprUsdGetRprObject<rpr::Shape>(shapes.data[iShape]);
+                    if (auto name = RprUsdGetListInfo<char>(shape, RPR_SHAPE_NAME)) {
+                        objectManifest[name.data.get()] = cryptomatte_hash_name(name.data.get(), name.size - 1);
+                    }
+
+                    if (rpr_material_node rprMaterialNode = RprUsdGetInfo<rpr_material_node>(shape, RPR_SHAPE_MATERIAL)) {
+                        auto name = RprUsdGetListInfo<char>(
+                            [rprMaterialNode](size_t size, void* data, size_t* size_ret) {
+                                return rprMaterialNodeGetInfo(rprMaterialNode, RPR_MATERIAL_NODE_NAME, size, data, size_ret);
+                            }
+                        );
+                        if (name) {
+                            materialManifest[name.data.get()] = cryptomatte_hash_name(name.data.get(), name.size - 1);
+                        }
+                    }
+                }
+                objectManifestEncoded = objectManifest.dump();
+                materialManifestEncoded = materialManifest.dump();
+            }
+
+            try {
+                namespace exr = OPENEXR_IMF_NAMESPACE;
+                exr::FrameBuffer exrFb;
+                exr::Header exrHeader(m_viewportSize[0], m_viewportSize[1]);
+                exrHeader.compression() = exr::ZIPS_COMPRESSION;
+
+                const int kNumComponents = 4;
+                const char* kComponentNames[kNumComponents] = {".R", ".G", ".B", ".A"};
+
+                size_t linesize = m_viewportSize[0] * kNumComponents * sizeof(float);
+                size_t layersize = m_viewportSize[1] * linesize;
+                std::unique_ptr<char[]> flipBuffer;
+                if (m_isOutputFlipped) {
+                    flipBuffer = std::make_unique<char[]>(layersize);
+                }
+
+                std::vector<std::unique_ptr<char[]>> cryptomatteLayers;
+                std::vector<std::unique_ptr<GfVec4f[]>> previewLayers;
+
+                auto addCryptomatte = [&](const char* name, CryptomatteAov const& cryptomatte, std::string const& manifest) {
+                    std::string nameHash = cryptomatte_hash_name(name).substr(0, 7);
+                    std::string cryptoPrefix = "cryptomatte/" + nameHash + "/";
+                    exrHeader.insert(cryptoPrefix + "name", exr::StringAttribute(name));
+                    exrHeader.insert(cryptoPrefix + "hash", exr::StringAttribute("MurmurHash3_32"));
+                    exrHeader.insert(cryptoPrefix + "conversion", exr::StringAttribute("uint32_to_float32"));
+                    exrHeader.insert(cryptoPrefix + "manifest", exr::StringAttribute(manifest));
+
+                    auto addLayer = [&](const char* layerName, char* basePtr) {
+                        for (int iComponent = 0; iComponent < kNumComponents; ++iComponent) {
+                            std::string channelName = TfStringPrintf("%s%s", layerName, kComponentNames[iComponent]);
+                            exrHeader.channels().insert(channelName.c_str(), exr::Channel(exr::FLOAT));
+
+                            char* dataPtr = &basePtr[iComponent * sizeof(float)];
+                            size_t xStride = kNumComponents * sizeof(float);
+                            size_t yStride = xStride * m_viewportSize[0];
+                            exrFb.insert(channelName.c_str(), exr::Slice(exr::FLOAT, dataPtr, xStride, yStride));
+                        }
+                    };
+
+                    for (int i = 0; i < 3; ++i) {
+                        auto rprLayer = cryptomatte.aov[i]->GetResolvedFb();
+                        cryptomatteLayers.push_back(std::make_unique<char[]>(layersize));
+                        if (!rprLayer->GetData(cryptomatteLayers.back().get(), layersize)) {
+                            throw std::runtime_error("failed to get RPR fb data");
+                        }
+
+                        if (m_isOutputFlipped) {
+                            for (int y = 0; y < m_viewportSize[1]; ++y) {
+                                void* src = &cryptomatteLayers.back()[y * linesize];
+                                void* dst = &flipBuffer[(m_viewportSize[1] - y - 1) * linesize];
+                                std::memcpy(dst, src, linesize);
+                            }
+                            std::swap(flipBuffer, cryptomatteLayers.back());
+                        }
+
+                        std::string layerName = TfStringPrintf("%s0%d", name, i);
+                        addLayer(layerName.c_str(), cryptomatteLayers.back().get());
+                    }
+
+                    if (m_cryptomattePreviewLayer) {
+                        size_t numPixels = m_viewportSize[0] * m_viewportSize[1];
+                        previewLayers.push_back(std::make_unique<GfVec4f[]>(numPixels));
+                        std::memset(previewLayers.back().get(), 0, numPixels * sizeof(GfVec4f));
+
+                        size_t channelOffset = cryptomatteLayers.size() - 3;
+
+                        GfVec4f* previewLayer = previewLayers.back().get();
+                        WorkParallelForN(numPixels,
+                            [&](size_t begin, size_t end) {
+                                for (size_t iChannel = 0; iChannel < 3; ++iChannel) {
+                                    auto channelData = cryptomatteLayers[channelOffset + iChannel].get();
+                                    for (size_t iPixel = begin; iPixel < end; ++iPixel) {
+                                        size_t offset = iPixel * kNumComponents * sizeof(float);
+
+                                        uint32_t id;
+                                        float contrib;
+                                        UnalignedRead(channelData, &offset, &id);
+                                        UnalignedRead(channelData, &offset, &contrib);
+                                        GfVec4f color = ColorizeId(id) * contrib;
+
+                                        UnalignedRead(channelData, &offset, &id);
+                                        UnalignedRead(channelData, &offset, &contrib);
+                                        color += ColorizeId(id) * contrib;
+
+                                        previewLayer[iPixel] += color;
+                                    }
+                                }
+                            }
+                        );
+
+                        addLayer(name, (char*)previewLayer);
+                    }
+                };
+
+                addCryptomatte("CryptoObject", m_cryptomatteAovs->obj, objectManifestEncoded);
+                addCryptomatte("CryptoMaterial", m_cryptomatteAovs->mat, materialManifestEncoded);
+
+                ArchUnlinkFile(outputPath.c_str());
+                exr::OutputFile exrFile(outputPath.c_str(), exrHeader);
+                exrFile.setFrameBuffer(exrFb);
+                exrFile.writePixels(m_viewportSize[1]);
+            } catch (std::exception& e) {
+                fprintf(stderr, "Failed to save cryptomatte: %s", e.what());
+            }
+        }
+    }
+
     void BatchRenderImpl(HdRprRenderThread* renderThread) {
         if (!CommonRenderImplPrologue()) {
             return;
@@ -2424,6 +2664,7 @@ public:
                         RenderImpl(renderThread);
                     }
                 }
+                SaveCryptomatte();
             } catch (std::runtime_error const& e) {
                 TF_RUNTIME_ERROR("Failed to render frame: %s", e.what());
             }
@@ -2464,12 +2705,8 @@ Don't show this message again?
         }
 #endif // BUILD_AS_HOUDINI_PLUGIN
 
-        // Create intermediate directories if needed
-        auto exportDir = TfGetPathName(m_rprSceneExportPath);
-        if (!exportDir.empty()) {
-            if (!TfMakeDirs(exportDir, -1, true)) {
-                fprintf(stderr, "Failed to create output directory\n");
-            }
+        if (!CreateIntermediateDirectories(m_rprSceneExportPath)) {
+            fprintf(stderr, "Failed to create .rpr export output directory\n");
         }
 
         uint32_t currentYFlip;
@@ -3712,6 +3949,17 @@ private:
     bool m_rprExportAsSingleFile;
     bool m_rprExportUseImageCache;
 
+    std::string m_cryptomatteOutputPath;
+    bool m_cryptomattePreviewLayer;
+    struct CryptomatteAov {
+        std::shared_ptr<HdRprApiAov> aov[3];
+    };
+    struct CryptomatteAovs {
+        CryptomatteAov mat;
+        CryptomatteAov obj;
+    };
+    std::unique_ptr<CryptomatteAovs> m_cryptomatteAovs;
+
     std::condition_variable* m_presentedConditionVariable = nullptr;
     bool* m_presentedCondition = nullptr;
     rprContextFlushFrameBuffers_func m_rprContextFlushFrameBuffers = nullptr;
@@ -3836,9 +4084,9 @@ HdRprApiVolume* HdRprApi::CreateVolume(
         gridSize, voxelSize, gridBBLow, materialParams);
 }
 
-RprUsdMaterial* HdRprApi::CreateMaterial(HdSceneDelegate* sceneDelegate, HdMaterialNetworkMap const& materialNetwork) {
+RprUsdMaterial* HdRprApi::CreateMaterial(SdfPath const& materialId, HdSceneDelegate* sceneDelegate, HdMaterialNetworkMap const& materialNetwork) {
     m_impl->InitIfNeeded();
-    return m_impl->CreateMaterial(sceneDelegate, materialNetwork);
+    return m_impl->CreateMaterial(materialId, sceneDelegate, materialNetwork);
 }
 
 RprUsdMaterial* HdRprApi::CreatePointsMaterial(VtVec3fArray const& colors) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -61,10 +61,12 @@ using json = nlohmann::json;
 #include <RadeonProRender_Baikal.h>
 #include <RprLoadStore.h>
 
+#ifdef RPR_EXR_EXPORT_ENABLED
 #include <MurmurHash3.h>
 #include <ImfOutputFile.h>
 #include <ImfChannelList.h>
 #include <ImfStringAttribute.h>
+#endif // RPR_EXR_EXPORT_ENABLED
 
 #ifdef BUILD_AS_HOUDINI_PLUGIN
 #include <HOM/HOM_Module.h>
@@ -1679,8 +1681,14 @@ public:
             }
 
             if (preferences.IsDirty(HdRprConfig::DirtyCryptomatte) || force) {
+#ifdef RPR_EXR_EXPORT_ENABLED
                 m_cryptomatteOutputPath = preferences.GetCryptomatteOutputPath();
                 m_cryptomattePreviewLayer = preferences.GetCryptomattePreviewLayer();
+#else
+                if (!preferences.GetCryptomatteOutputPath().empty()) {
+                    fprintf(stderr, "Cryptomatte export is not supported: hdRpr compiled without .exr support\n");
+                }
+#endif // RPR_EXR_EXPORT_ENABLED
             }
         }
     }
@@ -2180,6 +2188,7 @@ public:
     }
 
     void SaveCryptomatte() {
+#ifdef RPR_EXR_EXPORT_ENABLED
         if (m_cryptomatteAovs &&
             m_numSamples == m_maxSamples) {
 
@@ -2331,6 +2340,7 @@ public:
                 fprintf(stderr, "Failed to save cryptomatte: %s", e.what());
             }
         }
+#endif // RPR_EXR_EXPORT_ENABLED
     }
 
     void BatchRenderImpl(HdRprRenderThread* renderThread) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -109,7 +109,7 @@ public:
     void SetTransform(HdRprApiVolume* volume, GfMatrix4f const& transform);
     void Release(HdRprApiVolume* volume);
 
-    RprUsdMaterial* CreateMaterial(HdSceneDelegate* sceneDelegate, HdMaterialNetworkMap const& materialNetwork);
+    RprUsdMaterial* CreateMaterial(SdfPath const& materialId, HdSceneDelegate* sceneDelegate, HdMaterialNetworkMap const& materialNetwork);
     RprUsdMaterial* CreatePointsMaterial(VtVec3fArray const& colors);
     RprUsdMaterial* CreateDiffuseMaterial(GfVec3f const& color);
     void Release(RprUsdMaterial* material);

--- a/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.cpp
+++ b/pxr/imaging/plugin/rprHoudini/LOP_RPRMaterialProperties.cpp
@@ -33,11 +33,14 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 static PRM_Name g_materialPath("materialPath", "Material Path");
 static PRM_Name g_id("id", "ID");
+static PRM_Name g_cryptomatteName("cryptomatteName", "Cryptomatte Name");
 
 static PRM_Template g_templateList[] = {
     PRM_Template(PRM_STRING_E, 1, &g_materialPath),
     PRM_Template(PRM_INT, 1, &g_id, nullptr, nullptr, nullptr, nullptr, nullptr, 1,
-        "some help"),
+        "The ID that corresponds to ID on materialId AOV."),
+    PRM_Template(PRM_STRING_E, 1, &g_cryptomatteName, nullptr, nullptr, nullptr, nullptr, nullptr, 1,
+        "String used to generate cryptomatte ID. If not specified, the path to a primitive used."),
     PRM_Template()
 };
 
@@ -70,12 +73,15 @@ OP_ERROR LOP_RPRMaterialProperties::cookMyLop(OP_Context &context) {
     evalString(materialPath, g_materialPath.getToken(), 0, context.getTime());
     HUSDmakeValidUsdPath(materialPath, true);
 
-    int id = evalInt(g_id.getToken(), 0, context.getTime());
-
     if (!materialPath.isstring()) {
         return error();
     }
     SdfPath materialSdfPath(HUSDgetSdfPath(materialPath));
+
+    int id = evalInt(g_id.getToken(), 0, context.getTime());
+
+    UT_String cryptomatteName;
+    evalString(cryptomatteName, g_cryptomatteName.getToken(), 0, context.getTime());
 
     HUSD_AutoWriteLock writelock(editableDataHandle());
     HUSD_AutoLayerLock layerlock(writelock);
@@ -103,6 +109,9 @@ OP_ERROR LOP_RPRMaterialProperties::cookMyLop(OP_Context &context) {
     UsdShadeShader surfaceSource = material.ComputeSurfaceSource(RprUsdTokens->rpr);
     if (surfaceSource) {
         surfaceSource.CreateInput(RprUsdTokens->id, SdfValueTypeNames->Int).Set(id);
+        surfaceSource.CreateInput(RprUsdTokens->cryptomatteName, SdfValueTypeNames->String).Set(VtValue(std::string(cryptomatteName)));
+    } else {
+        addWarning(LOP_MESSAGE, "Material has no surface source");
     }
 
     return error();

--- a/pxr/imaging/rprUsd/materialRegistry.cpp
+++ b/pxr/imaging/rprUsd/materialRegistry.cpp
@@ -358,6 +358,7 @@ void ConvertLegacyHdMaterialNetwork(
 } // namespace anonymous
 
 RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
+    SdfPath const& materialId,
     HdSceneDelegate* sceneDelegate,
     HdMaterialNetworkMap const& legacyNetworkMap,
     rpr::Context* rprContext,
@@ -387,6 +388,7 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
             VtValue const& surfaceOutput,
             VtValue const& displacementOutput,
             VtValue const& volumeOutput,
+            const char* cryptomatteName,
             int materialId) {
 
             auto getTerminalRprNode = [](VtValue const& terminalOutput) -> rpr::MaterialNode* {
@@ -410,10 +412,14 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
             m_uvPrimvarName = TfToken(context.uvPrimvarName);
             m_displacementScale = std::move(context.displacementScale);
 
-            if (m_surfaceNode && materialId >= 0) {
-                // TODO: add C++ wrapper
-                auto apiHandle = rpr::GetRprObject(m_surfaceNode);
-                RPR_ERROR_CHECK(rprMaterialNodeSetID(apiHandle, rpr_uint(materialId)), "Failed to set material node id");
+            if (m_surfaceNode) {
+                if (materialId >= 0) {
+                    // TODO: add C++ wrapper
+                    auto apiHandle = rpr::GetRprObject(m_surfaceNode);
+                    RPR_ERROR_CHECK(rprMaterialNodeSetID(apiHandle, rpr_uint(materialId)), "Failed to set material node id");
+                }
+
+                RPR_ERROR_CHECK(m_surfaceNode->SetName(cryptomatteName), "Failed to set material name");
             }
 
             return m_volumeNode || m_surfaceNode || m_displacementNode;
@@ -525,7 +531,8 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
     auto surfaceOutput = getTerminalOutput(HdMaterialTerminalTokens->surface);
     auto displacementOutput = getTerminalOutput(HdMaterialTerminalTokens->displacement);
 
-    int materialId = -1;
+    int materialRprId = -1;
+    std::string const* cryptomatteName = nullptr;
 
     auto surfaceTerminalIt = network.terminals.find(HdMaterialTerminalTokens->surface);
     if (surfaceTerminalIt != network.terminals.end()) {
@@ -540,13 +547,26 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
                 auto& value = idIt->second;
 
                 if (value.IsHolding<int>()) {
-                    materialId = value.UncheckedGet<int>();
+                    materialRprId = value.UncheckedGet<int>();
+                }
+            }
+
+            auto cryptomatteNameIt = parameters.find(RprUsdTokens->cryptomatteName);
+            if (cryptomatteNameIt != parameters.end()) {
+                auto& value = cryptomatteNameIt->second;
+
+                if (value.IsHolding<std::string>()) {
+                    cryptomatteName = &value.UncheckedGet<std::string>();
                 }
             }
         }
     }
 
-    return out->Finalize(context, surfaceOutput, displacementOutput, volumeOutput, materialId) ? out.release() : nullptr;
+    if (!cryptomatteName) {
+        cryptomatteName = &materialId.GetString();
+    }
+
+    return out->Finalize(context, surfaceOutput, displacementOutput, volumeOutput, cryptomatteName->c_str(), materialRprId) ? out.release() : nullptr;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/materialRegistry.h
+++ b/pxr/imaging/rprUsd/materialRegistry.h
@@ -62,6 +62,7 @@ public:
 
     RPRUSD_API
     RprUsdMaterial* CreateMaterial(
+        SdfPath const& materialId,
         HdSceneDelegate* sceneDelegate,
         HdMaterialNetworkMap const& networkMap,
         rpr::Context* rprContext,

--- a/pxr/imaging/rprUsd/tokens.h
+++ b/pxr/imaging/rprUsd/tokens.h
@@ -23,7 +23,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 #define RPRUSD_TOKENS \
     (rpr) \
     /* UsdShadeShader */ \
-    ((id, "rpr:id"))
+    ((id, "rpr:id")) \
+    ((cryptomatteName, "rpr:cryptomatteName"))
 
 
 TF_DECLARE_PUBLIC_TOKENS(RprUsdTokens, RPRUSD_API, RPRUSD_TOKENS);


### PR DESCRIPTION
### PURPOSE
To improve cryptomatte integration

### EFFECT OF CHANGE
* Added a way to configure cryptomatte names for materials and meshes.
* Added cryptomatte export

### NOTES FOR REVIEWERS
Such custom implementation of cryptomatte export is required because there is no other way to export valid cryptomatte files from Houdini. 