### PR TITLE
Made adjustments due to USD 21.05 changes:

### DIFF
--- a/pxr/imaging/plugin/hdRpr/light.cpp
+++ b/pxr/imaging/plugin/hdRpr/light.cpp
@@ -397,7 +397,7 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
     HdDirtyBits bits = *dirtyBits;
 
     if (bits & DirtyBits::DirtyTransform) {
-        m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
+        m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
     }
 
     if (bits & DirtyParams) {

--- a/pxr/imaging/plugin/hdRpr/light.cpp
+++ b/pxr/imaging/plugin/hdRpr/light.cpp
@@ -397,7 +397,11 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
     HdDirtyBits bits = *dirtyBits;
 
     if (bits & DirtyBits::DirtyTransform) {
-        m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
+        if (PXR_VERSION >= 2011) {
+            m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
+        } else {
+            m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
+        }
     }
 
     if (bits & DirtyParams) {

--- a/pxr/imaging/plugin/hdRpr/light.cpp
+++ b/pxr/imaging/plugin/hdRpr/light.cpp
@@ -397,11 +397,11 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
     HdDirtyBits bits = *dirtyBits;
 
     if (bits & DirtyBits::DirtyTransform) {
-        if (PXR_VERSION >= 2011) {
-            m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
-        } else {
-            m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
-        }
+#if PXR_VERSION >= 2011
+        m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
+#else
+        m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
+#endif
     }
 
     if (bits & DirtyParams) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1806,7 +1806,9 @@ public:
 
             float focusDistance = 1.0f;
             m_hdCamera->GetFocusDistance(&focusDistance);
-            RPR_ERROR_CHECK(m_camera->SetFocusDistance(focusDistance), "Failed to set camera focus distance");
+            if (focusDistance > 0.0f) {
+                RPR_ERROR_CHECK(m_camera->SetFocusDistance(focusDistance), "Failed to set camera focus distance");
+            }
 
             float fstop = 0.0f;
             m_hdCamera->GetFStop(&fstop);


### PR DESCRIPTION
### PURPOSE
After updating USD to 21.05 release there are following errors:
1. Light position: `Error in 'pxrInternal_v0_21__pxrReserved__::VtValue::_FailGet' at line 565 in file D:\amd-gpuopen\BlenderUSDHydraAddon\deps\USD\pxr\base\vt\value.cpp : 'Attempted to get value of type 'GfMatrix4d' from empty VtValue.'`
2. Camera: `[RPR ERROR] Failed to set camera focus distance -- invalid parameter in UpdateCamera at line 1809 of D:\amd-gpuopen\BlenderUSDHydraAddon\deps\HdRPR\pxr\imaging\plugin\hdRpr\rprApi.cpp(7adc67f)`

### EFFECT OF CHANGE
Fixed light positioning and log error with camera focus distance for USD 21.05.

### TECHNICAL STEPS
- fixed getting light transform
- added check for camera focus distance

### NOTES FOR REVIEWERS
Probably we need more checks here to support older USD versions. @hshakula ?
