### PR TITLE
Fix compilation error

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -82,5 +82,6 @@ add_library(murmurhash STATIC
     ${MURMURHASH_DIR}/MurmurHash3.h
     ${MURMURHASH_DIR}/MurmurHash3.cpp)
 target_include_directories(murmurhash PUBLIC ${MURMURHASH_DIR})
+set_target_properties(murmurhash PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # ----------------------------------------------


### PR DESCRIPTION
### PURPOSE
Centos builds cannot be created due to compilation errors.

