### PR TITLE
Add support for aperture offset

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1949,13 +1949,20 @@ public:
         float focalLength;
 
         GfVec2f apertureSize;
+        GfVec2f apertureOffset(0.0f);
         HdRprCamera::Projection projection;
         if (m_hdCamera->GetFocalLength(&focalLength) &&
             m_hdCamera->GetApertureSize(&apertureSize) &&
+            m_hdCamera->GetApertureOffset(&apertureOffset) &&
             m_hdCamera->GetProjection(&projection)) {
             ApplyAspectRatioPolicy(m_viewportSize, aspectRatioPolicy.value, apertureSize);
             sensorWidth = apertureSize[0];
             sensorHeight = apertureSize[1];
+
+            apertureOffset[0] /= apertureSize[0];
+            apertureOffset[1] /= apertureSize[1];
+
+            apertureOffset[1] *= aspectRatio;
         } else {
             bool isOrthographic = round(m_cameraProjectionMatrix[3][3]) == 1.0;
             if (isOrthographic) {
@@ -1974,6 +1981,8 @@ public:
                 focalLength = m_cameraProjectionMatrix[1][1] / (2.0 * aspectRatio);
             }
         }
+
+        RPR_ERROR_CHECK(m_camera->SetLensShift(apertureOffset[0], apertureOffset[1]), "Failed to set camera lens shift");
 
         if (projection == HdRprCamera::Orthographic) {
             RPR_ERROR_CHECK(m_camera->SetMode(RPR_CAMERA_MODE_ORTHOGRAPHIC), "Failed to set camera mode");

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1961,8 +1961,6 @@ public:
 
             apertureOffset[0] /= apertureSize[0];
             apertureOffset[1] /= apertureSize[1];
-
-            apertureOffset[1] *= aspectRatio;
         } else {
             bool isOrthographic = round(m_cameraProjectionMatrix[3][3]) == 1.0;
             if (isOrthographic) {


### PR DESCRIPTION
### PURPOSE
To improve the camera feature set. To resolve #181.

### EFFECT OF CHANGE
The camera's aperture offset is now supported.

### TECHNICAL STEPS
Copy implementation from the blender addon.

### NOTES FOR REVIEWERS
I've tested it in Houdini by comparing it to `Houdini GL` delegate renders.
