### PR TITLE
Render device selection

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -215,25 +215,6 @@ render_setting_categories = [
         }
     },
     {
-        'name': 'Device',
-        'houdini': {
-            'hidewhen': hidewhen_hybrid
-        },
-        'settings': [
-            {
-                'name': 'renderDevice',
-                'ui_name': 'Render Device',
-                'help': 'Restart required.',
-                'defaultValue': 'GPU',
-                'values': [
-                    SettingValue('CPU'),
-                    SettingValue('GPU'),
-                    # SettingValue('CPU+GPU')
-                ]
-            }
-        ]
-    },
-    {
         'name': 'Denoise',
         'houdini': {
             'hidewhen': lambda settings: hidewhen_render_quality('<', 'High', settings)

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -426,12 +426,6 @@ void HdRprDelegate::SetDrivers(HdDriverVector const& drivers) {
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
-void HdRprSetRenderDevice(const char* renderDevice) {
-    PXR_INTERNAL_NS::HdRprConfig* config;
-    auto configInstanceLock = PXR_INTERNAL_NS::HdRprConfig::GetInstance(&config);
-    config->SetRenderDevice(PXR_INTERNAL_NS::TfToken(renderDevice));
-}
-
 void HdRprSetRenderQuality(const char* quality) {
     PXR_INTERNAL_NS::HdRprConfig* config;
     auto configInstanceLock = PXR_INTERNAL_NS::HdRprConfig::GetInstance(&config);

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -113,8 +113,6 @@ PXR_NAMESPACE_CLOSE_SCOPE
 
 extern "C" {
 
-HDRPR_API void HdRprSetRenderDevice(const char* renderDevice);
-
 HDRPR_API void HdRprSetRenderQuality(const char* quality);
 
 // Returned pointer should be released by the caller with HdRprFree

--- a/pxr/imaging/plugin/hdRpr/usdviewMenu/rpr.py
+++ b/pxr/imaging/plugin/hdRpr/usdviewMenu/rpr.py
@@ -113,7 +113,7 @@ class RprPluginContainer(PluginContainer):
     def registerPlugins(self, plugRegistry, usdviewApi):
         self.chooseRenderDevice = plugRegistry.registerCommandPlugin(
             "RprPluginContainer.chooseRenderDevice",
-            "Render Device",
+            "Render Devices",
             ChooseRenderDevice)
 
         self.setRenderLowQuality = plugRegistry.registerCommandPlugin(

--- a/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
+++ b/pxr/imaging/plugin/rprHoudini/CMakeLists.txt
@@ -64,6 +64,7 @@ install(
     FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/scripts/python/houRpr/__init__.py
         ${CMAKE_CURRENT_SOURCE_DIR}/scripts/python/houRpr/cache.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/scripts/python/houRpr/devices.py
         ${CMAKE_CURRENT_SOURCE_DIR}/scripts/python/houRpr/materialLibrary.py
         ${CMAKE_CURRENT_SOURCE_DIR}/scripts/python/houRpr/materialLibrary.ui
         ${CMAKE_CURRENT_SOURCE_DIR}/scripts/python/houRpr/na.png

--- a/pxr/imaging/plugin/rprHoudini/scripts/python/houRpr/cache.py
+++ b/pxr/imaging/plugin/rprHoudini/scripts/python/houRpr/cache.py
@@ -1,3 +1,14 @@
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import os
 import glob
 

--- a/pxr/imaging/plugin/rprHoudini/scripts/python/houRpr/devices.py
+++ b/pxr/imaging/plugin/rprHoudini/scripts/python/houRpr/devices.py
@@ -1,0 +1,6 @@
+import hou
+from hutil.Qt import QtCore
+from rpr import RprUsd
+
+def open_configuration_window():
+    RprUsd.devicesConfiguration.open_window(hou.ui.mainQtWindow(), QtCore.Qt.Window)

--- a/pxr/imaging/plugin/rprHoudini/scripts/python/houRpr/devices.py
+++ b/pxr/imaging/plugin/rprHoudini/scripts/python/houRpr/devices.py
@@ -1,3 +1,14 @@
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import hou
 from hutil.Qt import QtCore
 from rpr import RprUsd

--- a/pxr/imaging/plugin/rprHoudini/scripts/python/houRpr/materialLibrary.py
+++ b/pxr/imaging/plugin/rprHoudini/scripts/python/houRpr/materialLibrary.py
@@ -1,3 +1,14 @@
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import os
 import re
 import hou

--- a/pxr/imaging/plugin/rprHoudini/ui/MainMenuCommon.xml
+++ b/pxr/imaging/plugin/rprHoudini/ui/MainMenuCommon.xml
@@ -39,7 +39,7 @@
             </subMenu>
 
             <scriptItem id="rpr_devices">
-                <label>Devices...</label>
+                <label>Render Devices</label>
                 <scriptCode><![CDATA[__import__('houRpr.devices').devices.open_configuration_window()]]></scriptCode>
             </scriptItem>
 

--- a/pxr/imaging/plugin/rprHoudini/ui/MainMenuCommon.xml
+++ b/pxr/imaging/plugin/rprHoudini/ui/MainMenuCommon.xml
@@ -38,6 +38,11 @@
 
             </subMenu>
 
+            <scriptItem id="rpr_devices">
+                <label>Devices...</label>
+                <scriptCode><![CDATA[__import__('houRpr.devices').devices.open_configuration_window()]]></scriptCode>
+            </scriptItem>
+
             <separatorItem />
 
             <scriptItem id="rpr_import_material">

--- a/pxr/imaging/rprUsd/CMakeLists.txt
+++ b/pxr/imaging/rprUsd/CMakeLists.txt
@@ -43,9 +43,11 @@ pxr_library(rprUsd
     PYMODULE_CPPFILES
         module.cpp
         wrapConfig.cpp
+        wrapContextHelpers.cpp
 
     PYMODULE_FILES
         __init__.py
+        devicesConfiguration.py
 )
 
 if(HoudiniUSD_FOUND)

--- a/pxr/imaging/rprUsd/__init__.py
+++ b/pxr/imaging/rprUsd/__init__.py
@@ -1,4 +1,5 @@
 from . import _rprUsd
+from . import devicesConfiguration
 from pxr import Tf
 Tf.PrepareModule(_rprUsd, locals())
 del Tf

--- a/pxr/imaging/rprUsd/__init__.py
+++ b/pxr/imaging/rprUsd/__init__.py
@@ -1,3 +1,14 @@
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 from . import _rprUsd
 from . import devicesConfiguration
 from pxr import Tf

--- a/pxr/imaging/rprUsd/config.cpp
+++ b/pxr/imaging/rprUsd/config.cpp
@@ -243,4 +243,9 @@ std::string RprUsdConfig::GetKernelCacheDir() const {
     return ret;
 }
 
+std::string RprUsdConfig::GetDeviceConfigurationFilepath() const {
+    std::string configCacheDir = GetDefaultCacheDir("config");
+    return configCacheDir + ARCH_PATH_SEP + "devicesConfig.txt";
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/config.h
+++ b/pxr/imaging/rprUsd/config.h
@@ -48,6 +48,9 @@ public:
     RPRUSD_API
     void SetKernelCacheDir(std::string const&);
 
+    RPRUSD_API
+    std::string GetDeviceConfigurationFilepath() const;
+
 private:
     RprUsdConfig();
     friend class TfSingleton<RprUsdConfig>;

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -43,6 +43,7 @@ using json = nlohmann::json;
 #endif // __APPLE__
 
 #include <fstream>
+#include <thread>
 #include <map>
 
 #define PRINT_CONTEXT_CREATION_DEBUG_INFO(format, ...) \
@@ -328,7 +329,7 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
         contextProperties.push_back((rpr_context_properties)propertyValue);
     };
 
-    rpr::CreationFlags creationFlags;
+    rpr::CreationFlags creationFlags = 0;
     for (int gpuIndex : devicesConfiguration.gpus) {
         if (gpuIndex >= 0 && gpuIndex < kMaxNumGpus) {
             creationFlags |= kGpuCreationFlags[gpuIndex];

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -14,6 +14,7 @@ limitations under the License.
 #include "pxr/imaging/rprUsd/contextHelpers.h"
 #include "pxr/imaging/rprUsd/contextMetadata.h"
 #include "pxr/imaging/rprUsd/debugCodes.h"
+#include "pxr/imaging/rprUsd/helpers.h"
 #include "pxr/imaging/rprUsd/config.h"
 #include "pxr/imaging/rprUsd/error.h"
 #include "pxr/imaging/rprUsd/util.h"
@@ -30,6 +31,9 @@ limitations under the License.
 #include <vulkan/vulkan.h>
 #endif // HDRPR_ENABLE_VULKAN_INTEROP_SUPPORT
 
+#include <json.hpp>
+using json = nlohmann::json;
+
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #include <mach-o/getsect.h>
@@ -38,6 +42,7 @@ limitations under the License.
 #include <link.h>
 #endif // __APPLE__
 
+#include <fstream>
 #include <map>
 
 #define PRINT_CONTEXT_CREATION_DEBUG_INFO(format, ...) \
@@ -115,6 +120,26 @@ void SetupRprTracing() {
     }
 }
 
+const rpr::CreationFlags kGpuIndexToCreationFlag[] = {
+    RPR_CREATION_FLAGS_ENABLE_GPU0,
+    RPR_CREATION_FLAGS_ENABLE_GPU1,
+    RPR_CREATION_FLAGS_ENABLE_GPU2,
+    RPR_CREATION_FLAGS_ENABLE_GPU3,
+    RPR_CREATION_FLAGS_ENABLE_GPU4,
+    RPR_CREATION_FLAGS_ENABLE_GPU5,
+    RPR_CREATION_FLAGS_ENABLE_GPU6,
+    RPR_CREATION_FLAGS_ENABLE_GPU7,
+    RPR_CREATION_FLAGS_ENABLE_GPU8,
+    RPR_CREATION_FLAGS_ENABLE_GPU9,
+    RPR_CREATION_FLAGS_ENABLE_GPU10,
+    RPR_CREATION_FLAGS_ENABLE_GPU11,
+    RPR_CREATION_FLAGS_ENABLE_GPU12,
+    RPR_CREATION_FLAGS_ENABLE_GPU13,
+    RPR_CREATION_FLAGS_ENABLE_GPU14,
+    RPR_CREATION_FLAGS_ENABLE_GPU15,
+};
+const int kMaxNumGpus = sizeof(kGpuIndexToCreationFlag) / sizeof(kGpuIndexToCreationFlag[0]);
+
 const std::map<RprUsdPluginType, const char*> kPluginLibNames = {
 #ifdef WIN32
     {kPluginTahoe, "Tahoe64.dll"},
@@ -130,103 +155,11 @@ const std::map<RprUsdPluginType, const char*> kPluginLibNames = {
 #endif
 };
 
-rpr::CreationFlags getAllCompatibleGpuFlags(rpr_int pluginID, const char* cachePath) {
-    rpr::CreationFlags additionalFlags = 0x0;
-
-#if defined(__APPLE__)
-    additionalFlags |= RPR_CREATION_FLAGS_ENABLE_METAL;
-#endif
-
-    auto contextIsCreatable = [additionalFlags, pluginID, cachePath](rpr::CreationFlags creationFlag, rpr_context_info contextInfo) {
-        rpr_context temporaryContext = nullptr;
-        rpr_int id = pluginID;
-        auto status = rprCreateContext(RPR_API_VERSION, &id, 1, creationFlag | additionalFlags, nullptr, cachePath, &temporaryContext);
-        if (status == RPR_SUCCESS) {
-            size_t size = 0;
-            auto infoStatus = rprContextGetInfo(temporaryContext, contextInfo, 0, 0, &size);
-            if (infoStatus == RPR_SUCCESS) {
-                std::string deviceName;
-                deviceName.resize(size);
-                infoStatus = rprContextGetInfo(temporaryContext, contextInfo, size, &deviceName[0], 0);
-                if (infoStatus == RPR_SUCCESS) {
-                    PRINT_CONTEXT_CREATION_DEBUG_INFO("%s\n", deviceName.c_str());
-                }
-            }
-            if (infoStatus != RPR_SUCCESS) {
-                PRINT_CONTEXT_CREATION_DEBUG_INFO("Failed to query device name: %d\n", infoStatus);
-                return false;
-            }
-
-            rprObjectDelete(temporaryContext);
-        }
-        return status == RPR_SUCCESS;
-    };
-
-    PRINT_CONTEXT_CREATION_DEBUG_INFO("GPUs:\n");
-
-    rpr::CreationFlags creationFlags = 0x0;
-#define TEST_GPU_COMPATIBILITY(index) \
-    if (contextIsCreatable(RPR_CREATION_FLAGS_ENABLE_GPU ## index, RPR_CONTEXT_GPU ## index ## _NAME)) { \
-        creationFlags |= RPR_CREATION_FLAGS_ENABLE_GPU ## index; \
-    }
-
-    TEST_GPU_COMPATIBILITY(0);
-    TEST_GPU_COMPATIBILITY(1);
-    TEST_GPU_COMPATIBILITY(2);
-    TEST_GPU_COMPATIBILITY(3);
-    TEST_GPU_COMPATIBILITY(4);
-    TEST_GPU_COMPATIBILITY(5);
-    TEST_GPU_COMPATIBILITY(6);
-    TEST_GPU_COMPATIBILITY(7);
-    TEST_GPU_COMPATIBILITY(8);
-    TEST_GPU_COMPATIBILITY(9);
-    TEST_GPU_COMPATIBILITY(10);
-    TEST_GPU_COMPATIBILITY(11);
-    TEST_GPU_COMPATIBILITY(12);
-    TEST_GPU_COMPATIBILITY(13);
-    TEST_GPU_COMPATIBILITY(14);
-    TEST_GPU_COMPATIBILITY(15);
-
-    if (!creationFlags) {
-        PRINT_CONTEXT_CREATION_DEBUG_INFO("None\n");
-    }
-
-    return creationFlags;
-}
-
-rpr::CreationFlags getRprCreationFlags(RprUsdRenderDeviceType renderDevice, rpr_int pluginID, const char* cachePath) {
-    rpr::CreationFlags flags = 0x0;
-
-    if (RprUsdRenderDeviceType::CPU == renderDevice) {
-        PRINT_CONTEXT_CREATION_DEBUG_INFO("RPR CPU context\n");
-        flags = RPR_CREATION_FLAGS_ENABLE_CPU;
-    } else if (RprUsdRenderDeviceType::GPU == renderDevice) {
-        PRINT_CONTEXT_CREATION_DEBUG_INFO("RPR GPU context\n");
-        flags = getAllCompatibleGpuFlags(pluginID, cachePath);
-    } else {
-        return 0x0;
-    }
-
-#if __APPLE__
-    flags |= RPR_CREATION_FLAGS_ENABLE_METAL;
-#endif
-
-    return flags;
-}
-
-} // namespace anonymous
-
-rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
-    SetupRprTracing();
-
-    RprUsdConfig* config;
-    auto configLock = RprUsdConfig::GetInstance(&config);
-    auto cachePath = config->GetKernelCacheDir();
-
-    auto pluginLibNameIter = kPluginLibNames.find(metadata->pluginType);
+rpr_int GetPluginID(RprUsdPluginType pluginType) {
+    auto pluginLibNameIter = kPluginLibNames.find(pluginType);
     if (pluginLibNameIter == kPluginLibNames.end()) {
-        PRINT_CONTEXT_CREATION_DEBUG_INFO("Plugin is not supported: %d", metadata->pluginType);
-        return nullptr;
+        TF_RUNTIME_ERROR("Plugin is not supported: %d", pluginType);
+        return -1;
     }
     auto pluginLibName = pluginLibNameIter->second;
 
@@ -234,55 +167,197 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
     const std::string pluginPath = rprSdkPath.empty() ? pluginLibName : rprSdkPath + "/" + pluginLibName;
     rpr_int pluginID = rprRegisterPlugin(pluginPath.c_str());
     if (pluginID == -1) {
-        PRINT_CONTEXT_CREATION_DEBUG_INFO("Failed to register %s plugin located at \"%s\"", pluginLibName, pluginPath.c_str());
+        TF_RUNTIME_ERROR("Failed to register %s plugin located at \"%s\"", pluginLibName, pluginPath.c_str());
+        return -1;
+    }
+
+    return pluginID;
+}
+
+std::string GetGpuName(rpr_int pluginID, rpr::CreationFlags creationFlag, rpr::ContextInfo gpuNameId, const char* cachePath) {
+    rpr::CreationFlags additionalFlags = 0x0;
+
+#if defined(__APPLE__)
+    additionalFlags |= RPR_CREATION_FLAGS_ENABLE_METAL;
+#endif
+
+    try {
+        rpr::Status status;
+        std::unique_ptr<rpr::Context> context(rpr::Context::Create(RPR_API_VERSION, &pluginID, 1, creationFlag | additionalFlags, nullptr, cachePath, &status));
+        if (context) {
+            return RprUsdGetStringInfo(context.get(), gpuNameId);
+        }
+    } catch (RprUsdError& e) {
+        PRINT_CONTEXT_CREATION_DEBUG_INFO("Failed to get gpu name: %s", e.what());
+    }
+    
+    return {};
+}
+
+template <typename Func>
+void ForEachGpu(rpr_int pluginID, const char* cachePath, Func&& func) {
+#define GPU_ACTION(index) \
+    do { \
+        rpr::CreationFlags gpuFlag = RPR_CREATION_FLAGS_ENABLE_GPU ## index; \
+        std::string name = GetGpuName(pluginID, gpuFlag, RPR_CONTEXT_GPU ## index ## _NAME, cachePath); \
+        func(index, gpuFlag, name); \
+    } while (0);
+
+    GPU_ACTION(0);
+    GPU_ACTION(1);
+    GPU_ACTION(2);
+    GPU_ACTION(3);
+    GPU_ACTION(4);
+    GPU_ACTION(5);
+    GPU_ACTION(6);
+    GPU_ACTION(7);
+    GPU_ACTION(8);
+    GPU_ACTION(9);
+    GPU_ACTION(10);
+    GPU_ACTION(11);
+    GPU_ACTION(12);
+    GPU_ACTION(13);
+    GPU_ACTION(14);
+    GPU_ACTION(15);
+
+#undef GPU_ACTION
+}
+
+struct DevicesConfiguration {
+    int numCpuThreads;
+    std::vector<int> gpus;
+};
+
+DevicesConfiguration LoadDevicesConfiguration(RprUsdPluginType pluginType, std::string const& deviceConfigurationFilepath) {
+    DevicesConfiguration ret = {};
+
+    RprUsdDevicesInfo devicesInfo = RprUsdGetDevicesInfo(pluginType);
+
+    auto isLoaded = [&]() {
+        try {
+            std::ifstream configFile(deviceConfigurationFilepath);
+            if (!configFile.is_open()) {
+                return false;
+            }
+
+            json devicesConfig;
+            configFile >> devicesConfig;
+
+            auto pluginDevicesConfigIt = std::find_if(devicesConfig.begin(), devicesConfig.end(),
+                [pluginType](json& entry) {
+                    bool foundIt;
+                    RprUsdPluginType entryPluginType = TfEnum::GetValueFromName<RprUsdPluginType>(entry["plugin_type"], &foundIt);
+                    return foundIt && entryPluginType == pluginType;
+                }
+            );
+            if (pluginDevicesConfigIt == devicesConfig.end()) {
+                return false;
+            }
+
+            auto& pluginDevicesConfig = *pluginDevicesConfigIt;
+
+            auto& cpuConfig = pluginDevicesConfig.at("cpu_config");
+
+            auto& cpuInfo = cpuConfig.at("cpu_info");
+            if (devicesInfo.cpu.numThreads != cpuInfo.at("num_threads").get<int>()) {
+                return false;
+            }
+
+            cpuConfig.at("num_active_threads").get_to(ret.numCpuThreads);
+
+            for (auto& gpuConfig : pluginDevicesConfig.at("gpu_configs")) {
+                auto& configGpuInfo = gpuConfig.at("gpu_info");
+                RprUsdDevicesInfo::GPU gpuInfo(configGpuInfo.at("index"), configGpuInfo.at("name"));
+                if (std::find(devicesInfo.gpus.begin(), devicesInfo.gpus.end(), gpuInfo) == devicesInfo.gpus.end()) {
+                    return false;
+                }
+
+                if (gpuConfig.at("is_enabled").get<bool>()) {
+                    ret.gpus.push_back(gpuInfo.index);
+                }
+            }
+
+            return true;
+        } catch (std::exception& e) {
+            TF_RUNTIME_ERROR("Error on loading devices configurations: %s", e.what());
+            return false;
+        }
+    }();
+
+    if (!isLoaded ||
+        (ret.numCpuThreads == 0 && ret.gpus.empty())) {
+        // Setup default configuration: either use the first GPU or, if it is not available, CPU
+        ret = {};
+        if (devicesInfo.gpus.empty()) {
+            ret.numCpuThreads = devicesInfo.cpu.numThreads;
+        } else {
+            ret.gpus.push_back(devicesInfo.gpus.front().index);
+        }
+    }
+
+    return ret;
+}
+
+} // namespace anonymous
+
+rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
+    SetupRprTracing();
+
+    std::string cachePath;
+    std::string textureCachePath;
+    std::string deviceConfigurationFilepath;
+
+    {
+        RprUsdConfig* config;
+        auto configLock = RprUsdConfig::GetInstance(&config);
+        cachePath = config->GetKernelCacheDir();
+        textureCachePath = config->GetTextureCacheDir();
+        deviceConfigurationFilepath = config->GetDeviceConfigurationFilepath();
+    }
+
+    rpr_int pluginID = GetPluginID(metadata->pluginType);
+    if (pluginID == -1) {
         return nullptr;
     }
 
-    rpr::CreationFlags flags;
-    if (metadata->pluginType == kPluginHybrid) {
-        // Call to getRprCreationFlags is broken in case of hybrid:
-        //   1) getRprCreationFlags uses 'rprContextGetInfo' to query device compatibility,
-        //        but hybrid plugin does not support such call
-        //   2) Hybrid is working only on GPU
-        //   3) MultiGPU can be enabled only through vulkan interop
-        flags = RPR_CREATION_FLAGS_ENABLE_GPU0;
-    } else {
-        flags = getRprCreationFlags(metadata->renderDeviceType, pluginID, cachePath.c_str());
-        if (!flags) {
-            bool isGpuIncompatible = metadata->renderDeviceType == RprUsdRenderDeviceType::GPU;
-            PRINT_CONTEXT_CREATION_DEBUG_INFO("%s is not compatible", isGpuIncompatible ? "GPU" : "CPU");
-            metadata->renderDeviceType = isGpuIncompatible ? RprUsdRenderDeviceType::CPU : RprUsdRenderDeviceType::GPU;
-            flags = getRprCreationFlags(metadata->renderDeviceType, pluginID, cachePath.c_str());
-            if (!flags) {
-                PRINT_CONTEXT_CREATION_DEBUG_INFO("Could not find compatible device");
-                return nullptr;
-            } else {
-                PRINT_CONTEXT_CREATION_DEBUG_INFO("Using %s for render computations", isGpuIncompatible ? "CPU" : "GPU");
-            }
-        }
-    }
-
-    if (metadata->isGlInteropEnabled) {
-        if (metadata->renderDeviceType == RprUsdRenderDeviceType::CPU || metadata->pluginType == kPluginHybrid) {
-            PRINT_CONTEXT_CREATION_DEBUG_INFO("GL interop could not be used with CPU rendering or Hybrid plugin");
-            metadata->isGlInteropEnabled = false;
-        } else if (!RprUsdInitGLApi()) {
-            PRINT_CONTEXT_CREATION_DEBUG_INFO("Failed to init GL API. Disabling GL interop");
-            metadata->isGlInteropEnabled = false;
-        } else {
-            metadata->isGlInteropEnabled = true;
-        }
-    }
-
-    if (metadata->isGlInteropEnabled) {
-        flags |= RPR_CREATION_FLAGS_ENABLE_GL_INTEROP;
-    }
+    DevicesConfiguration devicesConfiguration = LoadDevicesConfiguration(metadata->pluginType, deviceConfigurationFilepath);
 
     std::vector<rpr_context_properties> contextProperties;
     auto appendContextProperty = [&contextProperties](uint64_t propertyKey, void* propertyValue) {
         contextProperties.push_back((rpr_context_properties)propertyKey);
         contextProperties.push_back((rpr_context_properties)propertyValue);
     };
+
+    rpr::CreationFlags creationFlags;
+    for (int gpuIndex : devicesConfiguration.gpus) {
+        if (gpuIndex >= 0 && gpuIndex < kMaxNumGpus) {
+            creationFlags |= kGpuIndexToCreationFlag[gpuIndex];
+        }
+    }
+    if (devicesConfiguration.numCpuThreads > 0) {
+        creationFlags |= RPR_CREATION_FLAGS_ENABLE_CPU;
+        appendContextProperty(RPR_CONTEXT_CPU_THREAD_LIMIT, (void*)(size_t)devicesConfiguration.numCpuThreads);
+    }
+#if __APPLE__
+    if ((creationFlags & RPR_CREATION_FLAGS_ENABLE_CPU) == 0) {
+        creationFlags |= RPR_CREATION_FLAGS_ENABLE_METAL;
+    }
+#endif
+
+    if (metadata->isGlInteropEnabled) {
+        if ((creationFlags & RPR_CREATION_FLAGS_ENABLE_CPU) == 0 ||
+            metadata->pluginType == kPluginHybrid) {
+            PRINT_CONTEXT_CREATION_DEBUG_INFO("GL interop could not be used with CPU rendering or Hybrid plugin");
+            metadata->isGlInteropEnabled = false;
+        } else if (!RprUsdInitGLApi()) {
+            PRINT_CONTEXT_CREATION_DEBUG_INFO("Failed to init GL API. Disabling GL interop");
+            metadata->isGlInteropEnabled = false;
+        }
+    }
+
+    if (metadata->isGlInteropEnabled) {
+        creationFlags |= RPR_CREATION_FLAGS_ENABLE_GL_INTEROP;
+    }
 
 #ifdef HDRPR_ENABLE_VULKAN_INTEROP_SUPPORT
     if (metadata->pluginType == RprUsdPluginType::kPluginHybrid && metadata->interopInfo) {
@@ -305,7 +380,7 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
     contextProperties.push_back(nullptr);
 
     rpr::Status status;
-    rpr::Context* context = rpr::Context::Create(RPR_API_VERSION, &pluginID, 1, flags, contextProperties.data(), cachePath.c_str(), &status);
+    rpr::Context* context = rpr::Context::Create(RPR_API_VERSION, &pluginID, 1, creationFlags, contextProperties.data(), cachePath.c_str(), &status);
 
     if (context) {
         if (RPR_ERROR_CHECK(context->SetActivePlugin(pluginID), "Failed to set active plugin")) {
@@ -317,9 +392,42 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
         return nullptr;
     }
 
-    RPR_ERROR_CHECK(context->SetParameter(RPR_CONTEXT_TEXTURE_CACHE_PATH, config->GetTextureCacheDir().c_str()), "Failed to set texture cache path");
+    RPR_ERROR_CHECK(context->SetParameter(RPR_CONTEXT_TEXTURE_CACHE_PATH, textureCachePath.c_str()), "Failed to set texture cache path");
 
     return context;
+}
+
+RprUsdDevicesInfo RprUsdGetDevicesInfo(RprUsdPluginType pluginType) {
+    RprUsdDevicesInfo ret = {};
+
+    std::string cachePath;
+    {
+        RprUsdConfig* config;
+        auto configLock = RprUsdConfig::GetInstance(&config);
+        cachePath = config->GetKernelCacheDir();
+    }
+
+    rpr_int pluginID = GetPluginID(pluginType);
+    if (pluginType == kPluginHybrid) {
+        ret.cpu.numThreads = 0;
+
+        std::string name = GetGpuName(pluginID, RPR_CREATION_FLAGS_ENABLE_GPU0, RPR_CONTEXT_GPU0_NAME, cachePath.c_str());
+        if (!name.empty()) {
+            ret.gpus.push_back({0, name});
+        }
+    } else {
+        ret.cpu.numThreads = std::thread::hardware_concurrency();
+
+        ForEachGpu(pluginID, cachePath.c_str(),
+            [&ret](int index, rpr::CreationFlags, std::string const& name) {
+                if (!name.empty()) {
+                    ret.gpus.push_back({index, name});
+                }
+            }
+        );
+    }
+
+    return ret;
 }
 
 bool RprUsdIsTracingEnabled() {

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -11,6 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ************************************************************************/
 
+#include <json.hpp>
+using json = nlohmann::json;
+
 #include "pxr/imaging/rprUsd/contextHelpers.h"
 #include "pxr/imaging/rprUsd/contextMetadata.h"
 #include "pxr/imaging/rprUsd/debugCodes.h"
@@ -30,9 +33,6 @@ limitations under the License.
 #include <RadeonProRender_Baikal.h>
 #include <vulkan/vulkan.h>
 #endif // HDRPR_ENABLE_VULKAN_INTEROP_SUPPORT
-
-#include <json.hpp>
-using json = nlohmann::json;
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>

--- a/pxr/imaging/rprUsd/contextHelpers.h
+++ b/pxr/imaging/rprUsd/contextHelpers.h
@@ -42,6 +42,10 @@ struct RprUsdDevicesInfo {
         bool operator==(GPU const& rhs) { return index == rhs.index && name == rhs.name; }
     };
     std::vector<GPU> gpus;
+
+    bool IsValid() const {
+        return cpu.numThreads > 0 || !gpus.empty();
+    }
 };
 
 RPRUSD_API

--- a/pxr/imaging/rprUsd/contextHelpers.h
+++ b/pxr/imaging/rprUsd/contextHelpers.h
@@ -15,15 +15,37 @@ limitations under the License.
 #define PXR_IMAGING_RPR_USD_CONTEXT_HELPERS_H
 
 #include "pxr/imaging/rprUsd/api.h"
+#include "pxr/imaging/rprUsd/contextMetadata.h"
+
+#include <string>
+#include <vector>
 
 namespace rpr { class Context; }
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-struct RprUsdContextMetadata;
-
 RPRUSD_API
 rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata);
+
+struct RprUsdDevicesInfo {
+    struct CPU {
+        int numThreads;
+        CPU(int numThreads = 0) : numThreads(numThreads) {}
+        bool operator==(CPU const& rhs) { return numThreads == rhs.numThreads; }
+    };
+    CPU cpu;
+
+    struct GPU {
+        int index;
+        std::string name;
+        GPU(int index = -1, std::string name = {}) : index(index), name(name) {}
+        bool operator==(GPU const& rhs) { return index == rhs.index && name == rhs.name; }
+    };
+    std::vector<GPU> gpus;
+};
+
+RPRUSD_API
+RprUsdDevicesInfo RprUsdGetDevicesInfo(RprUsdPluginType pluginType);
 
 RPRUSD_API
 bool RprUsdIsTracingEnabled();

--- a/pxr/imaging/rprUsd/contextMetadata.h
+++ b/pxr/imaging/rprUsd/contextMetadata.h
@@ -15,6 +15,9 @@ limitations under the License.
 #define PXR_IMAGING_RPR_USD_CONTEXT_METADATA_H
 
 #include "pxr/pxr.h"
+#include "pxr/imaging/rprUsd/api.h"
+
+#include <RadeonProRender.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -26,18 +29,15 @@ enum RprUsdPluginType {
     kPluginsCount
 };
 
-enum class RprUsdRenderDeviceType {
-    Invalid,
-    CPU,
-    GPU,
-};
-
 struct RprUsdContextMetadata {
     RprUsdPluginType pluginType = kPluginInvalid;
-    RprUsdRenderDeviceType renderDeviceType = RprUsdRenderDeviceType::Invalid;
     bool isGlInteropEnabled = false;
     void* interopInfo = nullptr;
+    rpr::CreationFlags creationFlags = 0;
 };
+
+RPRUSD_API
+bool RprUsdIsGpuUsed(RprUsdContextMetadata const& contextMetadata);
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/rprUsd/devicesConfiguration.py
+++ b/pxr/imaging/rprUsd/devicesConfiguration.py
@@ -320,7 +320,7 @@ class _DevicesConfigurationDialog(QtWidgets.QDialog):
         if self.configuration.context.parent:
             self.setParent(self.configuration.context.parent, self.configuration.context.parent_flags)
         self.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
-        self.setWindowTitle('RPR Devices')
+        self.setWindowTitle('RPR Render Devices')
 
         self.main_layout = QtWidgets.QVBoxLayout(self)
         self.main_layout.setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
@@ -334,7 +334,7 @@ class _DevicesConfigurationDialog(QtWidgets.QDialog):
 
         if show_restart_warning:
             self.restart_warning_label = QtWidgets.QLabel(self)
-            self.restart_warning_label.setText('Changes to a device will not take effect until the RPR renderer restarts.')
+            self.restart_warning_label.setText('Changes will not take effect until the RPR renderer restarts.')
             self.restart_warning_label.setStyleSheet('color: rgb(255,204,0)')
             self.restart_warning_label.hide()
             self.main_layout.addWidget(self.restart_warning_label)

--- a/pxr/imaging/rprUsd/devicesConfiguration.py
+++ b/pxr/imaging/rprUsd/devicesConfiguration.py
@@ -1,3 +1,14 @@
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import json
 
 from . import _rprUsd as RprUsd

--- a/pxr/imaging/rprUsd/devicesConfiguration.py
+++ b/pxr/imaging/rprUsd/devicesConfiguration.py
@@ -26,7 +26,12 @@ def _setup_devices_info():
     if _devices_info == None:
         _devices_info = dict()
         for plugin_type in RprUsd.PluginType.allValues[1:]:
-            _devices_info[plugin_type] = RprUsd.GetDevicesInfo(plugin_type)
+            try:
+                devices_info = RprUsd.GetDevicesInfo(plugin_type)
+                if devices_info.isValid:
+                    _devices_info[plugin_type] = devices_info
+            except:
+                pass
 
 
 class _GpuConfiguration:
@@ -175,8 +180,10 @@ class _Configuration:
 
     @staticmethod
     def default(context):
-        default_order = [RprUsd.kPluginNorthstar, RprUsd.kPluginTahoe, RprUsd.kPluginHybrid]
-        plugin_configurations = [_PluginConfiguration.default(plugin_type, _devices_info[plugin_type]) for plugin_type in default_order]
+        plugin_configurations = list()
+        for plugin_type in [RprUsd.kPluginNorthstar, RprUsd.kPluginTahoe, RprUsd.kPluginHybrid]:
+            if plugin_type in _devices_info:
+                plugin_configurations.append(_PluginConfiguration.default(plugin_type, _devices_info[plugin_type]))
         return _Configuration(context=context, plugin_configurations=plugin_configurations)
 
     def __eq__(self, other):

--- a/pxr/imaging/rprUsd/devicesConfiguration.py
+++ b/pxr/imaging/rprUsd/devicesConfiguration.py
@@ -1,0 +1,379 @@
+import json
+
+from . import _rprUsd as RprUsd
+
+try:
+    from hutil.Qt import QtCore, QtGui, QtWidgets
+except:
+    from .qt import QtCore, QtGui, QtWidgets
+
+# from rpr import RprUsd
+
+_devices_info = None
+def _setup_devices_info():
+    global _devices_info
+    if _devices_info == None:
+        _devices_info = dict()
+        for plugin_type in RprUsd.PluginType.allValues[1:]:
+            _devices_info[plugin_type] = RprUsd.GetDevicesInfo(plugin_type)
+
+
+class _GpuConfiguration:
+    def __init__(self, is_enabled, gpu_info):
+        self.is_enabled = is_enabled
+        self.gpu_info = gpu_info
+
+    def serialize(self):
+        return {
+            'is_enabled': self.is_enabled,
+            'gpu_info': {
+                'index': self.gpu_info.index,
+                'name': self.gpu_info.name
+            }
+        }
+
+    @staticmethod
+    def deserialize(data):
+        return _GpuConfiguration(is_enabled=data['is_enabled'],
+                                 gpu_info=RprUsd.GPUDeviceInfo(data['gpu_info']['index'], data['gpu_info']['name']))
+
+    def __eq__(self, other):
+        return self.is_enabled == other.is_enabled and \
+               self.gpu_info == other.gpu_info
+
+    def __ne__(self, other):
+        return not self == other
+
+    def deepcopy(self):
+        return _GpuConfiguration(is_enabled=self.is_enabled,
+                                 gpu_info=self.gpu_info)
+
+
+class _CpuConfiguration:
+    def __init__(self, num_active_threads, cpu_info):
+        self.num_active_threads = num_active_threads
+        self.cpu_info = cpu_info
+
+    def serialize(self):
+        return {
+            'num_active_threads': self.num_active_threads,
+            'cpu_info': {
+                'num_threads': self.cpu_info.numThreads
+            }
+        }
+
+    @staticmethod
+    def deserialize(data):
+        return _CpuConfiguration(num_active_threads=data['num_active_threads'],
+                                 cpu_info=RprUsd.CPUDeviceInfo(data['cpu_info']['num_threads']))
+
+    def __eq__(self, other):
+        return self.num_active_threads == other.num_active_threads and \
+               self.cpu_info == other.cpu_info
+
+    def __ne__(self, other):
+        return not self == other
+
+    def deepcopy(self):
+        return _CpuConfiguration(num_active_threads=self.num_active_threads,
+                                 cpu_info=self.cpu_info)
+
+
+class _PluginConfiguration:
+    def __init__(self, plugin_type, cpu_config, gpu_configs):
+        self.plugin_type = plugin_type
+        self.cpu_config = cpu_config
+        self.gpu_configs = gpu_configs
+
+    @staticmethod
+    def default(plugin_type, plugin_devices_info):
+        gpu_configs = [_GpuConfiguration(is_enabled=idx==0, gpu_info=gpu_info) for idx, gpu_info in enumerate(plugin_devices_info.gpus)]
+        cpu_config = _CpuConfiguration(num_active_threads=plugin_devices_info.cpu.num_threads if not gpu_configs else 0, cpu_info=plugin_devices_info.cpu)
+        return _PluginConfiguration(plugin_type=plugin_type, cpu_config=cpu_config, gpu_configs=gpu_configs)
+
+    def serialize(self):
+        return {
+            'plugin_type': self.plugin_type.name,
+            'cpu_config': self.cpu_config.serialize(),
+            'gpu_configs': [gpu.serialize() for gpu in self.gpu_configs]
+        }
+
+    @staticmethod
+    def deserialize(data):
+        return _PluginConfiguration(plugin_type=RprUsd.PluginType.GetValueFromName(data['plugin_type']),
+                                    cpu_config=_CpuConfiguration.deserialize(data['cpu_config']),
+                                    gpu_configs=[_GpuConfiguration.deserialize(gpu_data) for gpu_data in data['gpu_configs']])
+
+    def __eq__(self, other):
+        return self.plugin_type == other.plugin_type and \
+               self.cpu_config == other.cpu_config and \
+               self.gpu_configs == other.gpu_configs
+
+    def __ne__(self, other):
+        return not self == other
+
+    def deepcopy(self):
+        return _PluginConfiguration(plugin_type=self.plugin_type,
+                                    cpu_config=self.cpu_config.deepcopy(),
+                                    gpu_configs=[config.deepcopy() for config in self.gpu_configs])
+
+
+class _Configuration:
+    def __init__(self, context, plugin_configurations=list()):
+        self.context = context
+        self.plugin_configurations = plugin_configurations
+
+    def is_outdated(self):
+        for plugin_configuration in self.plugin_configurations:
+            devices_info = _devices_info[plugin_configuration.plugin_type]
+
+            config_gpu_infos = [gpu_config.gpu_info for gpu_config in plugin_configuration.gpu_configs]
+            if plugin_configuration.cpu_config.cpu_info == devices_info.cpu and \
+               config_gpu_infos == devices_info.gpus:
+               continue
+            return True
+        return False
+
+    @staticmethod
+    def load(context, file):
+        try:
+            with open(file) as f:
+                j = json.load(f)
+                plugin_configurations = [_PluginConfiguration.deserialize(data) for data in j]
+                configuration = _Configuration(context=context, plugin_configurations=plugin_configurations)
+                if not configuration.is_outdated():
+                    return configuration
+                else:
+                    print('Hardware change detected. Falling back to default device configuration.')
+        except IOError:
+            pass
+        except (ValueError, KeyError) as e:
+            context.show_error('Failed to load device configuration', 'Error: "{}". Falling back to default device configuration.\n'.format(e.msg))
+
+        return _Configuration.default(context)
+
+    def save(self, file):
+        try:
+            with open(file, 'w') as f:
+                serialized_data = [config.serialize() for config in self.plugin_configurations]
+                json.dump(serialized_data, f)
+        except IOError as e:
+            self.context.show_error('Failed to save device configuration', e.msg)
+
+    @staticmethod
+    def default(context):
+        default_order = [RprUsd.kPluginNorthstar, RprUsd.kPluginTahoe, RprUsd.kPluginHybrid]
+        plugin_configurations = [_PluginConfiguration.default(plugin_type, _devices_info[plugin_type]) for plugin_type in default_order]
+        return _Configuration(context=context, plugin_configurations=plugin_configurations)
+
+    def __eq__(self, other):
+        return self.plugin_configurations == other.plugin_configurations
+
+    def __ne__(self, other):
+        return not self == other
+
+    def deepcopy(self):
+        return _Configuration(context=self.context, plugin_configurations=[config.deepcopy() for config in self.plugin_configurations])
+
+
+BORDERSIZE=2
+BORDERRADIUS=10
+BORDERCOLOR = QtGui.QColor(42, 42, 42)
+
+class BorderWidget(QtWidgets.QFrame):
+    def __init__(self, borderradius=BORDERRADIUS, bordersize=BORDERSIZE, bordercolor=BORDERCOLOR, parent=None):
+        super(BorderWidget, self).__init__(parent)
+        color = '{}, {}, {}'.format(bordercolor.red(), bordercolor.green(), bordercolor.blue())
+        self.setObjectName('BorderWidget')
+        self.setStyleSheet('QFrame#BorderWidget {{ border-radius: {radius}px; border: {size}px; border-style: solid; border-color: rgb({color}) }}'.format(radius=borderradius, size=bordersize, color=color))
+
+
+class _DeviceWidget(BorderWidget):
+    on_change = QtCore.Signal()
+
+    def __init__(self, cpu_config=None, gpu_config=None, parent=None):
+        super(_DeviceWidget, self).__init__(parent=parent)
+
+        self.cpu_config = cpu_config
+        self.gpu_config = gpu_config
+
+        self.main_layout = QtWidgets.QHBoxLayout(self)
+        self.main_layout.setContentsMargins(
+            self.main_layout.contentsMargins().left() // 2,
+            self.main_layout.contentsMargins().top() // 4,
+            self.main_layout.contentsMargins().right() // 2,
+            self.main_layout.contentsMargins().bottom() // 4)
+
+        self.device_name_label = QtWidgets.QLabel(self)
+        self.main_layout.addWidget(self.device_name_label)
+
+        if gpu_config:
+            self.device_name_label.setText('GPU "{}"'.format(gpu_config.gpu_info.name))
+
+            self.is_enabled_check_box = QtWidgets.QCheckBox(self)
+            self.is_enabled_check_box.setChecked(gpu_config.is_enabled)
+            self.is_enabled_check_box.stateChanged.connect(self.on_gpu_update)
+            self.main_layout.addWidget(self.is_enabled_check_box)
+
+        elif cpu_config:
+            self.num_threads_spin_box = QtWidgets.QSpinBox(self)
+            self.num_threads_spin_box.setValue(cpu_config.num_active_threads)
+            self.num_threads_spin_box.setRange(0, cpu_config.cpu_info.numThreads)
+            self.num_threads_spin_box.valueChanged.connect(self.on_cpu_update)
+            self.main_layout.addWidget(self.num_threads_spin_box)
+
+            self.device_name_label.setText('CPU Threads')
+
+        self.setLayout(self.main_layout)
+
+    def on_gpu_update(self, is_enabled):
+        self.gpu_config.is_enabled = bool(is_enabled)
+        self.on_change.emit()
+
+    def on_cpu_update(self, num_threads):
+        self.cpu_config.num_active_threads = num_threads
+        self.on_change.emit()
+
+
+class _PluginConfigurationWidget(BorderWidget):
+    on_change = QtCore.Signal()
+
+    def __init__(self, plugin_configuration, parent):
+        super(_PluginConfigurationWidget, self).__init__(parent=parent)
+        self.plugin_configuration = plugin_configuration
+
+        self.main_layout = QtWidgets.QVBoxLayout(self)
+        self.main_layout.setContentsMargins(
+            self.main_layout.contentsMargins().left() // 2,
+            self.main_layout.contentsMargins().top() // 2,
+            self.main_layout.contentsMargins().right() // 2,
+            self.main_layout.contentsMargins().bottom() // 2)
+
+        self.plugin_type = plugin_configuration.plugin_type
+        if self.plugin_type == RprUsd.kPluginHybrid:
+            plugin_qualities = 'Low-High Qualities'
+        elif self.plugin_type == RprUsd.kPluginTahoe:
+            plugin_qualities = 'Full (Legacy) Quality'
+        elif self.plugin_type == RprUsd.kPluginNorthstar:
+            plugin_qualities = 'Full Quality'
+
+        self.labels_widget = QtWidgets.QWidget(self)
+        self.main_layout.addWidget(self.labels_widget)
+
+        self.labels_widget_layout = QtWidgets.QHBoxLayout(self.labels_widget)
+        self.labels_widget_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.plugin_qualities_label = QtWidgets.QLabel(self.labels_widget)
+        self.plugin_qualities_label.setText(plugin_qualities)
+        self.labels_widget_layout.addWidget(self.plugin_qualities_label)
+
+        self.incomplete_config_label = QtWidgets.QLabel(self.labels_widget)
+        self.incomplete_config_label.setStyleSheet('color: rgb(255,204,0)')
+        self.incomplete_config_label.setText('Configuration is incomplete: no devices')
+        self.labels_widget_layout.addWidget(self.incomplete_config_label)
+        self.incomplete_config_label.hide()
+
+        if plugin_configuration.cpu_config.cpu_info.numThreads:
+            cpu_widget = _DeviceWidget(parent=self, cpu_config=plugin_configuration.cpu_config)
+            cpu_widget.on_change.connect(self.on_device_change)
+            self.main_layout.addWidget(cpu_widget)
+
+        for gpu_config in plugin_configuration.gpu_configs:
+            gpu_widget = _DeviceWidget(parent=self, gpu_config=gpu_config)
+            gpu_widget.on_change.connect(self.on_device_change)
+            self.main_layout.addWidget(gpu_widget)
+
+        self.is_complete = True
+
+    def on_device_change(self):
+        self.is_complete = self.plugin_configuration.cpu_config.num_active_threads > 0 or \
+                           any([gpu_config.is_enabled for gpu_config in self.plugin_configuration.gpu_configs])
+
+        if self.is_complete:
+            self.incomplete_config_label.hide()
+        else:
+            self.incomplete_config_label.show()
+
+        self.on_change.emit()
+
+
+class _DevicesConfigurationDialog(QtWidgets.QDialog):
+    def __init__(self, configuration):
+        super(_DevicesConfigurationDialog, self).__init__()
+
+        self.configuration = configuration
+        self.initial_configuration = configuration.deepcopy()
+
+        if self.configuration.context.parent:
+            self.setParent(self.configuration.context.parent, self.configuration.context.parent_flags)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
+        self.setWindowTitle('RPR Devices')
+
+        self.main_layout = QtWidgets.QVBoxLayout(self)
+        self.main_layout.setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
+
+        self.plugin_configuration_widgets = list()
+        for config in configuration.plugin_configurations:
+            widget = _PluginConfigurationWidget(config, self)
+            widget.on_change.connect(self.on_plugin_configuration_change)
+            self.main_layout.addWidget(widget)
+            self.plugin_configuration_widgets.append(widget)
+
+        self.restart_warning_label = QtWidgets.QLabel(self)
+        self.restart_warning_label.setText('Changes to a device will not take effect until the RPR renderer restarts.')
+        self.restart_warning_label.setStyleSheet('color: rgb(255,204,0)')
+        self.restart_warning_label.hide()
+        self.main_layout.addWidget(self.restart_warning_label)
+
+        self.button_box = QtWidgets.QDialogButtonBox(self)
+        self.save_button = self.button_box.addButton("Save", QtWidgets.QDialogButtonBox.AcceptRole)
+        self.save_button.setEnabled(False)
+        self.button_box.addButton("Cancel", QtWidgets.QDialogButtonBox.RejectRole)
+        self.button_box.accepted.connect(self.on_accept)
+        self.button_box.rejected.connect(self.on_reject)
+        self.main_layout.addWidget(self.button_box)
+
+        self.show()
+
+        self.should_update_configuration = False
+
+    def on_reject(self):
+        self.close()
+
+    def on_accept(self):
+        self.should_update_configuration = True
+        self.close()
+
+    def on_plugin_configuration_change(self):
+        is_save_enabled = all([widget.is_complete for widget in self.plugin_configuration_widgets]) and \
+                          self.initial_configuration != self.configuration
+        self.save_button.setEnabled(is_save_enabled)
+        if is_save_enabled:
+            self.restart_warning_label.show()
+        else:
+            self.restart_warning_label.hide()
+
+def open_window(parent=None, parent_flags=QtCore.Qt.Widget):
+    _setup_devices_info()
+
+    class Context:
+        def __init__(self, parent, parent_flags):
+            self.parent = parent
+            self.parent_flags = parent_flags
+
+        def show_error(title, text):
+            msg = QtWidgets.QMessageBox()
+            msg.setParent(self.parent, self.parent_flags)
+            msg.setIcon(QtWidgets.QMessageBox.Critical)
+            msg.setText(text)
+            msg.setWindowTitle(title)
+            msg.show()
+
+    configuration_filepath = RprUsd.Config.GetDeviceConfigurationFilepath()
+    configuration = _Configuration.load(Context(parent, parent_flags), configuration_filepath)
+
+    dialog = _DevicesConfigurationDialog(configuration)
+    dialog.exec_()
+
+    if dialog.should_update_configuration:
+        configuration.save(configuration_filepath)

--- a/pxr/imaging/rprUsd/module.cpp
+++ b/pxr/imaging/rprUsd/module.cpp
@@ -19,4 +19,5 @@ PXR_NAMESPACE_USING_DIRECTIVE
 TF_WRAP_MODULE
 {
     TF_WRAP(Config);
+    TF_WRAP(ContextHelpers);
 }

--- a/pxr/imaging/rprUsd/wrapConfig.cpp
+++ b/pxr/imaging/rprUsd/wrapConfig.cpp
@@ -48,5 +48,6 @@ void wrapConfig() {
         CONFIG_GETTER(IsRestartWarningEnabled)
         CONFIG_GETTER(GetTextureCacheDir)
         CONFIG_GETTER(GetKernelCacheDir)
+        CONFIG_GETTER(GetDeviceConfigurationFilepath)
     ;
 }

--- a/pxr/imaging/rprUsd/wrapContextHelpers.cpp
+++ b/pxr/imaging/rprUsd/wrapContextHelpers.cpp
@@ -1,0 +1,59 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#include "contextHelpers.h"
+#include "boostIncludePath.h"
+
+#include "pxr/base/tf/pyEnum.h"
+#include "pxr/base/tf/registryManager.h"
+#include "pxr/base/tf/pyResultConversions.h"
+
+#include BOOST_INCLUDE_PATH(python.hpp)
+#include BOOST_INCLUDE_PATH(python/class.hpp)
+#include BOOST_INCLUDE_PATH(python/def.hpp)
+#include BOOST_INCLUDE_PATH(python/scope.hpp)
+
+using namespace BOOST_NS::python;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+TF_REGISTRY_FUNCTION(TfEnum) {
+    TF_ADD_ENUM_NAME(kPluginInvalid);
+    TF_ADD_ENUM_NAME(kPluginTahoe);
+    TF_ADD_ENUM_NAME(kPluginNorthstar);
+    TF_ADD_ENUM_NAME(kPluginHybrid);
+}
+
+void wrapContextHelpers() {
+    class_<RprUsdDevicesInfo::GPU>("GPUDeviceInfo")
+        .def(init<int, std::string>())
+        .def_readonly("index", &RprUsdDevicesInfo::GPU::index)
+        .def_readonly("name", &RprUsdDevicesInfo::GPU::name)
+        .def("__eq__", &RprUsdDevicesInfo::GPU::operator==)
+        ;
+
+    class_<RprUsdDevicesInfo::CPU>("CPUDeviceInfo")
+        .def(init<int>())
+        .def_readonly("numThreads", &RprUsdDevicesInfo::CPU::numThreads)
+        .def("__eq__", &RprUsdDevicesInfo::CPU::operator==)
+        ;
+
+    class_<RprUsdDevicesInfo>("DevicesInfo")
+        .add_property("cpu", +[](RprUsdDevicesInfo* thisPtr) { return thisPtr->cpu; })
+        .add_property("gpus", +[](RprUsdDevicesInfo* thisPtr) { return Tf_PySequenceToListConverter<decltype(RprUsdDevicesInfo::gpus)>{}(thisPtr->gpus); })
+        ;
+
+    def("GetDevicesInfo", RprUsdGetDevicesInfo, arg("pluginType"));
+
+    TfPyWrapEnum<RprUsdPluginType>();
+}

--- a/pxr/imaging/rprUsd/wrapContextHelpers.cpp
+++ b/pxr/imaging/rprUsd/wrapContextHelpers.cpp
@@ -49,6 +49,7 @@ void wrapContextHelpers() {
         ;
 
     class_<RprUsdDevicesInfo>("DevicesInfo")
+        .add_property("isValid", +[](RprUsdDevicesInfo* thisPtr) { return thisPtr->IsValid(); })
         .add_property("cpu", +[](RprUsdDevicesInfo* thisPtr) { return thisPtr->cpu; })
         .add_property("gpus", +[](RprUsdDevicesInfo* thisPtr) { return Tf_PySequenceToListConverter<decltype(RprUsdDevicesInfo::gpus)>{}(thisPtr->gpus); })
         ;


### PR DESCRIPTION
### PURPOSE
To improve render device selection.

### EFFECT OF CHANGE
* Added a new GUI for render device selection. It can be found under the main menu in RPR->Render Devices.
![image](https://user-images.githubusercontent.com/22181845/126875399-affd40da-bc3f-487f-84a3-41bc1cae0cda.png)
* Removed the renderDevice render setting.

The device configuration is tied to the current hardware. By default, only one GPU is used, if available, otherwise all CPU threads are used. It's now possible to select any device combination. Render devices are configured per plugin (this is motivated by the fact that each particular plugin might behave differently for a different combination of hardware, e.g. Tahoe might be slower with CPU+GPU rendering while Northstar not, Hybrid does not support CPU rendering at all).
![image](https://user-images.githubusercontent.com/22181845/126875450-612b76b0-d746-458a-bd7a-e4332ed8b877.png)

### TECHNICAL DETAILS
* Render device configuration GUI is implemented with PyQt.
* Render device configuration is saved under a separate cache folder as a JSON file.
* The same GUI code is reused between usdview and Houdini.

