### PR TITLE
DistantLight and DomeLight fix

### DIFF
--- a/pxr/imaging/plugin/hdRpr/distantLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/distantLight.cpp
@@ -43,9 +43,9 @@ void HdRprDistantLight::Sync(HdSceneDelegate* sceneDelegate,
 
     if (bits & HdLight::DirtyTransform) {
 #if PXR_VERSION >= 2011
-      m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
+        m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
 #else
-      m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
+        m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
 #endif
     }
 

--- a/pxr/imaging/plugin/hdRpr/distantLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/distantLight.cpp
@@ -42,7 +42,11 @@ void HdRprDistantLight::Sync(HdSceneDelegate* sceneDelegate,
     auto& id = GetId();
 
     if (bits & HdLight::DirtyTransform) {
-        m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
+#if PXR_VERSION >= 2011
+      m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
+#else
+      m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
+#endif
     }
 
     bool newLight = false;

--- a/pxr/imaging/plugin/hdRpr/domeLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/domeLight.cpp
@@ -54,7 +54,11 @@ void HdRprDomeLight::Sync(HdSceneDelegate* sceneDelegate,
     HdDirtyBits bits = *dirtyBits;
 
     if (bits & HdLight::DirtyTransform) {
-        m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
+#if PXR_VERSION >= 2011
+      m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
+#else
+      m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
+#endif
         m_transform *= GfMatrix4f(1.0).SetScale(GfVec3f(1.0f, 1.0f, -1.0f));
     }
 

--- a/pxr/imaging/plugin/hdRpr/domeLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/domeLight.cpp
@@ -55,9 +55,9 @@ void HdRprDomeLight::Sync(HdSceneDelegate* sceneDelegate,
 
     if (bits & HdLight::DirtyTransform) {
 #if PXR_VERSION >= 2011
-      m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
+        m_transform = GfMatrix4f(sceneDelegate->GetTransform(id));
 #else
-      m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
+        m_transform = GfMatrix4f(sceneDelegate->GetLightParamValue(id, HdTokens->transform).Get<GfMatrix4d>());
 #endif
         m_transform *= GfMatrix4f(1.0).SetScale(GfVec3f(1.0f, 1.0f, -1.0f));
     }


### PR DESCRIPTION
### PURPOSE
DistantLight and DomeLight doesn't work after updating USD to 21.05.
`Error in 'pxrInternal_v0_21__pxrReserved__::VtValue::_FailGet' at line 565 in file D:\amd-gpuopen\BlenderUSDHydraAddon\deps\USD\pxr\base\vt\value.cpp : 'Attempted to get value of type 'GfMatrix4d' from empty VtValue.'`

### EFFECT OF CHANGE
DistantLight and DomeLight now works.

### TECHNICAL STEPS
Fixed getting light transform

### NOTES FOR REVIEWERS
Same fixes as here https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/476
