### PR TITLE
Improve adaptive sampling performance with RPR2 in batch mode

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -275,7 +275,7 @@ render_setting_categories = [
     {
         'name': 'AdaptiveSampling',
         'houdini': {
-            'hidewhen': hidewhen_not_tahoe
+            'hidewhen': hidewhen_hybrid
         },
         'settings': [
             {


### PR DESCRIPTION
### PURPOSE
To improve adaptive sampling performance with RPR2 in batch mode

### EFFECT OF CHANGE
Improved performance of batch rendering when adaptive sampling enabled for the Full quality.

### TECHNICAL STEPS
Disable `RPR_CONTEXT_ACTIVE_PIXEL_COUNT` check for northstar.
