### PR TITLE
UsdShade materialX support

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -97,7 +97,10 @@ if (NOT PXR_MALLOC_LIBRARY)
     endif()
 endif()
 
-find_package(MaterialX QUIET)
+if(NOT MaterialX_FOUND)
+    find_package(MaterialX QUIET)
+endif()
+
 if(MaterialX_FOUND)
     set(RPR_DISABLE_CUSTOM_MATERIALX_LOADER ON)
 endif()

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -88,7 +88,7 @@ if(HoudiniUSD_FOUND)
     set(OPENEXR_LIB_LOCATION ${Houdini_LIB_DIR})
 else()
     # We are using python to generate source files
-    find_package(PythonInterp 2.7 REQUIRED)
+    find_package(PythonInterp 2.7)
 endif()
 
 if (NOT PXR_MALLOC_LIBRARY)

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -98,6 +98,9 @@ if (NOT PXR_MALLOC_LIBRARY)
 endif()
 
 find_package(MaterialX QUIET)
+if(MaterialX_FOUND)
+    set(RPR_DISABLE_CUSTOM_MATERIALX_LOADER ON)
+endif()
 
 if(RPR_ENABLE_VULKAN_INTEROP_SUPPORT)
     find_package(Vulkan REQUIRED)

--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -27,8 +27,20 @@ set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /EHsc")
 
 # Standards compliant.
 set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:rvalueCast
-                                      /Zc:strictStrings
-                                      /Zc:inline")
+                                      /Zc:strictStrings")
+
+# The /Zc:inline option strips out the "arch_ctor_<name>" symbols used for
+# library initialization by ARCH_CONSTRUCTOR starting in Visual Studio 2019, 
+# causing release builds to fail. Disable the option for this and later 
+# versions.
+# 
+# For more details, see:
+# https://developercommunity.visualstudio.com/content/problem/914943/zcinline-removes-extern-symbols-inside-anonymous-n.html
+if (MSVC_VERSION GREATER_EQUAL 1920)
+    set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:inline-")
+else()
+    set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:inline")
+endif()
 
 # Turn on all but informational warnings.
 set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /W3")

--- a/cmake/modules/FindHoudiniUSD.cmake
+++ b/cmake/modules/FindHoudiniUSD.cmake
@@ -113,6 +113,36 @@ else()
     set(Houdini_LIB_DIR ${HOUDINI_ROOT}/dsolib)
 endif()
 
+find_path(Houdini_MTLX_INCLUDE_DIR
+    "MaterialXCore/Document.h"
+    PATHS ${HOUDINI_ROOT}
+    PATH_SUFFIXES "toolkit/include"
+    NO_DEFAULT_PATH)
+if(Houdini_MTLX_INCLUDE_DIR)
+    if(WIN32)
+        find_path(Houdini_MTLX_IMPLIB_DIR
+            "MaterialXCore.lib"
+            PATHS ${HOUDINI_ROOT}
+            PATH_SUFFIXES "custom/houdini/dsolib"
+            NO_DEFAULT_PATH)
+        list(APPEND HUSD_REQ_VARS "Houdini_MTLX_IMPLIB_DIR")
+    endif()
+
+    foreach(targetName MaterialXCore MaterialXFormat)
+        add_library(${targetName} SHARED IMPORTED)
+        set_target_properties(${targetName} PROPERTIES
+            IMPORTED_LOCATION "${Houdini_USD_LIB_DIR}/${targetName}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+            INTERFACE_INCLUDE_DIRECTORIES ${Houdini_MTLX_INCLUDE_DIR})
+        target_compile_definitions(${targetName} INTERFACE -DMATERIALX_BUILD_SHARED_LIBS)
+        if(WIN32)
+            set_target_properties(${targetName} PROPERTIES
+                IMPORTED_IMPLIB "${Houdini_MTLX_IMPLIB_DIR}/${targetName}.lib")
+        endif()
+    endforeach()
+
+    set(MaterialX_FOUND 1)
+endif()
+
 include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(
@@ -125,6 +155,9 @@ if(HoudiniUSD_FOUND)
     message(STATUS "  Houdini Python includes: ${Houdini_Python_INCLUDE_DIR}")
     message(STATUS "  Houdini Python lib: ${Houdini_Python_LIB}")
     message(STATUS "  Houdini Boost.Python lib: ${Houdini_Boostpython_LIB}")
+    if(MaterialX_FOUND)
+        message(STATUS "  Houdini MaterialX: ${Houdini_MTLX_INCLUDE_DIR}")
+    endif()
 endif()
 
 if(HoudiniUSD_FOUND AND NOT TARGET hd)
@@ -136,8 +169,8 @@ if(HoudiniUSD_FOUND AND NOT TARGET hd)
     foreach(targetName
         arch tf gf js trace work plug vt ar kind sdf ndr sdr pcp usd usdGeom
         usdVol usdLux usdMedia usdShade usdRender usdHydra usdRi usdSkel usdUI
-        usdUtils garch hf hio cameraUtil pxOsd glf hgi hgiGL hd hdSt hdx
-        usdImaging usdImagingGL usdRiImaging usdSkelImaging usdVolImaging
+        usdUtils garch hf hio cameraUtil pxOsd glf hgi hgiGL hd hdSt hdMtlx hdx
+        usdImaging usdImagingGL usdRiImaging usdSkelImaging usdVolI maging
         usdAppUtils usdviewq)
         add_library(${targetName} SHARED IMPORTED)
         set_target_properties(${targetName} PROPERTIES

--- a/cmake/modules/FindRpr.cmake
+++ b/cmake/modules/FindRpr.cmake
@@ -49,7 +49,7 @@ find_library(RPR_LOADSTORE_LIBRARY
     NO_SYSTEM_ENVIRONMENT_PATH
 )
 
-foreach(entry "Tahoe64;TAHOE" "Northstar64;NORTHSTAR" "Hybrid;HYBRID")
+foreach(entry "Tahoe64;TAHOE" "Northstar64;NORTHSTAR" "Hybrid;HYBRID" "HybridPro;HYBRID_PRO")
     list(GET entry 0 libName)
     list(GET entry 1 libId)
 
@@ -89,10 +89,13 @@ find_package_handle_standard_args(Rpr
     REQUIRED_VARS
         RPR_LOCATION_INCLUDE
         RPR_VERSION_STRING
-        RPR_LOADSTORE_LIBRARY
         RPR_LIBRARY
 )
 
 add_library(rpr INTERFACE)
 target_include_directories(rpr INTERFACE ${RPR_LOCATION_INCLUDE})
-target_link_libraries(rpr INTERFACE ${RPR_LIBRARY} ${RPR_LOADSTORE_LIBRARY})
+target_link_libraries(rpr INTERFACE ${RPR_LIBRARY})
+if(RPR_LOADSTORE_LIBRARY)
+    target_compile_definitions(rpr INTERFACE -DRPR_LOADSTORE_AVAILABLE)
+    target_link_libraries(rpr INTERFACE ${RPR_LOADSTORE_LIBRARY})
+endif()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -52,7 +52,7 @@ add_library(cpprpr STATIC
     ${RPR_CPP_WRAPPER_LOCATION}/RadeonProRenderCpp.cpp
     ${RPR_CPP_WRAPPER_LOCATION}/tinyxml2.cpp)
 if(NOT RPR_DISABLE_CUSTOM_MATERIALX_LOADER)
-    target_sources(cpprpr
+    target_sources(cpprpr PRIVATE
         ${RPRMTLXLOADER_LOCATION}/rprMtlxLoader.h
         ${RPRMTLXLOADER_LOCATION}/rprMtlxLoader.cpp)
     target_link_libraries(cpprpr PUBLIC MaterialXCore MaterialXFormat)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,7 +1,7 @@
 # MaterialX
 # ----------------------------------------------
 
-if(NOT MaterialX_FOUND)
+if(NOT RPR_DISABLE_CUSTOM_MATERIALX_LOADER)
     # If MaterialX was not explicitly provided, use the one from a submodule
     set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
     set(MATERIALX_PYTHON_LTO OFF)
@@ -48,14 +48,19 @@ if(NOT RPR_CPP_WRAPPER_LOCATION)
 endif()
 
 add_library(cpprpr STATIC
-    ${RPRMTLXLOADER_LOCATION}/rprMtlxLoader.h
-    ${RPRMTLXLOADER_LOCATION}/rprMtlxLoader.cpp
     ${RPR_CPP_WRAPPER_LOCATION}/RadeonProRender.hpp
     ${RPR_CPP_WRAPPER_LOCATION}/RadeonProRenderCpp.cpp
     ${RPR_CPP_WRAPPER_LOCATION}/tinyxml2.cpp)
+if(NOT RPR_DISABLE_CUSTOM_MATERIALX_LOADER)
+    target_sources(cpprpr
+        ${RPRMTLXLOADER_LOCATION}/rprMtlxLoader.h
+        ${RPRMTLXLOADER_LOCATION}/rprMtlxLoader.cpp)
+    target_link_libraries(cpprpr PUBLIC MaterialXCore MaterialXFormat)
+    target_compile_definitions(cpprpr PUBLIC -DUSE_CUSTOM_MATERIALX_LOADER)
+endif()
 set_target_properties(cpprpr PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(cpprpr PUBLIC ${RPRMTLXLOADER_LOCATION} ${RPR_CPP_WRAPPER_LOCATION})
-target_link_libraries(cpprpr PUBLIC rpr MaterialXCore MaterialXFormat)
+target_link_libraries(cpprpr PUBLIC rpr)
 target_compile_definitions(cpprpr PUBLIC
     RPR_CPPWRAPER_DISABLE_MUTEXLOCK
     RPR_API_USE_HEADER_V2)

--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -185,9 +185,10 @@ install(
 }\")")
 
 if(WIN32)
-    set(RPR_BINARIES
-        ${RPR_BIN_LOCATION}/RadeonProRender64.dll
-        ${RPR_BIN_LOCATION}/RprLoadStore64.dll)
+    set(RPR_BINARIES ${RPR_BIN_LOCATION}/RadeonProRender64.dll)
+    if(RPR_LOADSTORE_LIBRARY)
+        list(APPEND RPR_BINARIES ${RPR_BIN_LOCATION}/RprLoadStore64.dll)
+    endif()
     install(
         FILES ${RPR_BINARIES} ${RPR_PLUGINS} ${RIF_BINARIES} ${OptBin}
         DESTINATION lib)

--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -68,6 +68,7 @@ render_setting_categories = [
                     SettingValue('Low', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
                     SettingValue('Medium', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
                     SettingValue('High', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
+                    SettingValue('HybridPro', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
                     SettingValue('Full', 'Full (Legacy)'),
                     SettingValue('Northstar', 'Full')
                 ]

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -118,7 +118,8 @@ private:
 TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (openvdbAsset) \
     (percentDone) \
-    (RPR)
+    (RPR) \
+    (mtlx)
 );
 
 const TfTokenVector HdRprDelegate::SUPPORTED_RPRIM_TYPES = {
@@ -203,8 +204,8 @@ void HdRprDelegate::CommitResources(HdChangeTracker* tracker) {
     m_rprApi->CommitResources();
 }
 
-TfToken HdRprDelegate::GetMaterialNetworkSelector() const {
-    return RprUsdMaterialRegistry::GetInstance().GetMaterialNetworkSelector();
+TfTokenVector HdRprDelegate::GetMaterialRenderContexts() const {
+    return {RprUsdMaterialRegistry::GetInstance().GetMaterialNetworkSelector(), _tokens->mtlx};
 }
 
 TfTokenVector const& HdRprDelegate::GetSupportedRprimTypes() const {

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.h
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.h
@@ -75,7 +75,7 @@ public:
     void CommitResources(HdChangeTracker* tracker) override;
 
     TfToken GetMaterialBindingPurpose() const override { return HdTokens->full; }
-    TfToken GetMaterialNetworkSelector() const override;
+    TfTokenVector GetMaterialRenderContexts() const override;
 
     HdAovDescriptor GetDefaultAovDescriptor(TfToken const& name) const override;
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1752,8 +1752,7 @@ public:
     }
 
     void UpdateHybridSettings(HdRprConfig const& preferences, bool force) {
-        // TODO: check if HybridPro has render qualities
-        if ((!preferences.IsDirty(HdRprConfig::DirtyRenderQuality) || force) && m_rprContextMetadata.pluginType == kPluginHybrid) {
+        if (preferences.IsDirty(HdRprConfig::DirtyRenderQuality) || force) {
             rpr_uint hybridRenderQuality = -1;
             if (m_currentRenderQuality == HdRprRenderQualityTokens->High) {
                 hybridRenderQuality = RPR_RENDER_QUALITY_HIGH;
@@ -1781,7 +1780,7 @@ public:
         if (m_rprContextMetadata.pluginType == kPluginTahoe ||
             m_rprContextMetadata.pluginType == kPluginNorthstar) {
             UpdateTahoeSettings(preferences, force);
-        } else if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
+        } else if (m_rprContextMetadata.pluginType == kPluginHybrid) {
             UpdateHybridSettings(preferences, force);
         }
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -57,7 +57,9 @@ using json = nlohmann::json;
 #include "notify/message.h"
 
 #include <RadeonProRender_Baikal.h>
+#ifdef RPR_LOADSTORE_AVAILABLE
 #include <RprLoadStore.h>
+#endif // RPR_LOADSTORE_AVAILABLE
 
 #ifdef RPR_EXR_EXPORT_ENABLED
 #include <MurmurHash3.h>
@@ -389,7 +391,7 @@ public:
 
         VtIntArray newNormalIndices;
         if (normalSamples.empty()) {
-            if (m_rprContextMetadata.pluginType == kPluginHybrid) {
+            if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
                 // XXX (Hybrid): we need to generate geometry normals by ourself
                 VtVec3fArray normals;
                 normals.reserve(newVpf.size());
@@ -432,7 +434,7 @@ public:
 
         VtIntArray newUvIndices;
         if (uvSamples.empty()) {
-            if (m_rprContextMetadata.pluginType == kPluginHybrid) {
+            if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
                 newUvIndices = newIndices;
                 VtVec2fArray uvs(pointSamples[0].size(), GfVec2f(0.0f));
                 uvSamples.push_back(uvs);
@@ -558,7 +560,7 @@ public:
             return;
         }
 
-        if (m_rprContextMetadata.pluginType == kPluginHybrid) {
+        if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
             // Not supported
             return;
         }
@@ -584,7 +586,7 @@ public:
             return;
         }
 
-        if (m_rprContextMetadata.pluginType == kPluginHybrid) {
+        if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
             // Not supported
             return;
         }
@@ -631,7 +633,7 @@ public:
 
     void SetCurveVisibility(rpr::Curve* curve, uint32_t visibilityMask) {
         LockGuard rprLock(m_rprContext->GetMutex());
-        if (m_rprContextMetadata.pluginType == kPluginHybrid) {
+        if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
             // XXX (Hybrid): rprCurveSetVisibility not supported, emulate visibility using attach/detach
             if (visibilityMask) {
                 m_scene->Attach(curve);
@@ -677,7 +679,7 @@ public:
 
     void SetMeshVisibility(rpr::Shape* mesh, uint32_t visibilityMask) {
         LockGuard rprLock(m_rprContext->GetMutex());
-        if (m_rprContextMetadata.pluginType == kPluginHybrid) {
+        if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
             // XXX (Hybrid): rprShapeSetVisibility not supported, emulate visibility using attach/detach
             if (visibilityMask) {
                 m_scene->Attach(mesh);
@@ -908,7 +910,7 @@ public:
             return nullptr;
         }
 
-        if (m_rprContextMetadata.pluginType == kPluginHybrid) {
+        if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
             if ((status = m_scene->SetEnvironmentLight(envLight->light.get())) == RPR_SUCCESS) {
                 envLight->state = HdRprApiEnvironmentLight::kAttachedAsEnvLight;
             }
@@ -1750,7 +1752,8 @@ public:
     }
 
     void UpdateHybridSettings(HdRprConfig const& preferences, bool force) {
-        if (preferences.IsDirty(HdRprConfig::DirtyRenderQuality) || force) {
+        // TODO: check if HybridPro has render qualities
+        if ((!preferences.IsDirty(HdRprConfig::DirtyRenderQuality) || force) && m_rprContextMetadata.pluginType == kPluginHybrid) {
             rpr_uint hybridRenderQuality = -1;
             if (m_currentRenderQuality == HdRprRenderQualityTokens->High) {
                 hybridRenderQuality = RPR_RENDER_QUALITY_HIGH;
@@ -1778,7 +1781,7 @@ public:
         if (m_rprContextMetadata.pluginType == kPluginTahoe ||
             m_rprContextMetadata.pluginType == kPluginNorthstar) {
             UpdateTahoeSettings(preferences, force);
-        } else if (m_rprContextMetadata.pluginType == kPluginHybrid) {
+        } else if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
             UpdateHybridSettings(preferences, force);
         }
 
@@ -2158,7 +2161,7 @@ public:
     }
 
     void IncrementFrameCount(bool isAdaptiveSamplingEnabled) {
-        if (m_rprContextMetadata.pluginType == kPluginHybrid) {
+        if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
             return;
         }
 
@@ -2679,7 +2682,7 @@ public:
     }
 
     void InteropRenderImpl(HdRprRenderThread* renderThread) {
-        if (m_rprContextMetadata.pluginType != RprUsdPluginType::kPluginHybrid) {
+        if (!RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
             TF_CODING_ERROR("InteropRenderImpl should be called for Hybrid plugin only");
             return;
         }
@@ -2733,7 +2736,7 @@ public:
                 if (m_isBatch) {
                     BatchRenderImpl(renderThread);
                 } else {
-                    if (m_rprContextMetadata.pluginType == RprUsdPluginType::kPluginHybrid &&
+                    if (RprUsdIsHybrid(m_rprContextMetadata.pluginType) &&
                         m_rprContextMetadata.interopInfo) {
                         InteropRenderImpl(renderThread);
                     } else {
@@ -2774,6 +2777,8 @@ Don't show this message again?
     }
 
     void ExportRpr() {
+#ifdef RPR_LOADSTORE_AVAILABLE
+
 #ifdef BUILD_AS_HOUDINI_PLUGIN
         if (HOM().isApprentice()) {
             fprintf(stderr, "Cannot export .rpr from Apprentice");
@@ -2978,6 +2983,9 @@ Don't show this message again?
         } catch (json::exception& e) {
             fprintf(stderr, "Failed to fill config file: %s\n", configFilename.c_str());
         }
+#else // !defined(RPR_LOADSTORE_AVAILABLE)
+        TF_RUNTIME_ERROR(".rpr export is not supported: hdRpr compiled without rprLoadStore library");
+#endif // RPR_LOADSTORE_AVAILABLE
     }
 
     void CommitResources() {
@@ -3093,11 +3101,11 @@ Don't show this message again?
     }
 
     bool IsVulkanInteropEnabled() const {
-        return m_rprContext && m_rprContextMetadata.pluginType == kPluginHybrid && m_rprContextMetadata.interopInfo;
+        return m_rprContext && RprUsdIsHybrid(m_rprContextMetadata.pluginType) && m_rprContextMetadata.interopInfo;
     }
 
     bool IsArbitraryShapedLightSupported() const {
-        return m_rprContextMetadata.pluginType != kPluginHybrid;
+        return !RprUsdIsHybrid(m_rprContextMetadata.pluginType);
     }
 
     bool IsSphereAndDiskLightSupported() const {
@@ -3135,6 +3143,8 @@ private:
             return kPluginTahoe;
         } else if (renderQuality == HdRprRenderQualityTokens->Northstar) {
             return kPluginNorthstar;
+        } else if (renderQuality == HdRprRenderQualityTokens->HybridPro) {
+            return kPluginHybridPro;
         } else {
             return kPluginHybrid;
         }
@@ -3231,12 +3241,14 @@ private:
             RPR_THROW_ERROR_MSG("Failed to create RPR context");
         }
 
-        if (m_rprContextMetadata.pluginType == RprUsdPluginType::kPluginHybrid) {
+        // TODO: verify
+        if (RprUsdIsHybrid(m_rprContextMetadata.pluginType)) {
             RPR_ERROR_CHECK(m_rprContext->SetParameter(rpr::ContextInfo(RPR_CONTEXT_ENABLE_RELAXED_MATERIAL_CHECKS), 1u), "Failed to enable relaxed material checks");
         }
 
         uint32_t requiredYFlip = 0;
-        if (m_rprContextMetadata.pluginType == RprUsdPluginType::kPluginHybrid && m_rprContextMetadata.interopInfo) {
+        // TODO: verify
+        if (RprUsdIsHybrid(m_rprContextMetadata.pluginType) && m_rprContextMetadata.interopInfo) {
             RPR_ERROR_CHECK_THROW(m_rprContext->GetFunctionPtr(
                 RPR_CONTEXT_FLUSH_FRAMEBUFFERS_FUNC_NAME, 
                 (void**)(&m_rprContextFlushFrameBuffers)
@@ -3358,7 +3370,7 @@ private:
     std::unique_ptr<RprUsdCoreImage> CreateConstantColorImage(float const* color) {
         std::array<float, 3> colorArray = {color[0], color[1], color[2]};
         rpr_image_format format = {3, RPR_COMPONENT_TYPE_FLOAT32};
-        rpr_uint imageSize = m_rprContextMetadata.pluginType == kPluginHybrid ? 64 : 1;
+        rpr_uint imageSize = RprUsdIsHybrid(m_rprContextMetadata.pluginType) ? 64 : 1;
         std::vector<std::array<float, 3>> imageData(imageSize * imageSize, colorArray);
 
         rpr::Status status;

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -876,6 +876,10 @@ public:
     }
 
     RprUsdMaterial* CreateGeometryLightMaterial(GfVec3f const& emissionColor) {
+        if (!m_rprContext) {
+            return nullptr;
+        }
+
         LockGuard rprLock(m_rprContext->GetMutex());
 
         auto material = HdRprApiRawMaterial::Create(m_rprContext.get(), RPR_MATERIAL_NODE_EMISSIVE, {
@@ -2807,7 +2811,7 @@ Don't show this message again?
 
         auto rprContextHandle = rpr::GetRprObject(m_rprContext.get());
         auto rprSceneHandle = rpr::GetRprObject(m_scene.get());
-        if (RPR_ERROR_CHECK(rprsExport(m_rprSceneExportPath.c_str(), rprContextHandle, rprSceneHandle, 0, nullptr, nullptr, 0, nullptr, nullptr, rprsFlags), "Failed to export .rpr file")) {
+        if (RPR_ERROR_CHECK(rprsExport(m_rprSceneExportPath.c_str(), rprContextHandle, rprSceneHandle, 0, nullptr, nullptr, 0, nullptr, nullptr, rprsFlags, nullptr), "Failed to export .rpr file")) {
             return;
         }
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -3025,6 +3025,10 @@ Don't show this message again?
         }
 
         if (m_isAbortingEnabled) {
+            if (m_rprContextMetadata.pluginType == kPluginHybridPro) {
+                return;
+            }
+
             RPR_ERROR_CHECK(m_rprContext->AbortRender(), "Failed to abort render");
         } else {
             // In case aborting is disabled, we postpone abort until it's enabled

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
@@ -66,7 +66,7 @@ HdRprApiAov::HdRprApiAov(rpr_aov rprAovType, int width, int height, HdFormat for
     m_aov->AttachAs(rprAovType);
 
     // XXX (Hybrid): Hybrid plugin does not support framebuffer resolving (rprContextResolveFrameBuffer)
-    if (rprContextMetadata.pluginType != kPluginHybrid) {
+    if (!RprUsdIsHybrid(rprContextMetadata.pluginType)) {
         m_resolved = pxr::make_unique<HdRprApiFramebuffer>(rprContext, width, height);
     }
 }

--- a/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.cpp
+++ b/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.cpp
@@ -539,6 +539,7 @@ void VOP_MaterialX::opChanged(OP_EventType reason, void* data) {
             // Rebuild renderable elements cache
             //
             m_renderableElements = {};
+#ifdef USE_CUSTOM_MATERIALX_LOADER
             if (auto mtlxLoader = RprUsdMaterialRegistry::GetInstance().GetMtlxLoader()) {
                 try {
                     auto mtlxDoc = MaterialX::createDocument();
@@ -549,6 +550,7 @@ void VOP_MaterialX::opChanged(OP_EventType reason, void* data) {
                     // no-op
                 }
             }
+#endif
 
             // Hide everything but file parm when a file is not specified
             //

--- a/pxr/imaging/rprUsd/CMakeLists.txt
+++ b/pxr/imaging/rprUsd/CMakeLists.txt
@@ -17,6 +17,8 @@ pxr_library(rprUsd
         hdMtlx
         cpprpr
         json
+        MaterialXCore
+        MaterialXFormat
 
     PUBLIC_CLASSES
         util
@@ -60,25 +62,24 @@ target_sources(rprUsd PRIVATE
     materialNodes/materialNode.h
     materialNodes/usdNode.h
     materialNodes/usdNode.cpp
+    materialNodes/mtlxNode.h
+    materialNodes/mtlxNode.cpp
+    materialNodes/rprApiMtlxNode.h
+    materialNodes/rprApiMtlxNode.cpp
     materialNodes/rpr/baseNode.h
     materialNodes/rpr/baseNode.cpp
     materialNodes/rpr/nodeInfo.h
     materialNodes/rpr/toonNode.cpp
     materialNodes/rpr/catcherNode.cpp
     materialNodes/rpr/displaceNode.cpp
+    materialNodes/rpr/materialXNode.cpp
     materialNodes/rpr/arithmeticNode.h
     materialNodes/rpr/arithmeticNode.cpp
     materialNodes/rpr/combineShadersNode.cpp
     materialNodes/houdiniPrincipledShaderNode.h
     materialNodes/houdiniPrincipledShaderNode.cpp)
-if(NOT RPR_DISABLE_CUSTOM_MATERIALX_LOADER)
-    target_sources(rprUsd PRIVATE
-        materialNodes/mtlxNode.h
-        materialNodes/mtlxNode.cpp
-        materialNodes/rpr/materialXNode.cpp)
-    add_subdirectory(materialNodes/mtlxFiles)
-endif()
 
+add_subdirectory(materialNodes/mtlxFiles)
 
 GroupSources(rprUsd)
 

--- a/pxr/imaging/rprUsd/CMakeLists.txt
+++ b/pxr/imaging/rprUsd/CMakeLists.txt
@@ -12,7 +12,10 @@ pxr_library(rprUsd
         glf
         sdf
         sdr
+        hio
+        plug
         arch
+        garch
         work
         hdMtlx
         cpprpr

--- a/pxr/imaging/rprUsd/CMakeLists.txt
+++ b/pxr/imaging/rprUsd/CMakeLists.txt
@@ -11,8 +11,10 @@ pxr_library(rprUsd
         hd
         glf
         sdf
+        sdr
         arch
         work
+        hdMtlx
         cpprpr
         json
 
@@ -58,22 +60,25 @@ target_sources(rprUsd PRIVATE
     materialNodes/materialNode.h
     materialNodes/usdNode.h
     materialNodes/usdNode.cpp
-    materialNodes/mtlxNode.h
-    materialNodes/mtlxNode.cpp
     materialNodes/rpr/baseNode.h
     materialNodes/rpr/baseNode.cpp
     materialNodes/rpr/nodeInfo.h
     materialNodes/rpr/toonNode.cpp
     materialNodes/rpr/catcherNode.cpp
     materialNodes/rpr/displaceNode.cpp
-    materialNodes/rpr/materialXNode.cpp
     materialNodes/rpr/arithmeticNode.h
     materialNodes/rpr/arithmeticNode.cpp
     materialNodes/rpr/combineShadersNode.cpp
     materialNodes/houdiniPrincipledShaderNode.h
     materialNodes/houdiniPrincipledShaderNode.cpp)
+if(NOT RPR_DISABLE_CUSTOM_MATERIALX_LOADER)
+    target_sources(rprUsd PRIVATE
+        materialNodes/mtlxNode.h
+        materialNodes/mtlxNode.cpp
+        materialNodes/rpr/materialXNode.cpp)
+    add_subdirectory(materialNodes/mtlxFiles)
+endif()
 
-add_subdirectory(materialNodes/mtlxFiles)
 
 GroupSources(rprUsd)
 

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -146,6 +146,7 @@ const std::map<RprUsdPluginType, const char*> kPluginLibNames = {
     {kPluginTahoe, "Tahoe64.dll"},
     {kPluginNorthstar, "Northstar64.dll"},
     {kPluginHybrid, "Hybrid.dll"},
+    {kPluginHybridPro, "HybridPro.dll"},
 #elif defined __linux__
     {kPluginNorthstar, "libNorthstar64.so"},
     {kPluginTahoe, "libTahoe64.so"},
@@ -354,8 +355,8 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
 #endif
 
     if (metadata->isGlInteropEnabled) {
-        if ((creationFlags & RPR_CREATION_FLAGS_ENABLE_CPU) == 0 ||
-            metadata->pluginType == kPluginHybrid) {
+        if ((creationFlags & RPR_CREATION_FLAGS_ENABLE_CPU) ||
+            RprUsdIsHybrid(metadata->pluginType)) {
             PRINT_CONTEXT_CREATION_DEBUG_INFO("GL interop could not be used with CPU rendering or Hybrid plugin");
             metadata->isGlInteropEnabled = false;
         } else if (!RprUsdInitGLApi()) {
@@ -369,7 +370,7 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
     }
 
 #ifdef HDRPR_ENABLE_VULKAN_INTEROP_SUPPORT
-    if (metadata->pluginType == RprUsdPluginType::kPluginHybrid && metadata->interopInfo) {
+    if (RprUsdIsHybrid(metadata->pluginType) && metadata->interopInfo) {
         // Create interop context for hybrid
         // TODO: should not it be configurable?
         constexpr std::uint32_t MB = 1024u * 1024u;

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -398,10 +398,10 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
             return nullptr;
         }
 
-		if (metadata->pluginType == kPluginHybridPro) {
-			std::string pluginName = "Hybrid";
-			status = rprContextSetInternalParameterBuffer(rpr::GetRprObject(context), pluginID, "plugin.name", pluginName.c_str(), pluginName.size() + 1);
-		}
+        if (metadata->pluginType == kPluginHybridPro) {
+            std::string pluginName = "Hybrid";
+            status = rprContextSetInternalParameterBuffer(rpr::GetRprObject(context), pluginID, "plugin.name", pluginName.c_str(), pluginName.size() + 1);
+        }
 
         RPR_ERROR_CHECK(context->SetParameter(RPR_CONTEXT_TEXTURE_CACHE_PATH, textureCachePath.c_str()), "Failed to set texture cache path");
 

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -398,6 +398,11 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
             return nullptr;
         }
 
+		if (metadata->pluginType == kPluginHybridPro) {
+			std::string pluginName = "Hybrid";
+			status = rprContextSetInternalParameterBuffer(rpr::GetRprObject(context), pluginID, "plugin.name", pluginName.c_str(), pluginName.size() + 1);
+		}
+
         RPR_ERROR_CHECK(context->SetParameter(RPR_CONTEXT_TEXTURE_CACHE_PATH, textureCachePath.c_str()), "Failed to set texture cache path");
 
         metadata->creationFlags = creationFlags;

--- a/pxr/imaging/rprUsd/contextMetadata.h
+++ b/pxr/imaging/rprUsd/contextMetadata.h
@@ -26,6 +26,7 @@ enum RprUsdPluginType {
     kPluginTahoe,
     kPluginNorthstar,
     kPluginHybrid,
+    kPluginHybridPro,
     kPluginsCount
 };
 
@@ -38,6 +39,10 @@ struct RprUsdContextMetadata {
 
 RPRUSD_API
 bool RprUsdIsGpuUsed(RprUsdContextMetadata const& contextMetadata);
+
+inline bool RprUsdIsHybrid(RprUsdPluginType pluginType) {
+    return pluginType == kPluginHybrid || pluginType == kPluginHybridPro;
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/rprUsd/materialNodes/materialNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/materialNode.h
@@ -24,24 +24,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class RprUsdImageCache;
 
-struct RprUsd_MaterialNetwork {
-    struct Connection {
-        SdfPath upstreamNode;
-        TfToken upstreamOutputName;
-    };
-
-    struct Node {
-        TfToken nodeTypeId;
-        std::map<TfToken, VtValue> parameters;
-        std::map<TfToken, Connection> inputConnections;
-    };
-
-    std::map<SdfPath, Node> nodes;
-    std::map<TfToken, Connection> terminals;
-};
-
 struct RprUsd_MaterialBuilderContext {
-    RprUsd_MaterialNetwork const* hdMaterialNetwork;
+    HdMaterialNetwork2 const* hdMaterialNetwork;
     SdfPath const* currentNodePath;
 
     rpr::Context* rprContext;

--- a/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/materialXNode.cpp
@@ -14,6 +14,7 @@ limitations under the License.
 #include "materialXNode.h"
 #include "baseNode.h"
 #include "nodeInfo.h"
+#include "../rprApiMtlxNode.h"
 
 #include "pxr/usd/sdf/assetPath.h"
 #include "pxr/base/arch/attributes.h"
@@ -22,19 +23,23 @@ limitations under the License.
 
 #include <fstream>
 
+#ifdef USE_CUSTOM_MATERIALX_LOADER
 #include <rprMtlxLoader.h>
 #include <MaterialXFormat/XmlIo.h>
+#endif
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_PUBLIC_TOKENS(RprUsdRprMaterialXNodeTokens, RPRUSD_RPR_MATERIALX_NODE_TOKENS);
 
+#ifdef USE_CUSTOM_MATERIALX_LOADER
 static rpr_material_node ReleaseOutputNodeOwnership(RPRMtlxLoader::Result* mtlx, RPRMtlxLoader::OutputType outputType) {
     auto idx = mtlx->rootNodeIndices[outputType];
     auto ret = mtlx->nodes[idx];
     mtlx->nodes[idx] = nullptr;
     return ret;
 }
+#endif
 
 template <typename T>
 static bool ReadInput(TfToken const& inputId, VtValue const& inputValue, T* dst) {
@@ -103,20 +108,25 @@ public:
             bool ret = ReadInput(inputId, value, &m_mtlxBasePath);
             if (ret) { ResetNodeOutput(); }
             return ret;
-        } else if (inputId == RprUsdRprMaterialXNodeTokens->surfaceElement) {
-            return SetRenderElement(RPRMtlxLoader::kOutputSurface, value);
-        } else if (inputId == RprUsdRprMaterialXNodeTokens->displacementElement) {
-            return SetRenderElement(RPRMtlxLoader::kOutputDisplacement, value);
         } else if (inputId == RprUsdRprMaterialXNodeTokens->stPrimvarName) {
             return ReadInput(inputId, value, &m_ctx->uvPrimvarName);
-        }
+		} else {
+#ifdef USE_CUSTOM_MATERIALX_LOADER
+			if (inputId == RprUsdRprMaterialXNodeTokens->surfaceElement) {
+				return SetRenderElement(RPRMtlxLoader::kOutputSurface, value);
+			} else if (inputId == RprUsdRprMaterialXNodeTokens->displacementElement) {
+				return SetRenderElement(RPRMtlxLoader::kOutputDisplacement, value);
+			}
+#endif
+		}
 
         TF_RUNTIME_ERROR("[%s] Unknown input %s",
             RprUsdRprMaterialXNodeTokens->rpr_materialx_node.GetText(), inputId.GetText());
         return false;
     }
 
-    bool SetRenderElement(RPRMtlxLoader::OutputType outputType, VtValue const& value) {
+#ifdef USE_CUSTOM_MATERIALX_LOADER
+	bool SetRenderElement(RPRMtlxLoader::OutputType outputType, VtValue const& value) {
         if (!value.IsHolding<std::string>()) {
             TF_RUNTIME_ERROR("[rpr_materialx_node] Invalid type of render element: %s",
                 value.GetTypeName().c_str());
@@ -132,6 +142,7 @@ public:
 
         return true;
     }
+#endif
 
     void ResetNodeOutput() {
         m_isDirty = true;
@@ -140,6 +151,7 @@ public:
     }
 
     bool UpdateNodeOutput() {
+#ifdef USE_CUSTOM_MATERIALX_LOADER
         auto basePath = !m_mtlxBasePath.empty() ? m_mtlxBasePath : TfGetPathName(m_mtlxFilepath);
         if (basePath.empty()) {
             TF_WARN("[rpr_materialx_node] no base path specified, image loading might be broken");
@@ -327,33 +339,16 @@ public:
 
             return m_surfaceNode || m_displacementNode;
         }
+#endif
 
-        rpr::Status status;
         if (!m_mtlxString.empty()) {
-            m_surfaceNode.reset(m_ctx->rprContext->CreateMaterialXNode(m_mtlxString.c_str(), basePath.c_str(), 0, nullptr, nullptr, &status));
+            m_surfaceNode.reset(RprUsd_CreateRprMtlxFromString(m_mtlxString, *m_ctx));
         } else {
-            std::ifstream mtlxFile(m_mtlxFilepath);
-            if (!mtlxFile.good()) {
-                TF_RUNTIME_ERROR("Failed to open \"%s\" file", m_mtlxFilepath.c_str());
-                return false;
-            }
-
-            mtlxFile.seekg(0, std::ios::end);
-            auto fileSize = mtlxFile.tellg();
-            if (fileSize == 0) {
-                TF_RUNTIME_ERROR("Empty file: \"%s\"", m_mtlxFilepath.c_str());
-                return false;
-            }
-
-            auto xmlData = std::make_unique<char[]>(fileSize);
-            mtlxFile.seekg(0);
-            mtlxFile.read(&xmlData[0], fileSize);
-
-            m_surfaceNode.reset(m_ctx->rprContext->CreateMaterialXNode(xmlData.get(), basePath.c_str(), 0, nullptr, nullptr, &status));
+            m_surfaceNode.reset(RprUsd_CreateRprMtlxFromFile(m_mtlxFilepath, *m_ctx));
         }
 
         if (!m_surfaceNode) {
-            RPR_ERROR_CHECK(status, "Failed to create materialX node", m_ctx->rprContext);
+            RPR_ERROR_CHECK(RPR_ERROR_UNSUPPORTED, "Failed to create materialX node", m_ctx->rprContext);
         }
         return m_surfaceNode != nullptr;
     }
@@ -413,7 +408,10 @@ private:
     std::string m_mtlxFilepath;
     std::string m_mtlxString;
     std::string m_mtlxBasePath;
-    std::string m_selectedRenderElements[RPRMtlxLoader::kOutputsTotal];
+
+#ifdef USE_CUSTOM_MATERIALX_LOADER
+	std::string m_selectedRenderElements[RPRMtlxLoader::kOutputsTotal];
+#endif
 
     bool m_isDirty = true;
     std::shared_ptr<rpr::MaterialNode> m_surfaceNode;

--- a/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.cpp
@@ -1,0 +1,83 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#include "rprApiMtlxNode.h"
+
+#include "pxr/imaging/rprUsd/material.h"
+#include "pxr/imaging/rprUsd/error.h"
+#include "pxr/base/arch/fileSystem.h"
+#include "rpr/baseNode.h"
+
+#include <RadeonProRender_MaterialX.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+rpr::MaterialNode* RprUsd_CreateRprMtlxFromString(std::string const& mtlxString, RprUsd_MaterialBuilderContext const& context) {
+    rpr::Status status;
+    std::unique_ptr<rpr::MaterialNode> matxNode(context.rprContext->CreateMaterialNode(RPR_MATERIAL_NODE_MATX, &status));
+    if (!matxNode) {
+        RPR_ERROR_CHECK(status, "Failed to create matx node");
+        return nullptr;
+    }
+
+    rpr_material_node matxNodeHandle = rpr::GetRprObject(matxNode.get());
+    // TODO: use rprMaterialXSetFileAsBuffer when supported
+    /*status = rprMaterialXSetFileAsBuffer(matxNodeHandle, mtlxString.c_str(), mtlxString.size());
+    if (status != RPR_SUCCESS) {
+        RPR_ERROR_CHECK(status, "Failed to set matx node file from buffer");
+        return nullptr;
+    }*/
+
+    // For now, as we have only rprMaterialXSetFile working, create a temporary file
+    {
+        std::string temporaryFilePath = ArchMakeTmpFileName("tmpMaterial", ".mtlx");
+
+        FILE* fout = fopen(temporaryFilePath.c_str(), "w");
+        if (!fout) {
+            return nullptr;
+        }
+
+        fwrite(mtlxString.c_str(), 1, mtlxString.size(), fout);
+        fclose(fout);
+
+        status = rprMaterialXSetFile(matxNodeHandle, temporaryFilePath.c_str());
+        if (status != RPR_SUCCESS) {
+            RPR_ERROR_CHECK(status, "Failed to set matx node file");
+            ArchUnlinkFile(temporaryFilePath.c_str());
+            return nullptr;
+        }
+    }
+
+    return matxNode.release();
+}
+
+rpr::MaterialNode* RprUsd_CreateRprMtlxFromFile(std::string const& mtlxFile, RprUsd_MaterialBuilderContext const& context) {
+    rpr::Status status;
+    std::unique_ptr<rpr::MaterialNode> matxNode(context.rprContext->CreateMaterialNode(RPR_MATERIAL_NODE_MATX, &status));
+    if (!matxNode) {
+        RPR_ERROR_CHECK(status, "Failed to create matx node");
+        return nullptr;
+    }
+
+    rpr_material_node matxNodeHandle = rpr::GetRprObject(matxNode.get());
+    status = rprMaterialXSetFile(matxNodeHandle, mtlxFile.c_str());
+    if (status != RPR_SUCCESS) {
+        RPR_ERROR_CHECK(status, "Failed to set matx node file");
+        ArchUnlinkFile(mtlxFile.c_str());
+        return nullptr;
+    }
+
+    return matxNode.release();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.h
@@ -1,0 +1,32 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#ifndef RPRUSD_MATERIAL_NODES_RPR_API_MTLX_NODE_H
+#define RPRUSD_MATERIAL_NODES_RPR_API_MTLX_NODE_H
+
+#include "pxr/pxr.h"
+
+#include <string>
+
+namespace rpr { class MaterialNode; }
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+struct RprUsd_MaterialBuilderContext;
+
+rpr::MaterialNode* RprUsd_CreateRprMtlxFromString(std::string const& mtlxString, RprUsd_MaterialBuilderContext const& context);
+rpr::MaterialNode* RprUsd_CreateRprMtlxFromFile(std::string const& mtlxFile, RprUsd_MaterialBuilderContext const& context);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // RPRUSD_MATERIAL_NODES_RPR_API_MTLX_NODE_H

--- a/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.cpp
@@ -295,20 +295,29 @@ RprUsd_UsdUVTexture::RprUsd_UsdUVTexture(
     // Analyze material graph and find out the minimum required amount of components required
     textureCommit.numComponentsRequired = 0;
     for (auto& entry : m_ctx->hdMaterialNetwork->nodes) {
-        for (auto& connection : entry.second.inputConnections) {
-            if (connection.second.upstreamNode == *m_ctx->currentNodePath) {
+        for (auto& entry : entry.second.inputConnections) {
+            auto& connections = entry.second;
+            if (connections.size() != 1) {
+                if (connections.size() > 1) {
+                    TF_RUNTIME_ERROR("Connected array elements are not supported. Please report this.");
+                }
+                continue;
+            }
+            auto& connection = connections[0];
+
+            if (connection.upstreamNode == *m_ctx->currentNodePath) {
                 uint32_t numComponentsRequired = 0;
-                if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->rgba) {
+                if (connection.upstreamOutputName == RprUsd_UsdUVTextureTokens->rgba) {
                     numComponentsRequired = 4;
-                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->rgb) {
+                } else if (connection.upstreamOutputName == RprUsd_UsdUVTextureTokens->rgb) {
                     numComponentsRequired = 3;
-                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->r) {
+                } else if (connection.upstreamOutputName == RprUsd_UsdUVTextureTokens->r) {
                     numComponentsRequired = 1;
-                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->g) {
+                } else if (connection.upstreamOutputName == RprUsd_UsdUVTextureTokens->g) {
                     numComponentsRequired = 2;
-                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->b) {
+                } else if (connection.upstreamOutputName == RprUsd_UsdUVTextureTokens->b) {
                     numComponentsRequired = 3;
-                } else if (connection.second.upstreamOutputName == RprUsd_UsdUVTextureTokens->a) {
+                } else if (connection.upstreamOutputName == RprUsd_UsdUVTextureTokens->a) {
                     numComponentsRequired = 4;
                 }
                 textureCommit.numComponentsRequired = std::max(textureCommit.numComponentsRequired, numComponentsRequired);

--- a/pxr/imaging/rprUsd/materialRegistry.cpp
+++ b/pxr/imaging/rprUsd/materialRegistry.cpp
@@ -18,19 +18,35 @@ limitations under the License.
 #include "pxr/imaging/rprUsd/material.h"
 #include "pxr/imaging/rprUsd/tokens.h"
 #include "pxr/imaging/rprUsd/error.h"
+#include "pxr/base/plug/registry.h"
+#include "pxr/base/plug/plugin.h"
+#include "pxr/base/arch/fileSystem.h"
+#include "pxr/base/arch/vsnprintf.h"
 #include "pxr/base/tf/instantiateSingleton.h"
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/envSetting.h"
 #include "pxr/base/tf/pathUtils.h"
 #include "pxr/base/tf/getenv.h"
 #include "pxr/base/work/loops.h"
+#include "pxr/usd/sdr/registry.h"
+#include "pxr/usd/usd/schemaBase.h"
 
 #include "materialNodes/usdNode.h"
 #include "materialNodes/houdiniPrincipledShaderNode.h"
 
+#include "pxr/imaging/hdMtlx/hdMtlx.h"
+
+#include <RadeonProRender_MaterialX.h>
+
+#include <MaterialXCore/Document.h>
+#include <MaterialXFormat/Util.h>
+namespace mx = MaterialX;
+
+#ifdef USE_CUSTOM_MATERIALX_LOADER
 #include "materialNodes/mtlxNode.h"
 #include <MaterialXFormat/XmlIo.h>
 #include <rprMtlxLoader.h>
+#endif
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -38,10 +54,15 @@ TF_INSTANTIATE_SINGLETON(RprUsdMaterialRegistry);
 
 TF_DEFINE_ENV_SETTING(RPRUSD_MATERIAL_NETWORK_SELECTOR, "rpr",
     "Material network selector to be used in hdRpr");
+
+#ifdef USE_CUSTOM_MATERIALX_LOADER
 TF_DEFINE_ENV_SETTING(RPRUSD_USE_RPRMTLXLOADER, true,
     "Whether to use RPRMtlxLoader or rprLoadMateriaX");
 TF_DEFINE_ENV_SETTING(RPRUSD_RPRMTLXLOADER_LOG_LEVEL, int(RPRMtlxLoader::LogLevel::Error),
     "Set logging level of RPRMtlxLoader");
+#endif // USE_CUSTOM_MATERIALX_LOADER
+
+TF_DEFINE_PRIVATE_TOKENS(_tokens, (mtlx));
 
 RprUsdMaterialRegistry::RprUsdMaterialRegistry()
     : m_materialNetworkSelector(TfGetEnvSetting(RPRUSD_MATERIAL_NETWORK_SELECTOR)) {
@@ -52,6 +73,7 @@ RprUsdMaterialRegistry::~RprUsdMaterialRegistry() = default;
 
 std::vector<RprUsdMaterialNodeDesc> const&
 RprUsdMaterialRegistry::GetRegisteredNodes() {
+#ifdef USE_CUSTOM_MATERIALX_LOADER
     if (m_mtlxDefsDirty) {
         m_mtlxDefsDirty = false;
 
@@ -115,6 +137,7 @@ RprUsdMaterialRegistry::GetRegisteredNodes() {
             }
         }
     }
+#endif // USE_CUSTOM_MATERIALX_LOADER
 
     return m_registeredNodes;
 }
@@ -307,50 +330,110 @@ void DumpMaterialNetwork(HdMaterialNetworkMap const& networkMap) {
     }
 }
 
-void ConvertLegacyHdMaterialNetwork(
-    HdMaterialNetworkMap const& hdNetworkMap,
-    RprUsd_MaterialNetwork *result) {
-
-    for (auto& entry : hdNetworkMap.map) {
-        auto& terminalName = entry.first;
-        auto& hdNetwork = entry.second;
-
-        // Transfer over individual nodes
-        for (auto& node : hdNetwork.nodes) {
-            // Check if this node is a terminal
-            auto termIt = std::find(hdNetworkMap.terminals.begin(), hdNetworkMap.terminals.end(), node.path);
-            if (termIt != hdNetworkMap.terminals.end()) {
-                result->terminals.emplace(
-                    terminalName,
-                    RprUsd_MaterialNetwork::Connection{node.path, terminalName});
-            }
-
-            if (result->nodes.count(node.path)) {
-                continue;
-            }
-
-            auto& newNode = result->nodes[node.path];
-            newNode.nodeTypeId = node.identifier;
-            newNode.parameters = node.parameters;
-        }
-
-        // Transfer relationships to inputConnections on receiving/downstream nodes.
-        for (HdMaterialRelationship const& rel : hdNetwork.relationships) {
-            // outputId (in hdMaterial terms) is the input of the receiving node
-            auto const& iter = result->nodes.find(rel.outputId);
-            // skip connection if the destination node doesn't exist
-            if (iter == result->nodes.end()) {
-                continue;
-            }
-            auto &connection = iter->second.inputConnections[rel.outputName];
-            connection.upstreamNode = rel.inputId;
-            connection.upstreamOutputName = rel.inputName;
-        }
-
-        // Currently unused
-        // Transfer primvars:
-        //result->primvars.insert(hdNetwork.primvars.begin(), hdNetwork.primvars.end());
+RprUsdMaterial* CreateMaterialXFromUsdShade(
+    SdfPath const& materialPath,
+    RprUsd_MaterialBuilderContext const& context,
+    std::string* materialXStdlibPath) {
+    auto terminalIt = context.hdMaterialNetwork->terminals.find(HdMaterialTerminalTokens->surface);
+    if (terminalIt == context.hdMaterialNetwork->terminals.end()) {
+        return nullptr;
     }
+    HdMaterialConnection2 const& nodeConnection = terminalIt->second;
+
+    SdfPath const& nodePath = nodeConnection.upstreamNode;
+    auto nodeIt = context.hdMaterialNetwork->nodes.find(nodePath);
+    if (nodeIt == context.hdMaterialNetwork->nodes.end()) {
+        return nullptr;
+    }
+
+    HdMaterialNode2 const& terminalNode = nodeIt->second;
+
+    SdrRegistry &sdrRegistry = SdrRegistry::GetInstance();
+    SdrShaderNodeConstPtr const mtlxSdrNode = sdrRegistry.GetShaderNodeByIdentifierAndType(terminalNode.nodeTypeId, _tokens->mtlx);
+
+    if (!mtlxSdrNode) {
+        return nullptr;
+    }
+
+    if (materialXStdlibPath->empty()) {
+        const TfType schemaBaseType = TfType::Find<UsdSchemaBase>();
+        PlugPluginPtr usdPlugin = PlugRegistry::GetInstance().GetPluginForType(schemaBaseType);
+        if (usdPlugin) {
+            std::string usdLibPath = usdPlugin->GetPath();
+            std::string usdDir = TfNormPath(TfGetPathName(usdLibPath) + "..");
+            *materialXStdlibPath = usdDir;
+        }
+    }
+    
+    mx::DocumentPtr stdLibraries = mx::createDocument();
+
+    if (!materialXStdlibPath->empty()) {
+        mx::FilePathVec libraryFolders = {"libraries"};
+        mx::FileSearchPath searchPath;
+        searchPath.append(mx::FilePath(*materialXStdlibPath));
+        mx::loadLibraries(libraryFolders, searchPath, stdLibraries);
+    }
+
+    MaterialX::StringMap textureMap;
+    std::set<SdfPath> hdTextureNodes;
+    mx::DocumentPtr mtlxDoc = HdMtlxCreateMtlxDocumentFromHdNetwork(
+        *context.hdMaterialNetwork,
+        terminalNode,
+        materialPath,
+        stdLibraries,
+        &hdTextureNodes,
+        &textureMap);
+
+    // Add Hydra parameters for each of the Texture nodes
+    /*_UpdateTextureNodes(hdNetwork, terminalNodePath, hdTextureNodes,
+        &mxHdInfo.textureMap, &mxHdInfo.primvarMap,
+        &mxHdInfo.defaultTexcoordName);*/
+
+    std::string mtlxString = mx::writeToXmlString(mtlxDoc, nullptr);
+
+    rpr::Status status;
+    std::unique_ptr<rpr::MaterialNode> matxNode(context.rprContext->CreateMaterialNode(RPR_MATERIAL_NODE_MATX, &status));
+    if (!matxNode) {
+        RPR_ERROR_CHECK(status, "Failed to create matx node");
+        return nullptr;
+    }
+
+    rpr_material_node matxNodeHandle = rpr::GetRprObject(matxNode.get());
+    /*status = rprMaterialXSetFileAsBuffer(matxNodeHandle, mtlxString.c_str(), mtlxString.size());
+    if (status != RPR_SUCCESS) {
+        RPR_ERROR_CHECK(status, "Failed to set matx node file from buffer");
+        return nullptr;
+    }*/
+
+    {
+        std::string temporaryFilePath;
+        int fd = ArchMakeTmpFile("tmpMaterial", &temporaryFilePath);
+        if (fd != -1) {
+            FILE* fout = ArchFdOpen(fd, "w");
+            fwrite(mtlxString.c_str(), 1, mtlxString.size(), fout);
+            fclose(fout);
+
+            status = rprMaterialXSetFile(matxNodeHandle, temporaryFilePath.c_str());
+            if (status != RPR_SUCCESS) {
+                RPR_ERROR_CHECK(status, "Failed to set matx node file");
+                return nullptr;
+            }
+        } else {
+            return nullptr;
+        }
+    }
+
+    struct RprUsdMaterial_RprApiMaterialX : public RprUsdMaterial {
+        std::unique_ptr<rpr::MaterialNode> retainedNode;
+
+        RprUsdMaterial_RprApiMaterialX(std::unique_ptr<rpr::MaterialNode> retainedNode)
+            : retainedNode(std::move(retainedNode)) {
+            // TODO: fill m_uvPrimvarName
+            m_surfaceNode = retainedNode.get();
+        }
+    };
+
+    return new RprUsdMaterial_RprApiMaterialX(std::move(matxNode));
 }
 
 } // namespace anonymous
@@ -366,17 +449,24 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
         DumpMaterialNetwork(legacyNetworkMap);
     }
 
-    // HdMaterialNetworkMap is deprecated,
-    // convert HdMaterialNetwork over to the new description
-    // so we do not have to redo all the code when new description comes in Hd
-    RprUsd_MaterialNetwork network;
-    ConvertLegacyHdMaterialNetwork(legacyNetworkMap, &network);
+    bool isVolume = false;
+    HdMaterialNetwork2 network;
+    HdMaterialNetwork2ConvertFromHdMaterialNetworkMap(legacyNetworkMap, &network, &isVolume);
 
     RprUsd_MaterialBuilderContext context = {};
     context.hdMaterialNetwork = &network;
     context.rprContext = rprContext;
     context.imageCache = imageCache;
+#ifdef USE_CUSTOM_MATERIALX_LOADER
     context.mtlxLoader = m_mtlxLoader.get();
+#endif // USE_CUSTOM_MATERIALX_LOADER
+
+    if (!isVolume) {
+        if (auto usdShadeMtlxMaterial = CreateMaterialXFromUsdShade(materialId, context, &m_materialXStdlibPath)) {
+            return usdShadeMtlxMaterial;
+        }
+    }
+    
 
     // The simple wrapper to retain material nodes that are used to build terminal outputs
     struct RprUsdGraphBasedMaterial : public RprUsdMaterial {
@@ -470,9 +560,9 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
     }
 
     std::set<SdfPath> visited;
-    std::function<VtValue(RprUsd_MaterialNetwork::Connection const&)> getNodeOutput =
+    std::function<VtValue(HdMaterialConnection2 const&)> getNodeOutput =
         [&materialNodes, &network, &getNodeOutput, &visited]
-        (RprUsd_MaterialNetwork::Connection const& nodeConnection) -> VtValue {
+        (HdMaterialConnection2 const& nodeConnection) -> VtValue {
         auto& nodePath = nodeConnection.upstreamNode;
 
         auto nodeIt = network.nodes.find(nodePath);
@@ -491,7 +581,14 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
                 visited.insert(nodePath);
 
                 for (auto& inputConnection : node.inputConnections) {
-                    auto& connection = inputConnection.second;
+                    auto& connections = inputConnection.second;
+                    if (connections.size() != 1) {
+                        if (connections.size() > 1) {
+                            TF_RUNTIME_ERROR("Connected array elements are not supported. Please report this.");
+                        }
+                        continue;
+                    }
+                    HdMaterialConnection2 const& connection = connections[0];
 
                     auto nodeOutput = getNodeOutput(connection);
                     if (!nodeOutput.IsEmpty()) {
@@ -511,7 +608,14 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
             if (node.inputConnections.empty()) {
                 return VtValue();
             } else {
-                return getNodeOutput(node.inputConnections.begin()->second);
+                auto& connections = node.inputConnections.begin()->second;
+                if (connections.size() != 1) {
+                    if (connections.size() > 1) {
+                        TF_RUNTIME_ERROR("Connected array elements are not supported. Please report this.");
+                    }
+                    return VtValue();
+                }
+                return getNodeOutput(connections[0]);
             }
         }
     };

--- a/pxr/imaging/rprUsd/materialRegistry.cpp
+++ b/pxr/imaging/rprUsd/materialRegistry.cpp
@@ -394,31 +394,31 @@ RprUsdMaterial* CreateMaterialXFromUsdShade(
     }
 
     rpr_material_node matxNodeHandle = rpr::GetRprObject(matxNode.get());
-	// TODO: use rprMaterialXSetFileAsBuffer when supported
+    // TODO: use rprMaterialXSetFileAsBuffer when supported
     /*status = rprMaterialXSetFileAsBuffer(matxNodeHandle, mtlxString.c_str(), mtlxString.size());
     if (status != RPR_SUCCESS) {
         RPR_ERROR_CHECK(status, "Failed to set matx node file from buffer");
         return nullptr;
     }*/
 
-	// For now, as we have only rprMaterialXSetFile working, create a temporary file
+    // For now, as we have only rprMaterialXSetFile working, create a temporary file
     {
-		std::string temporaryFilePath = ArchMakeTmpFileName("tmpMaterial", ".mtlx");
+        std::string temporaryFilePath = ArchMakeTmpFileName("tmpMaterial", ".mtlx");
 
-		FILE* fout = fopen(temporaryFilePath.c_str(), "w");
-		if (!fout) {
-			return nullptr;
-		}
+        FILE* fout = fopen(temporaryFilePath.c_str(), "w");
+        if (!fout) {
+            return nullptr;
+        }
 
-		fwrite(mtlxString.c_str(), 1, mtlxString.size(), fout);
-		fclose(fout);
+        fwrite(mtlxString.c_str(), 1, mtlxString.size(), fout);
+        fclose(fout);
 
-		status = rprMaterialXSetFile(matxNodeHandle, temporaryFilePath.c_str());
-		if (status != RPR_SUCCESS) {
-			RPR_ERROR_CHECK(status, "Failed to set matx node file");
-			ArchUnlinkFile(temporaryFilePath.c_str());
-			return nullptr;
-		}
+        status = rprMaterialXSetFile(matxNodeHandle, temporaryFilePath.c_str());
+        if (status != RPR_SUCCESS) {
+            RPR_ERROR_CHECK(status, "Failed to set matx node file");
+            ArchUnlinkFile(temporaryFilePath.c_str());
+            return nullptr;
+        }
     }
 
     struct RprUsdMaterial_RprApiMaterialX : public RprUsdMaterial {

--- a/pxr/imaging/rprUsd/materialRegistry.h
+++ b/pxr/imaging/rprUsd/materialRegistry.h
@@ -74,8 +74,10 @@ public:
     RPRUSD_API
     std::vector<RprUsdMaterialNodeDesc> const& GetRegisteredNodes();
 
+#ifdef USE_CUSTOM_MATERIALX_LOADER
     RPRUSD_API
     RPRMtlxLoader* GetMtlxLoader() const { return m_mtlxLoader.get(); }
+#endif
 
     /// Register implementation of the Node with \p id
     RPRUSD_API
@@ -107,13 +109,17 @@ private:
     /// Material network selector for the current session, controlled via env variable
     TfToken m_materialNetworkSelector;
 
+#ifdef USE_CUSTOM_MATERIALX_LOADER
     std::unique_ptr<RPRMtlxLoader> m_mtlxLoader;
-
-    std::vector<RprUsdMaterialNodeDesc> m_registeredNodes;
-    std::map<TfToken, size_t> m_registeredNodesLookup;
 
     std::vector<std::unique_ptr<RprUsd_MtlxNodeInfo>> m_mtlxInfos;
     bool m_mtlxDefsDirty = true;
+#else
+    mutable std::string m_materialXStdlibPath;
+#endif
+
+    std::vector<RprUsdMaterialNodeDesc> m_registeredNodes;
+    std::map<TfToken, size_t> m_registeredNodesLookup;
 
     std::vector<TextureCommit> m_textureCommits;
 };


### PR DESCRIPTION
### PURPOSE
To support MaterialX via UsdShade.

### EFFECT OF CHANGE
Added support of MaterialX defined via UsdShade network.

### TECHNICAL STEPS
* Disable the custom mtlx loader if the target USD has materialX
* Add HybridPro RPR plugin
* Use hdMtlx to convert UsdShade network to Materialx::Document