### PR TITLE
Nested instancer fix

### DIFF
--- a/pxr/imaging/plugin/hdRpr/instancer.cpp
+++ b/pxr/imaging/plugin/hdRpr/instancer.cpp
@@ -291,14 +291,13 @@ HdTimeSampleArray<VtMatrix4dArray, 2> HdRprInstancer::SampleInstanceTransforms(S
 
 void
 HdRprInstancer::Sync(HdSceneDelegate *sceneDelegate,
-	HdRenderParam   *renderParam,
-	HdDirtyBits     *dirtyBits) {
-	HD_TRACE_FUNCTION();
-	HF_MALLOC_TAG_FUNCTION();
+    HdRenderParam   *renderParam,
+    HdDirtyBits     *dirtyBits) {
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
 
-	SdfPath const& instancerId = GetId();
-
-	_UpdateInstancer(sceneDelegate, dirtyBits);
+    SdfPath const& instancerId = GetId();
+    _UpdateInstancer(sceneDelegate, dirtyBits);
 }
 
 

--- a/pxr/imaging/plugin/hdRpr/instancer.cpp
+++ b/pxr/imaging/plugin/hdRpr/instancer.cpp
@@ -30,109 +30,6 @@ TF_DEFINE_PRIVATE_TOKENS(
     (translate)
 );
 
-void HdRprInstancer::_Sync() {
-    HD_TRACE_FUNCTION();
-    HF_MALLOC_TAG_FUNCTION();
-
-    auto& instancerId = GetId();
-    auto& changeTracker = GetDelegate()->GetRenderIndex().GetChangeTracker();
-
-    // Use the double-checked locking pattern to check if this instancer's
-    // primvars are dirty.
-    int dirtyBits = changeTracker.GetInstancerDirtyBits(instancerId);
-    if (!HdChangeTracker::IsAnyPrimvarDirty(dirtyBits, instancerId)) {
-        return;
-    }
-
-    std::lock_guard<std::mutex> lock(m_syncMutex);
-    dirtyBits = changeTracker.GetInstancerDirtyBits(instancerId);
-    if (!HdChangeTracker::IsAnyPrimvarDirty(dirtyBits, instancerId)) {
-        return;
-    }
-
-    auto primvarDescs = GetDelegate()->GetPrimvarDescriptors(instancerId, HdInterpolationInstance);
-    for (auto& desc : primvarDescs) {
-        if (!HdChangeTracker::IsPrimvarDirty(dirtyBits, instancerId, desc.name)) {
-            continue;
-        }
-
-        VtValue value = GetDelegate()->Get(instancerId, desc.name);
-        if (value.IsEmpty()) {
-            continue;
-        }
-
-        if (desc.name == _tokens->translate) {
-            if (value.IsHolding<VtVec3fArray>()) {
-                m_translate = value.UncheckedGet<VtVec3fArray>();
-            }
-        } else if (desc.name == _tokens->rotate) {
-            if (value.IsHolding<VtVec4fArray>()) {
-                m_rotate = value.UncheckedGet<VtVec4fArray>();
-            }
-        } else if (desc.name == _tokens->scale) {
-            if (value.IsHolding<VtVec3fArray>()) {
-                m_scale = value.UncheckedGet<VtVec3fArray>();
-            }
-        } else if (desc.name == _tokens->instanceTransform) {
-            if (value.IsHolding<VtMatrix4dArray>()) {
-                m_transform = value.UncheckedGet<VtMatrix4dArray>();
-            }
-        }
-    }
-
-    // Mark the instancer as clean
-    changeTracker.MarkInstancerClean(instancerId);
-}
-
-VtMatrix4dArray HdRprInstancer::ComputeTransforms(SdfPath const& prototypeId) {
-    _Sync();
-
-    GfMatrix4d instancerTransform = GetDelegate()->GetInstancerTransform(GetId());
-    VtIntArray instanceIndices = GetDelegate()->GetInstanceIndices(GetId(), prototypeId);
-
-    VtMatrix4dArray transforms;
-    transforms.reserve(instanceIndices.size());
-    for (int idx : instanceIndices) {
-        GfMatrix4d translateMat(1);
-        GfMatrix4d rotateMat(1);
-        GfMatrix4d scaleMat(1);
-        GfMatrix4d transform(1);
-
-        if (!m_translate.empty()) {
-            translateMat.SetTranslate(GfVec3d(m_translate.cdata()[idx]));
-        }
-
-        if (!m_rotate.empty()) {
-            auto& v = m_rotate.cdata()[idx];
-            rotateMat.SetRotate(GfQuatd(v[0], GfVec3d(v[1], v[2], v[3])));
-        }
-
-        if (!m_scale.empty()) {
-            scaleMat.SetScale(GfVec3d(m_scale.cdata()[idx]));
-        }
-
-        if (!m_transform.empty()) {
-            transform = m_transform.cdata()[idx];
-        }
-
-        transforms.push_back(transform * scaleMat * rotateMat * translateMat * instancerTransform);
-    }
-
-    auto parentInstancer = static_cast<HdRprInstancer*>(GetDelegate()->GetRenderIndex().GetInstancer(GetParentId()));
-    if (!parentInstancer) {
-        return transforms;
-    }
-
-    VtMatrix4dArray wordTransform;
-    for (const GfMatrix4d& parentTransform : parentInstancer->ComputeTransforms(GetId())) {
-        for (const GfMatrix4d& localTransform : transforms) {
-            wordTransform.push_back(parentTransform * localTransform);
-        }
-    }
-
-    return wordTransform;
-}
-
 namespace {
 
 // Helper to accumulate sample times from the largest set of
@@ -391,5 +288,18 @@ HdTimeSampleArray<VtMatrix4dArray, 2> HdRprInstancer::SampleInstanceTransforms(S
 
     return sa;
 }
+
+void
+HdRprInstancer::Sync(HdSceneDelegate *sceneDelegate,
+	HdRenderParam   *renderParam,
+	HdDirtyBits     *dirtyBits) {
+	HD_TRACE_FUNCTION();
+	HF_MALLOC_TAG_FUNCTION();
+
+	SdfPath const& instancerId = GetId();
+
+	_UpdateInstancer(sceneDelegate, dirtyBits);
+}
+
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/instancer.h
+++ b/pxr/imaging/plugin/hdRpr/instancer.h
@@ -41,9 +41,9 @@ public:
 
     HdTimeSampleArray<VtMatrix4dArray, 2> SampleInstanceTransforms(SdfPath const& prototypeId);
 
-	void Sync(HdSceneDelegate *sceneDelegate,
-			  HdRenderParam   *renderParam,
-			  HdDirtyBits     *dirtyBits) override;
+    void Sync(HdSceneDelegate *sceneDelegate,
+              HdRenderParam   *renderParam,
+              HdDirtyBits     *dirtyBits) override;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/instancer.h
+++ b/pxr/imaging/plugin/hdRpr/instancer.h
@@ -39,19 +39,11 @@ public:
         HdInstancer(delegate, id HDRPR_INSTANCER_ID_ARG) {
     }
 
-    VtMatrix4dArray ComputeTransforms(SdfPath const& prototypeId);
-
     HdTimeSampleArray<VtMatrix4dArray, 2> SampleInstanceTransforms(SdfPath const& prototypeId);
 
-private:
-    void _Sync();
-
-    VtMatrix4dArray m_transform;
-    VtVec3fArray m_translate;
-    VtVec4fArray m_rotate;
-    VtVec3fArray m_scale;
-
-    std::mutex m_syncMutex;
+	void Sync(HdSceneDelegate *sceneDelegate,
+			  HdRenderParam   *renderParam,
+			  HdDirtyBits     *dirtyBits) override;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -632,6 +632,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         if (newMesh || (*dirtyBits & HdChangeTracker::DirtyInstancer)) {
 #ifdef USE_DECOUPLED_INSTANCER
             _UpdateInstancer(sceneDelegate, dirtyBits);
+			HdInstancer::_SyncInstancerAndParents(sceneDelegate->GetRenderIndex(), GetInstancerId());
 #endif
             if (auto instancer = static_cast<HdRprInstancer*>(sceneDelegate->GetRenderIndex().GetInstancer(GetInstancerId()))) {
                 auto instanceTransforms = instancer->SampleInstanceTransforms(id);

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -632,7 +632,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         if (newMesh || (*dirtyBits & HdChangeTracker::DirtyInstancer)) {
 #ifdef USE_DECOUPLED_INSTANCER
             _UpdateInstancer(sceneDelegate, dirtyBits);
-			HdInstancer::_SyncInstancerAndParents(sceneDelegate->GetRenderIndex(), GetInstancerId());
+            HdInstancer::_SyncInstancerAndParents(sceneDelegate->GetRenderIndex(), GetInstancerId());
 #endif
             if (auto instancer = static_cast<HdRprInstancer*>(sceneDelegate->GetRenderIndex().GetInstancer(GetInstancerId()))) {
                 auto instanceTransforms = instancer->SampleInstanceTransforms(id);

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.h
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.h
@@ -173,8 +173,10 @@ inline VtValue HdRpr_GetParam(HdSceneDelegate* sceneDelegate, SdfPath id, TfToke
     // We may need to fix this in newer versions of USD
 #if PXR_VERSION < 2108
     return sceneDelegate->GetLightParamValue(id, name);
-#else
+#elif PXR_VERSION < 2111
     return sceneDelegate->GetCameraParamValue(id, name);
+#else
+    return sceneDelegate->GetLightParamValue(id, name);
 #endif
 }
 


### PR DESCRIPTION
### PURPOSE
After migrate to USD 21.11 we've got invalid instancer logic. They weren't work if composed into nested structures

### EFFECT OF CHANGE
Fixed nested instancers transforms

### TECHNICAL STEPS
- Called _SyncInstancerAndParents on instancer, which calls Instancer::Sync() under hood 
- Implemented virtual Sync() method for HdRprInstancer. Logic was taken from HdStInstancer
- Removed unused code

### NOTES FOR REVIEWERS
None
