### PR TITLE
Dynamically hide unused parameters of RPR Toon node

### DIFF
--- a/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.cpp
+++ b/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.cpp
@@ -352,6 +352,87 @@ VOP_Type VOP_RPRMaterial::getShaderType() const {
 
 #endif
 
+template <typename T>
+VtValue GetParmValue(PRM_Parm const* parm) {
+    T value;
+    parm->getValue(0.0, value, 0, 0);
+    return VtValue(value);
+}
+
+template <>
+VtValue GetParmValue<std::string>(PRM_Parm const* parm) {
+    UT_String value;
+    parm->getValue(0.0, value, 0, true, 0);
+    return VtValue(std::string(value));
+}
+
+struct VOP_Node_StateProvider : public RprUsdMaterialNodeStateProvider {
+    VOP_Node const* node;
+
+    VOP_Node_StateProvider(VOP_Node const* node) : node(node) {
+
+    }
+
+    VtValue GetValue(const char* name) override {
+        PRM_Parm const* parm = node->getParmPtr(name);
+        if (!parm) {
+            return {};
+        }
+
+        PRM_Type const& type = parm->getType();
+        if (type == PRM_FLT) {
+            return GetParmValue<fpreal>(parm);
+        } else if (type == PRM_TOGGLE) {
+            return GetParmValue<int32>(parm);
+        } else if (type == PRM_ORD_E) {
+            return GetParmValue<int32>(parm);
+        } else if (type == PRM_STRING_E) {
+            return GetParmValue<std::string>(parm);
+        }
+        return {};
+    }
+};
+
+void VOP_RPRMaterial::opChanged(OP_EventType reason, void* data) {
+    VOP_Node::opChanged(reason, data);
+
+    if (!m_shaderInfo->HasDynamicVisibility()) {
+        return;
+    }
+
+    if (reason == OP_PARM_CHANGED) {
+        int parmIndex = int(reinterpret_cast<intptr_t>(data));
+        if (parmIndex == -1) {
+            // might happen on "File"->"Save As..." and Auto-Save
+            return;
+        }
+
+        VOP_Node_StateProvider stateProvider{this};
+        PRM_Parm const& parm = getParm(parmIndex);
+        auto visibilityUpdate = m_shaderInfo->GetVisibilityUpdate(parm.getToken(), &stateProvider);
+        for (auto const& parmVisibility : visibilityUpdate.parmsVisibility) {
+            getParm(parmVisibility.name).setVisibleState(parmVisibility.isVisible);
+        }
+    }
+}
+
+bool VOP_RPRMaterial::runCreateScript() {
+    if (!m_shaderInfo->HasDynamicVisibility()) {
+        return true;
+    }
+
+    VOP_Node_StateProvider stateProvider{this};
+    for (size_t i = 0; i < m_shaderInfo->GetNumInputs(); ++i) {
+        const char* parmName = m_shaderInfo->GetInput(i)->GetName();
+        auto visibilityUpdate = m_shaderInfo->GetVisibilityUpdate(parmName, &stateProvider);
+        for (auto const& parmVisibility : visibilityUpdate.parmsVisibility) {
+            getParm(parmVisibility.name).setVisibleState(parmVisibility.isVisible);
+        }
+    }
+
+    return true;
+}
+
 void VOP_RPRMaterial::getInputNameSubclass(UT_String &in, int i_idx) const {
     in = inputLabel(i_idx);
 }
@@ -504,7 +585,7 @@ void VOP_MaterialX::ElementChoiceGenFunc(
 }
 
 void VOP_MaterialX::opChanged(OP_EventType reason, void* data) {
-    VOP_RPRMaterial::opChanged(reason, data);
+    VOP_Node::opChanged(reason, data);
 
     if (reason == OP_PARM_CHANGED) {
         int parmIndex = int(reinterpret_cast<intptr_t>(data));

--- a/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.cpp
+++ b/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.cpp
@@ -168,7 +168,7 @@ static PRM_Default* NewPRMDefault(
         items->push_back(PRM_Item());
 
         auto& choiceList = *choiceListPtr;
-        auto choiceListType = PRM_ChoiceListType(PRM_CHOICELIST_SINGLE | PRM_CHOICELIST_USE_TOKEN);
+        auto choiceListType = PRM_ChoiceListType(PRM_CHOICELIST_SINGLE);
         choiceList = LEAKED(new PRM_ChoiceList(choiceListType, items->data()));
 
         return defau1t;
@@ -416,21 +416,19 @@ void VOP_RPRMaterial::opChanged(OP_EventType reason, void* data) {
     }
 }
 
-bool VOP_RPRMaterial::runCreateScript() {
-    if (!m_shaderInfo->HasDynamicVisibility()) {
-        return true;
-    }
+void VOP_RPRMaterial::onCreated() {
+    VOP_Node::onCreated();
 
-    VOP_Node_StateProvider stateProvider{this};
-    for (size_t i = 0; i < m_shaderInfo->GetNumInputs(); ++i) {
-        const char* parmName = m_shaderInfo->GetInput(i)->GetName();
-        auto visibilityUpdate = m_shaderInfo->GetVisibilityUpdate(parmName, &stateProvider);
-        for (auto const& parmVisibility : visibilityUpdate.parmsVisibility) {
-            getParm(parmVisibility.name).setVisibleState(parmVisibility.isVisible);
+    if (m_shaderInfo->HasDynamicVisibility()) {
+        VOP_Node_StateProvider stateProvider{this};
+        for (size_t i = 0; i < m_shaderInfo->GetNumInputs(); ++i) {
+            const char* parmName = m_shaderInfo->GetInput(i)->GetName();
+            auto visibilityUpdate = m_shaderInfo->GetVisibilityUpdate(parmName, &stateProvider);
+            for (auto const& parmVisibility : visibilityUpdate.parmsVisibility) {
+                getParm(parmVisibility.name).setVisibleState(parmVisibility.isVisible);
+            }
         }
     }
-
-    return true;
 }
 
 void VOP_RPRMaterial::getInputNameSubclass(UT_String &in, int i_idx) const {

--- a/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.h
+++ b/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.h
@@ -73,7 +73,7 @@ public:
 #endif
 
     void opChanged(OP_EventType reason, void* data) override;
-    bool runCreateScript() override;
+    void onCreated() override;
 
 protected:
     /// Returns the internal name of an input parameter.
@@ -112,6 +112,7 @@ public:
 
     void opChanged(OP_EventType reason, void* data) override;
     bool runCreateScript() override;
+    void onCreated() override { VOP_Node::onCreated(); }
 
 private:
     static void ElementChoiceGenFunc(void* op, PRM_Name* choices, int maxChoicesSize, const PRM_SpareData*, const PRM_Parm*);

--- a/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.h
+++ b/pxr/imaging/plugin/rprHoudini/VOP_RPRMaterial.h
@@ -72,6 +72,9 @@ public:
     VOP_Type getShaderType() const override;
 #endif
 
+    void opChanged(OP_EventType reason, void* data) override;
+    bool runCreateScript() override;
+
 protected:
     /// Returns the internal name of an input parameter.
     void getInputNameSubclass(UT_String &in, int i_idx) const override;

--- a/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
@@ -45,10 +45,7 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (ThreeColors)
     (FiveColors)
 
-    (transparencyMode)
     (transparency)
-    (DisableTransparency)
-    (EnableTransparency)
     
     (interpolationMode)
     (Linear)
@@ -93,7 +90,7 @@ public:
     ~RprUsd_RprToonNode() override = default;
 
     VtValue GetOutput(TfToken const& outputId) override {
-        if (m_TransparencyEnabled) {
+        if (m_blendNode) {
             return VtValue(m_blendNode);
         } else {
             return VtValue(m_toonClosureNode);
@@ -157,18 +154,10 @@ public:
             return false;
         } else if (id == _tokens->transparency) {
             if (value.IsHolding<float>()) {
-                float transparency = value.UncheckedGet<float>();
-                return m_blendNode->SetInput(RPR_MATERIAL_INPUT_WEIGHT, transparency, transparency, transparency, transparency) == RPR_SUCCESS;
-            }
-            TF_RUNTIME_ERROR("Input `%s` has invalid type: %s, expected - `float`", id.GetText(), value.GetTypeName().c_str());
-            return false;
-        } else if (id == _tokens->transparencyMode) {
-            if (value.IsHolding<int>()) {
-                int transparencyModeInt = value.UncheckedGet<int>();
-                SetTransparencyEnabled(static_cast<bool>(transparencyModeInt));
+                UpdateTransparency(value.UncheckedGet<float>());
                 return true;
             }
-            TF_RUNTIME_ERROR("Input `%s` has invalid type: %s, expected - `int`", id.GetText(), value.GetTypeName().c_str());
+            TF_RUNTIME_ERROR("Input `%s` has invalid type: %s, expected - `float`", id.GetText(), value.GetTypeName().c_str());
             return false;
         }
 
@@ -181,10 +170,7 @@ public:
         VisibilityUpdate GetVisibilityUpdate(const char* changedParam, RprUsdMaterialNodeStateProvider* stateProvider) const override {
             VisibilityUpdate visibilityUpdate;
 
-            if (_tokens->transparencyMode == changedParam) {
-                bool isTransparencyEnabled = stateProvider->GetValue(changedParam).GetWithDefault(0) != 0;
-                visibilityUpdate.Add(isTransparencyEnabled, _tokens->transparency.GetText());
-            } else if (_tokens->colorsMode == changedParam) {
+            if (_tokens->colorsMode == changedParam) {
                 bool isFiveColorMode = stateProvider->GetValue(changedParam).GetWithDefault(0) != 0;
                 visibilityUpdate.Add(isFiveColorMode, _tokens->shadowTint2.GetText());
                 visibilityUpdate.Add(isFiveColorMode, _tokens->highlightTint2.GetText());
@@ -234,11 +220,7 @@ public:
         nodeInfo.inputs.emplace_back(_tokens->highlightLevelMix, 0.05f);
         nodeInfo.inputs.emplace_back(_tokens->highlightLevelMix2, 0.05f);
 
-        RprUsd_RprNodeInput transparencyModeInput(_tokens->transparencyMode, _tokens->DisableTransparency);
-        transparencyModeInput.value = VtValue(0);
-        transparencyModeInput.tokenValues = { _tokens->DisableTransparency, _tokens->EnableTransparency };
-        nodeInfo.inputs.push_back(transparencyModeInput);
-        nodeInfo.inputs.emplace_back(_tokens->transparency, 0.5f);
+        nodeInfo.inputs.emplace_back(_tokens->transparency, 0.0f);
 
         RprUsd_RprNodeInput interpolationModeInput(_tokens->interpolationMode, _tokens->None);
         interpolationModeInput.value = VtValue(0);
@@ -261,43 +243,49 @@ private:
     std::shared_ptr<rpr::MaterialNode> m_blendNode;
     std::shared_ptr<rpr::MaterialNode> m_toonClosureNode;
 
-    bool m_TransparencyEnabled = false;
     rpr::Context* m_rprContext = nullptr;
 
-    void SetTransparencyEnabled(bool value) {
-        if (value) {
+    void UpdateTransparency(float transparency) {
+        if (transparency > 0.0f) {
             rpr::Status status;
-
-            m_transparentNode.reset(m_rprContext->CreateMaterialNode(RPR_MATERIAL_NODE_TRANSPARENT, &status));
-            if (!m_transparentNode) {
-                throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to create transparent node", m_rprContext));
-            }
-
-            m_blendNode.reset(m_rprContext->CreateMaterialNode(RPR_MATERIAL_NODE_BLEND, &status));
             if (!m_blendNode) {
-                throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to create blend node", m_rprContext));
-            }
+                std::unique_ptr<rpr::MaterialNode> blendNode(m_rprContext->CreateMaterialNode(RPR_MATERIAL_NODE_BLEND, &status));
+                if (!blendNode) {
+                    throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to create blend node", m_rprContext));
+                }
 
-            status = m_blendNode->SetInput(RPR_MATERIAL_INPUT_COLOR0, m_transparentNode.get());
-            if (status != RPR_SUCCESS) {
-                throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to set color1 input of blend node", m_rprContext));
-            }
+                std::unique_ptr<rpr::MaterialNode> transparentNode(m_rprContext->CreateMaterialNode(RPR_MATERIAL_NODE_TRANSPARENT, &status));
+                if (!transparentNode) {
+                    throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to create transparent node", m_rprContext));
+                }
 
-            status = m_blendNode->SetInput(RPR_MATERIAL_INPUT_COLOR1, m_toonClosureNode.get());
-            if (status != RPR_SUCCESS) {
-                throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to set color0 input of blend node", m_rprContext));
-            }
+                status = blendNode->SetInput(RPR_MATERIAL_INPUT_COLOR0, m_toonClosureNode.get());
+                if (status != RPR_SUCCESS) {
+                    throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to set color1 input of blend node", m_rprContext));
+                }
 
-            status = m_blendNode->SetInput(RPR_MATERIAL_INPUT_WEIGHT, 0.5f);
-            if (status != RPR_SUCCESS) {
-                throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to set weight input of blend node", m_rprContext));
+                status = blendNode->SetInput(RPR_MATERIAL_INPUT_COLOR1, transparentNode.get());
+                if (status != RPR_SUCCESS) {
+                    throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to set color0 input of blend node", m_rprContext));
+                }
+
+                status = blendNode->SetInput(RPR_MATERIAL_INPUT_WEIGHT, transparency, transparency, transparency, transparency);
+                if (status != RPR_SUCCESS) {
+                    throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to set weight input of blend node", m_rprContext));
+                }
+
+                m_blendNode = std::move(blendNode);
+                m_transparentNode = std::move(transparentNode);
+            } else {
+                status = m_blendNode->SetInput(RPR_MATERIAL_INPUT_WEIGHT, transparency, transparency, transparency, transparency);
+                if (status != RPR_SUCCESS) {
+                    throw RprUsd_NodeError(RPR_GET_ERROR_MESSAGE(status, "Failed to set weight input of blend node", m_rprContext));
+                }
             }
         } else {
             m_blendNode.reset();
             m_transparentNode.reset();
         }
-
-        m_TransparencyEnabled = value;
     }
 };
 

--- a/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
@@ -176,13 +176,35 @@ public:
         return false;
     }
 
-    static RprUsd_RprNodeInfo* GetInfo() {
-        static RprUsd_RprNodeInfo* ret = nullptr;
+    struct RprUsd_ToonNodeInfo : public RprUsd_RprNodeInfo {
+        bool HasDynamicVisibility() const override { return true; }
+        VisibilityUpdate GetVisibilityUpdate(const char* changedParam, RprUsdMaterialNodeStateProvider* stateProvider) const override {
+            VisibilityUpdate visibilityUpdate;
+
+            if (_tokens->transparencyMode == changedParam) {
+                bool isTransparencyEnabled = stateProvider->GetValue(changedParam).GetWithDefault(0) != 0;
+                visibilityUpdate.Add(isTransparencyEnabled, _tokens->transparency.GetText());
+            } else if (_tokens->colorsMode == changedParam) {
+                bool isFiveColorMode = stateProvider->GetValue(changedParam).GetWithDefault(0) != 0;
+                visibilityUpdate.Add(isFiveColorMode, _tokens->shadowTint2.GetText());
+                visibilityUpdate.Add(isFiveColorMode, _tokens->highlightTint2.GetText());
+                visibilityUpdate.Add(isFiveColorMode, _tokens->shadowLevel.GetText());
+                visibilityUpdate.Add(isFiveColorMode, _tokens->shadowLevelMix.GetText());
+                visibilityUpdate.Add(isFiveColorMode, _tokens->highlightLevel2.GetText());
+                visibilityUpdate.Add(isFiveColorMode, _tokens->highlightLevelMix2.GetText());
+            }
+
+            return visibilityUpdate;
+        };
+    };
+
+    static RprUsd_ToonNodeInfo* GetInfo() {
+        static RprUsd_ToonNodeInfo* ret = nullptr;
         if (ret) {
             return ret;
         }
 
-        ret = new RprUsd_RprNodeInfo;
+        ret = new RprUsd_ToonNodeInfo;
         auto& nodeInfo = *ret;
 
         nodeInfo.name = "rpr_toon";

--- a/pxr/imaging/rprUsd/materialRegistry.h
+++ b/pxr/imaging/rprUsd/materialRegistry.h
@@ -152,6 +152,10 @@ private:
 class RprUsdMaterialNodeInput;
 class RprUsdMaterialNodeElement;
 
+struct RprUsdMaterialNodeStateProvider {
+    virtual VtValue GetValue(const char* name) = 0;
+};
+
 /// \class RprUsdMaterialNodeInfo
 ///
 /// Describes resolved node, its name, inputs, outputs, etc
@@ -170,6 +174,20 @@ public:
 
     virtual const char* GetUIName() const = 0;
     virtual const char* GetUIFolder() const { return nullptr; };
+
+    virtual bool HasDynamicVisibility() const { return false; }
+    struct VisibilityUpdate {
+        struct Visibility {
+            const char* name;
+            bool isVisible;
+        };
+        std::vector<Visibility> parmsVisibility;
+
+        void Add(bool isVisible, const char* name) {
+            parmsVisibility.push_back({ name, isVisible });
+        }
+    };
+    virtual VisibilityUpdate GetVisibilityUpdate(const char* changedParam, RprUsdMaterialNodeStateProvider*) const { return {}; };
 };
 
 class RprUsdMaterialNodeElement {


### PR DESCRIPTION
### PURPOSE
To improve UX when using RPR Toon node.

### EFFECT OF CHANGE
RPR Toon node dynamically hides/shows its parameters.
