### PR TITLE
Update texture loading

### DIFF
--- a/pxr/imaging/rprUsd/materialNodes/materialNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/materialNode.h
@@ -39,8 +39,6 @@ struct RprUsd_MaterialBuilderContext {
     VtValue displacementScale;
 
     RPRMtlxLoader* mtlxLoader;
-
-    std::vector<RprUsdMaterialRegistry::TextureCommit> textureCommits;
 };
 
 class RprUsd_MaterialNode {

--- a/pxr/imaging/rprUsd/materialNodes/usdNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/usdNode.h
@@ -96,6 +96,8 @@ private:
     std::shared_ptr<RprUsd_RprArithmeticNode> m_scaleNode;
     std::shared_ptr<RprUsd_RprArithmeticNode> m_biasNode;
 
+    std::shared_ptr<RprUsdMaterialRegistry::TextureLoadRequest> m_textureLoadRequest;
+
     std::map<TfToken, VtValue> m_outputs;
 };
 

--- a/pxr/imaging/rprUsd/materialRegistry.h
+++ b/pxr/imaging/rprUsd/materialRegistry.h
@@ -114,14 +114,17 @@ public:
         RprUsdMaterialNodeFactoryFnc factory,
         RprUsdMaterialNodeInfo const* info = nullptr);
 
-    struct TextureCommit {
+    struct TextureLoadRequest {
         std::string filepath;
         std::string colorspace;
         rpr::ImageWrapType wrapType;
         uint32_t numComponentsRequired = 0;
 
-        std::function<void(std::shared_ptr<RprUsdCoreImage> const&)> setTextureCallback;
+        std::function<void(std::shared_ptr<RprUsdCoreImage> const&)> onDidLoadTexture;
     };
+
+    RPRUSD_API
+    void EnqueueTextureLoadRequest(std::weak_ptr<TextureLoadRequest> textureLoadRequest);
 
     RPRUSD_API
     void CommitResources(RprUsdImageCache* imageCache);
@@ -146,7 +149,7 @@ private:
     std::vector<RprUsdMaterialNodeDesc> m_registeredNodes;
     std::map<TfToken, size_t> m_registeredNodesLookup;
 
-    std::vector<TextureCommit> m_textureCommits;
+    std::vector<std::weak_ptr<TextureLoadRequest>> m_textureLoadRequests;
 };
 
 class RprUsdMaterialNodeInput;


### PR DESCRIPTION
### PURPOSE
When continuous parameter change triggers full material rebuild, render might be aborted before resources are committed, thus texture load result is discarded. With these changes, we avoid loading texture if it's not needed anymore and avoid potential crashes when calling texture callback for the already released material node.

### EFFECT OF CHANGE
Fix random crashes on continuous scene changes (e.g. dragging transform or material parameters).

### TECHNICAL STEPS
Instead of storing texture load data as is, store a weak reference to it. Material that enqueues texture load stores strong reference. Thus if the material is released before a texture load request has been processed, it will be invalidated.

