### PR TITLE
Do not show prototype if instancer has no instances

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -645,11 +645,6 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                         }
                     }
                     m_rprMeshInstances.clear();
-
-                    auto visibilityMask = GetVisibilityMask();
-                    for (int i = 0; i < m_rprMeshes.size(); ++i) {
-                        rprApi->SetMeshVisibility(m_rprMeshes[i], visibilityMask);
-                    }
                 } else {
                     updateTransform = false;
 

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -625,17 +625,19 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         }
 
         if (newMesh || (*dirtyBits & HdChangeTracker::DirtyInstancer)) {
+            forceVisibilityUpdate = true;
+
 #ifdef USE_DECOUPLED_INSTANCER
             _UpdateInstancer(sceneDelegate, dirtyBits);
             HdInstancer::_SyncInstancerAndParents(sceneDelegate->GetRenderIndex(), GetInstancerId());
 #endif
+
             m_instancer = static_cast<HdRprInstancer*>(sceneDelegate->GetRenderIndex().GetInstancer(GetInstancerId()));
             if (m_instancer) {
                 auto instanceTransforms = m_instancer->SampleInstanceTransforms(id);
                 auto newNumInstances = (instanceTransforms.count > 0) ? instanceTransforms.values[0].size() : 0;
                 if (newNumInstances == 0) {
                     ReleaseInstances(rprApi);
-                    forceVisibilityUpdate = true;
                 } else {
                     updateTransform = false;
 
@@ -688,12 +690,9 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                             rprApi->SetTransform(meshInstances[j], instanceTransforms.count, instanceTransforms.times.data(), combinedTransforms[j].data());
                         }
                     }
-
-                    forceVisibilityUpdate = true;
                 }
             } else {
                 ReleaseInstances(rprApi);
-                forceVisibilityUpdate = true;
             }
         }
 

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -27,6 +27,7 @@ namespace rpr { class Shape; }
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdRprApi;
+class HdRprInstancer;
 class RprUsdMaterial;
 
 class HdRprMesh final : public HdRprBaseRprim<HdMesh> {
@@ -56,6 +57,8 @@ private:
         HdRprApi* rprApi,
         HdDirtyBits dirtyBits,
         std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation);
+
+    void ReleaseInstances(HdRprApi* rprApi);
 
 private:
     std::vector<rpr::Shape*> m_rprMeshes;
@@ -91,6 +94,8 @@ private:
     bool m_ignoreContour;
     std::string m_cryptomatteName;
     size_t m_numGeometrySamples = 1;
+
+    HdRprInstancer* m_instancer = nullptr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### PURPOSE
Do not show prototype if an instancer has no instances

### EFFECT OF CHANGE
Prototype mesh is no more shown when an instancer has no instances.

