### PR TITLE
Add camera mode render setting

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -58,6 +58,7 @@ def houdini_parm_name(name):
 
 HYBRID_IS_AVAILABLE_PY_CONDITION = lambda: 'platform.system() != "Darwin"'
 NORTHSTAR_ENABLED_PY_CONDITION = lambda: 'hou.pwd().parm("{}").evalAsString() == "Northstar"'.format(houdini_parm_name('core:renderQuality'))
+NOT_NORTHSTAR_ENABLED_PY_CONDITION = lambda: 'hou.pwd().parm("{}").evalAsString() != "Northstar"'.format(houdini_parm_name('core:renderQuality'))
 
 render_setting_categories = [
     {
@@ -631,8 +632,8 @@ render_setting_categories = [
                     SettingValue('Default'),
                     SettingValue('Latitude Longitude 360'),
                     SettingValue('Latitude Longitude Stereo'),
-                    SettingValue('Cubemap'),
-                    SettingValue('Cubemap Stereo'),
+                    SettingValue('Cubemap', enable_py_condition=NOT_NORTHSTAR_ENABLED_PY_CONDITION),
+                    SettingValue('Cubemap Stereo', enable_py_condition=NOT_NORTHSTAR_ENABLED_PY_CONDITION),
                     SettingValue('Fisheye'),
                 ]
             }

--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -621,6 +621,24 @@ render_setting_categories = [
         }
     },
     {
+        'name': 'Camera',
+        'settings': [
+            {
+                'name': 'core:cameraMode',
+                'ui_name': 'Camera Mode',
+                'defaultValue': 'Default',
+                'values': [
+                    SettingValue('Default'),
+                    SettingValue('Latitude Longitude 360'),
+                    SettingValue('Latitude Longitude Stereo'),
+                    SettingValue('Cubemap'),
+                    SettingValue('Cubemap Stereo'),
+                    SettingValue('Fisheye'),
+                ]
+            }
+        ]
+    },
+    {
         'name': 'UsdNativeCamera',
         'settings': [
             {

--- a/pxr/imaging/rprUsd/schema.usda
+++ b/pxr/imaging/rprUsd/schema.usda
@@ -149,6 +149,12 @@ class "RprRendererSettingsAPI" (
               """
     )
 
+    uniform token rpr:core:cameraMode = "Default" (
+        allowedTokens = ["Default", "Latitude Longitude 360", "Latitude Longitude Stereo", "Cubemap", "Cubemap Stereo", "Fisheye"]
+        displayName = "Camera Mode"
+        displayGroup = "General"
+    )
+
     uniform bool rpr:alpha:enable = false (
         displayName = "Enable Color Alpha"
         displayGroup = "General"


### PR DESCRIPTION
### PURPOSE
Add camera render mode render setting

### EFFECT OF CHANGE
A new render setting is added - "Camera Mode". More info about the modes [here](https://radeon-pro.github.io/RadeonProRenderDocs/en/sdk/info_setting_types/rpr_camera_mode.html?highlight=camera%20mode). The "perspective" and "orthographic" mode is controlled by USD's camera. Other modes are exposed as overrides. Cubemap camera modes are not available in the Full quality (not supported yet).

