### PR TITLE
Fix light visibility flags

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateLightSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateLightSettingFiles.py
@@ -11,20 +11,74 @@
 # 
 import argparse
 
-from commonSettings import visibility_flag_settings
 from houdiniDsGenerator import generate_houdini_ds
-
-light_visibility_flag_settings = visibility_flag_settings
-for setting in light_visibility_flag_settings:
-    if setting['name'] == 'primvars:rpr:visibilityPrimary' or \
-       setting['name'] == 'primvars:rpr:visibilityShadow' or \
-       setting['name'] == 'primvars:rpr:visibilityLight':
-        setting['defaultValue'] = False
 
 light_settings = [
     {
         'name': 'Light',
-        'settings': light_visibility_flag_settings
+        'settings': [
+            {
+            'name': 'rpr:object:visibility:camera',
+                'ui_name': 'Camera Visibility',
+                'defaultValue': False,
+                'help': 'Used to show or hide an object from the camera.\\n' \
+                        'Disabling camera visibility is the most optimized way to hide ' \
+                        'an object from the camera but still have it cast shadows, ' \
+                        'be visible in reflections, etc.'
+            },
+            {
+                'name': 'rpr:object:visibility:shadow',
+                'ui_name': 'Shadow Visibility',
+                'defaultValue': False,
+                'help': 'Shadow visibility controls whether to show or to hide shadows cast by ' \
+                        'the object onto other surfaces (including reflected shadows and shadows ' \
+                        'seen through transparent objects). You might need this option to hide shadows ' \
+                        'that darken other objects in the scene or create unwanted effects.'
+            },
+            {
+                'name': 'rpr:object:visibility:reflection',
+                'ui_name': 'Reflection Visibility',
+                'defaultValue': True,
+                'help': 'Reflection visibility makes an object visible or invisible in reflections on ' \
+                        'specular surfaces. Note that hiding an object from specular reflections keeps ' \
+                        'its shadows (including reflected shadows) visible.'
+            },
+            {
+                'name': 'rpr:object:visibility:glossyReflection',
+                'ui_name': 'Glossy Reflection Visibility',
+                'defaultValue': True
+            },
+            {
+                'name': 'rpr:object:visibility:refraction',
+                'ui_name': 'Refraction Visibility',
+                'defaultValue': True,
+                'help': 'Refraction visibility makes an object visible or invisible when seen through ' \
+                        'transparent objects. Note that hiding an object from refractive rays keeps its ' \
+                        'shadows (including refracted shadows) visible.'
+            },
+            {
+                'name': 'rpr:object:visibility:glossyRefraction',
+                'ui_name': 'Glossy Refraction Visibility',
+                'defaultValue': True
+            },
+            {
+                'name': 'rpr:object:visibility:diffuse',
+                'ui_name': 'Diffuse Visibility',
+                'defaultValue': True,
+                'help': 'Diffuse visibility affects indirect diffuse rays and makes an object visible ' \
+                        'or invisible in reflections on diffuse surfaces.'
+            },
+            {
+                'name': 'rpr:object:visibility:transparent',
+                'ui_name': 'Transparent Visibility',
+                'defaultValue': True
+            },
+            {
+                'name': 'rpr:object:visibility:light',
+                'ui_name': 'Light Visibility',
+                'defaultValue': True
+            }
+        ]
     }
 ]
 

--- a/pxr/imaging/rprUsd/schema.usda
+++ b/pxr/imaging/rprUsd/schema.usda
@@ -684,6 +684,90 @@ class "RprMaterialSettingsAPI" (
     )
 }
 
+class "RprLightSettingsAPI" (
+    customData= {
+        string className = "LightSettingsAPI"
+        token apiSchemaType = "singleApply"
+        token[] apiSchemaAutoApplyTo = ["SphereLight", "DiskLight", "RectLight", "CylinderLight"]
+    }
+    inherits = </APISchemaBase>
+)
+{
+    uniform bool rpr:object:visibility:camera = false (
+        customData = {
+            string apiName = "objectVisibilityCamera"
+        }
+        displayGroup = "Visibility"
+        displayName = "Visibility Camera"
+        doc = """ Used to show or hide an object from the camera.
+                  Disabling camera visibility is the most optimized way to hide an object from the camera but still have it cast shadows, be visible in reflections, etc.
+              """
+    )
+
+    uniform bool rpr:object:visibility:diffuse = true (
+        customData = {
+            string apiName = "objectVisibilityDiffuse"
+        }
+        displayGroup = "Visibility"
+        displayName = "Visibility Diffuse"
+        doc = "Diffuse visibility affects indirect diffuse rays and makes an object visible or invisible in reflections on diffuse surfaces."
+    )
+
+    uniform bool rpr:object:visibility:shadow = false (
+        customData = {
+            string apiName = "objectVisibilityShadow"
+        }
+        displayGroup = "Visibility"
+        displayName = "Visibility Shadow"
+        doc = "Shadow visibility controls whether to show or to hide shadows cast by the object onto other surfaces (including reflected shadows and shadows seen through transparent objects). You might need this option to hide shadows that darken other objects in the scene or create unwanted effects."
+    )
+
+    uniform bool rpr:object:visibility:reflection = true (
+        customData = {
+            string apiName = "objectVisibilityReflection"
+        }
+        displayGroup = "Visibility"
+        displayName = "Visibility Reflection"
+        doc = "Reflection visibility makes an object visible or invisible in reflections on specular surfaces. Note that hiding an object from specular reflections keeps its shadows (including reflected shadows) visible."
+    )
+
+    uniform bool rpr:object:visibility:glossyReflection = true (
+        customData = {
+            string apiName = "objectVisibilityGlossyReflection"
+        }
+        displayGroup = "Visibility"
+        displayName = "Visibility Glossy Reflection"
+        doc = ""
+    )
+
+    uniform bool rpr:object:visibility:refraction = true (
+        customData = {
+            string apiName = "objectVisibilityRefraction"
+        }
+        displayGroup = "Visibility"
+        displayName = "Visibility Refraction"
+        doc = "Refraction visibility makes an object visible or invisible when seen through transparent objects. Note that hiding an object from refractive rays keeps its shadows (including refracted shadows) visible."
+    )
+
+    uniform bool rpr:object:visibility:glossyRefraction = true (
+        customData = {
+            string apiName = "objectVisibilityGlossyRefraction"
+        }
+        displayGroup = "Visibility"
+        displayName = "Visibility Glossy Refraction"
+        doc = ""
+    )
+
+    uniform bool rpr:object:visibility:transparent = true (
+        customData = {
+            string apiName = "objectVisibilityTransparent"
+        }
+        displayGroup = "Visibility"
+        displayName = "Visibility Transparent"
+        doc = ""
+    )
+}
+
 class "RprDomeLightSettingsAPI" (
     customData = {
         string className = "DomeLightSettingsAPI"


### PR DESCRIPTION
### PURPOSE
Fix light visibility flags

### EFFECT OF CHANGE
Fixed light visibility flags in the latest Houdini.

### TECHNICAL STEPS
Added light visibility flags to the schema. Updated the way visibility flags are queried in HdRprLight::Sync.

### NOTES FOR REVIEWERS
A Houdini project showcasing the fix can be downloaded [here ](https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/files/8550426/lightVisibilityTest.zip)

Make sure to read this:
![image](https://user-images.githubusercontent.com/22181845/164994472-aa9c9f73-52bd-45ae-92b0-1e70e100bb12.png)

Expected render:
![image](https://user-images.githubusercontent.com/22181845/164994488-b5e2420c-5f7b-4623-bc70-111570f7e119.png)

