### PR TITLE
Fix processing relative path to the textures

### DIFF
--- a/pxr/imaging/rprUsd/hdMtlxFixed.cpp
+++ b/pxr/imaging/rprUsd/hdMtlxFixed.cpp
@@ -165,7 +165,7 @@ HdMtlxConvertToString(VtValue const& hdParameterValue)
         return valStream.str();
     }
     else if (hdParameterValue.IsHolding<SdfAssetPath>()) {
-        return hdParameterValue.UncheckedGet<SdfAssetPath>().GetAssetPath();
+        return hdParameterValue.UncheckedGet<SdfAssetPath>().GetResolvedPath();
     }
     else if (hdParameterValue.IsHolding<std::string>()) {
         return hdParameterValue.UncheckedGet<std::string>();


### PR DESCRIPTION
### PURPOSE
Currently files that have relative paths to textures are not processed correctly: RadeonProRenderUSD can not find these textures.

### EFFECT OF CHANGE
Files that have relative paths to textures are now processed correctly.

### TECHNICAL STEPS
SdfAssetPath::GetReslvedPath() returns absolute path to the texture file, thus materialX file with absolute paths is constructed.

