### PR TITLE
autotests fix

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -593,7 +593,11 @@ public:
         }
 
         if (dirty) {
-            if (RPR_ERROR_CHECK(mesh->SetSubdivisionFactor(level), "Failed to set mesh subdividion level")) return;
+            uint64_t normalCount;
+            if (RPR_ERROR_CHECK(rprMeshGetInfo(GetRprObject(mesh), RPR_MESH_NORMAL_COUNT, sizeof(normalCount), &normalCount, nullptr), "Failed to get normal count")) return;
+            if (normalCount != 0) {
+                if (RPR_ERROR_CHECK(mesh->SetSubdivisionFactor(level), "Failed to set mesh subdividion level")) return;
+            }
             m_dirtyFlags |= ChangeTracker::DirtyScene;
         }
     }

--- a/pxr/imaging/rprUsd/material.cpp
+++ b/pxr/imaging/rprUsd/material.cpp
@@ -34,8 +34,13 @@ bool RprUsdMaterial::AttachTo(rpr::Shape* mesh, bool displacementEnabled) const 
 
         if (subdFactor == 0) {
             TF_WARN("Displacement material requires subdivision to be enabled. The subdivision will be enabled with refine level of 1");
-            if (!RPR_ERROR_CHECK(mesh->SetSubdivisionFactor(1), "Failed to set mesh subdividion")) {
-                subdFactor = 1;
+            uint64_t normalCount;
+            if (!RPR_ERROR_CHECK(rprMeshGetInfo(GetRprObject(mesh), RPR_MESH_NORMAL_COUNT, sizeof(normalCount), &normalCount, nullptr), "Failed to get normal count")) {
+                if (normalCount != 0) {
+                    if (!RPR_ERROR_CHECK(mesh->SetSubdivisionFactor(1), "Failed to set mesh subdividion")) {
+                        subdFactor = 1;
+                    }
+                }
             }
         }
         if (subdFactor > 0) {


### PR DESCRIPTION
### PURPOSE
Fix for https://amdrender.atlassian.net/browse/RPRUS-107

### TECHNICAL STEPS
Test crashes when rprShapeSetSubdivisionFactor is used on mesh without normals.
The solution is simply avoid rprShapeSetSubdivisionFactor call when mash has no normals
