### PR TITLE
Scene units token rename

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -378,9 +378,10 @@ public:
             m_state = kStateInvalid;
         }
 
-		// Try to get scene unit size from delegate. Default value is 1 meter per unit
-		double unitSize = m_delegate->GetRenderSetting<double>(UsdGeomTokens->metersPerUnit, 1.0);
-		m_unitSizeTransform[0][0] = m_unitSizeTransform[1][1] = m_unitSizeTransform[2][2] = unitSize;
+        // Try to get scene unit size from delegate. Default value is 1 meter per unit
+        static const TfToken metersPerUnitToken("stageMetersPerUnit", TfToken::Immortal);
+        double unitSize = m_delegate->GetRenderSetting<double>(metersPerUnitToken, 1.0);
+        m_unitSizeTransform[0][0] = m_unitSizeTransform[1][1] = m_unitSizeTransform[2][2] = unitSize;
     }
 
     rpr::Shape* CreateMesh(VtVec3fArray const& points, VtIntArray const& pointIndices,

--- a/pxr/imaging/rprUsd/schema.usda
+++ b/pxr/imaging/rprUsd/schema.usda
@@ -164,6 +164,7 @@ class "RprRendererSettingsAPI" (
     uniform double stageMetersPerUnit = 1.0 (
         displayName = "Meters Per Unit"
         displayGroup = "General"
+	doc = "Scene unit size in meters"
     )
 
     # Northstar only

--- a/pxr/imaging/rprUsd/schema.usda
+++ b/pxr/imaging/rprUsd/schema.usda
@@ -160,6 +160,11 @@ class "RprRendererSettingsAPI" (
         displayGroup = "General"
         doc = ""
     )
+	
+	uniform double stageMetersPerUnit = 1.0 (
+	    displayName = "Meters Per Unit"
+		displayGroup = "General"
+	)
 
     # Northstar only
     uniform bool rpr:beautyMotionBlur:enable = true (

--- a/pxr/imaging/rprUsd/schema.usda
+++ b/pxr/imaging/rprUsd/schema.usda
@@ -163,7 +163,7 @@ class "RprRendererSettingsAPI" (
 	
 	uniform double stageMetersPerUnit = 1.0 (
 	    displayName = "Meters Per Unit"
-		displayGroup = "General"
+	    displayGroup = "General"
 	)
 
     # Northstar only

--- a/pxr/imaging/rprUsd/schema.usda
+++ b/pxr/imaging/rprUsd/schema.usda
@@ -161,10 +161,10 @@ class "RprRendererSettingsAPI" (
         doc = ""
     )
 	
-	uniform double stageMetersPerUnit = 1.0 (
-	    displayName = "Meters Per Unit"
-	    displayGroup = "General"
-	)
+    uniform double stageMetersPerUnit = 1.0 (
+        displayName = "Meters Per Unit"
+        displayGroup = "General"
+    )
 
     # Northstar only
     uniform bool rpr:beautyMotionBlur:enable = true (


### PR DESCRIPTION
### PURPOSE
Houdini USD use "stageMetersPerUnit" token name to provide unit size data. We need to use token with same name. https://www.sidefx.com/docs/hdk/_h_d_k__u_s_d_hydra.html#HDK_USDHydraCustomSettings

### EFFECT OF CHANGE
Now scene unit token is renamed to be same with Houdini. Also, token added to hdRPR parameters schema.

