### PR TITLE
Color primvars

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -84,13 +84,19 @@ RprUsdMaterial const* HdRprMesh::GetFallbackMaterial(
     }
 
     if (!m_fallbackMaterial) {
-        // XXX: Currently, displayColor is used as one color for whole mesh,
-        // but it should be used as attribute per vertex/face.
-        // RPR does not have such functionality, yet
+
+        // Means that vertex color primvar correctly set on mesh. Only Northstar supports this feature
+        if (m_colorsSet)
+        {
+            m_fallbackMaterial = rprApi->CreatePrimvarColorLookupMaterial();
+            rprApi->SetName(m_fallbackMaterial, GetId().GetText());
+            return m_fallbackMaterial;
+        }
 
         GfVec3f color(0.18f);
 
         if (HdRprIsPrimvarExists(HdTokens->displayColor, primvarDescsPerInterpolation)) {
+
             VtValue val = sceneDelegate->Get(GetId(), HdTokens->displayColor);
             if (val.IsHolding<VtVec3fArray>()) {
                 auto colors = val.UncheckedGet<VtVec3fArray>();
@@ -345,6 +351,9 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         if (!m_authoredColors) {
             m_colorSamples.clear();
         }
+
+        newMesh = true;
+        m_colorsSet = false;
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
@@ -444,7 +453,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
         if (m_geomSubsets.empty()) {
             if (auto rprMesh = rprApi->CreateMesh(m_pointSamples, m_faceVertexIndices, m_normalSamples, m_normalIndices, m_uvSamples, m_uvIndices, m_faceVertexCounts, m_topology.GetOrientation())) {
-                rprApi->SetMeshVertexColor(rprMesh, m_colorSamples, m_colorInterpolation);
+                m_colorsSet = rprApi->SetMeshVertexColor(rprMesh, m_colorSamples, m_colorInterpolation);
                 m_rprMeshes.push_back(rprMesh);
             }
         } else {
@@ -567,7 +576,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                 }
 
                 if (auto rprMesh = rprApi->CreateMesh(subsetPointSamples, subsetIndexes, subsetNormalSamples, subsetNormalIndices, subsetUvSamples, subsetUvIndices, subsetVertexPerFace, m_topology.GetOrientation())) {
-                    rprApi->SetMeshVertexColor(rprMesh, subsetColorSamples, m_colorInterpolation);
+                    m_colorsSet = rprApi->SetMeshVertexColor(rprMesh, subsetColorSamples, m_colorInterpolation);
                     m_rprMeshes.push_back(rprMesh);
                     ++it;
                 } else {

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -87,6 +87,7 @@ private:
     VtArray<VtVec3fArray> m_colorSamples;
     HdInterpolation m_colorInterpolation;
     bool m_authoredColors = false;
+    bool m_colorsSet = false;
 
     VtArray<VtVec2fArray> m_uvSamples;
     VtIntArray m_uvIndices;

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -84,6 +84,10 @@ private:
     bool m_authoredNormals = false;
     bool m_smoothNormals = false;
 
+    VtArray<VtVec3fArray> m_colorSamples;
+    HdInterpolation m_colorInterpolation;
+    bool m_authoredColors = false;
+
     VtArray<VtVec2fArray> m_uvSamples;
     VtIntArray m_uvIndices;
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -788,6 +788,7 @@ public:
             m_dirtyFlags |= ChangeTracker::DirtyScene;
             return true;
         }
+        return false;
     }
 
     rpr::Curve* CreateCurve(VtVec3fArray const& points, VtIntArray const& indices, VtFloatArray const& radiuses, VtVec2fArray const& uvs, VtIntArray const& segmentPerCurve) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -743,13 +743,13 @@ public:
         }
     }
 
-    void SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation) {
+    bool SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation) {
 
         // We use zero primvar channel to store vertex colors
         const int colorPrimvarKey = 0;
 
         if (primvarSamples.empty()) {
-            return;
+            return false;
         }
         if (m_rprContextMetadata.pluginType == kPluginNorthstar) {
             LockGuard rprLock(m_rprContext->GetMutex());
@@ -768,19 +768,25 @@ public:
                 rprInterpolation = RPR_PRIMVAR_INTERPOLATION_VERTEX;
                 break;
             case HdInterpolationVarying:
-                rprInterpolation = RPR_PRIMVAR_INTERPOLATION_FACEVARYING_UV;
+                rprInterpolation = RPR_PRIMVAR_INTERPOLATION_FACEVARYING_NORMAL;
                 break;
             case HdInterpolationFaceVarying:
-                rprInterpolation = RPR_PRIMVAR_INTERPOLATION_FACEVARYING_NORMAL;
+                rprInterpolation = RPR_PRIMVAR_INTERPOLATION_FACEVARYING_UV;
                 break;
             default:
                 // Rpr does not support HdInterpolationInstance
-                return;
+                return false;
+            }
+            try {
+                RPR_ERROR_CHECK_THROW(mesh->SetPrimvar(colorPrimvarKey, (rpr_float const*)primvarSamples[0].cdata(), primvarSamples[0].size() * 3, 3, rprInterpolation), "Failed to set color primvars");
+            }
+            catch (RprUsdError& e) {
+                TF_RUNTIME_ERROR("Failed to set vertex color: %s", e.what());
+                return false;
             }
 
-            mesh->SetPrimvar(colorPrimvarKey, (rpr_float const*)primvarSamples[0].cdata(), primvarSamples.size() * 3, 3, rprInterpolation);
-
             m_dirtyFlags |= ChangeTracker::DirtyScene;
+            return true;
         }
     }
 
@@ -1284,6 +1290,54 @@ public:
         try {
             return new HdRprApiPointsMaterial(colors, m_rprContext.get());
         } catch (RprUsdError& e) {
+            TF_RUNTIME_ERROR("Failed to create points material: %s", e.what());
+            return nullptr;
+        }
+    }
+
+    RprUsdMaterial* CreatePrimvarColorLookupMaterial() {
+        if (!m_rprContext) {
+            return nullptr;
+        }
+
+        LockGuard rprLock(m_rprContext->GetMutex());
+
+        class HdRprApiPrimvarColorLookupMaterial : public RprUsdMaterial {
+        public:
+            HdRprApiPrimvarColorLookupMaterial(rpr::Context* context) {
+                rpr::Status status;
+
+                m_primvarLookupNode.reset(context->CreateMaterialNode(RPR_MATERIAL_NODE_PRIMVAR_LOOKUP, &status));
+                if (!m_primvarLookupNode) {
+                    RPR_ERROR_CHECK_THROW(status, "Failed to create primvar lookup node");
+                }
+
+                // we use zero primvar channel to store vertex color values
+                status = m_primvarLookupNode->SetInput(RPR_MATERIAL_INPUT_VALUE, (rpr_uint) 0);
+                if (status != RPR_SUCCESS) {
+                    RPR_ERROR_CHECK_THROW(status, "Failed to set lookup node input value");
+                }
+
+                m_uberNode.reset(context->CreateMaterialNode(RPR_MATERIAL_NODE_UBERV2, &status));
+                if (!m_uberNode) {
+                    RPR_ERROR_CHECK_THROW(status, "Failed to create uber node");
+                }
+                RPR_ERROR_CHECK_THROW(m_uberNode->SetInput(RPR_MATERIAL_INPUT_UBER_DIFFUSE_COLOR, m_primvarLookupNode.get()), "Failed to set root material diffuse color");
+
+                m_surfaceNode = m_uberNode.get();
+            };
+
+            ~HdRprApiPrimvarColorLookupMaterial() final = default;
+
+        private:
+            std::unique_ptr<rpr::MaterialNode> m_primvarLookupNode;
+            std::unique_ptr<rpr::MaterialNode> m_uberNode;
+        };
+
+        try {
+            return new HdRprApiPrimvarColorLookupMaterial(m_rprContext.get());
+        }
+        catch (RprUsdError& e) {
             TF_RUNTIME_ERROR("Failed to create points material: %s", e.what());
             return nullptr;
         }
@@ -4383,6 +4437,11 @@ RprUsdMaterial* HdRprApi::CreateDiffuseMaterial(GfVec3f const& color) {
     });
 }
 
+RprUsdMaterial* HdRprApi::CreatePrimvarColorLookupMaterial(){
+    m_impl->InitIfNeeded();
+    return m_impl->CreatePrimvarColorLookupMaterial();
+}
+
 void HdRprApi::SetMeshRefineLevel(rpr::Shape* mesh, int level) {
     m_impl->SetMeshRefineLevel(mesh, level);
 }
@@ -4407,8 +4466,8 @@ void HdRprApi::SetMeshIgnoreContour(rpr::Shape* mesh, bool ignoreContour) {
     m_impl->SetMeshIgnoreContour(mesh, ignoreContour);
 }
 
-void HdRprApi::SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation) {
-    m_impl->SetMeshVertexColor(mesh, primvarSamples, interpolation);
+bool HdRprApi::SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation) {
+    return m_impl->SetMeshVertexColor(mesh, primvarSamples, interpolation);
 }
 
 void HdRprApi::SetCurveMaterial(rpr::Curve* curve, RprUsdMaterial const* material) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -123,6 +123,7 @@ public:
     void SetMeshVisibility(rpr::Shape* mesh, uint32_t visibilityMask);
     void SetMeshId(rpr::Shape* mesh, uint32_t id);
     void SetMeshIgnoreContour(rpr::Shape* mesh, bool ignoreContour);
+    void SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation);
     void Release(rpr::Shape* shape);
 
     rpr::Curve* CreateCurve(VtVec3fArray const& points, VtIntArray const& indices, VtFloatArray const& radiuses, VtVec2fArray const& uvs, VtIntArray const& segmentPerCurve);

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -112,6 +112,7 @@ public:
     RprUsdMaterial* CreateMaterial(SdfPath const& materialId, HdSceneDelegate* sceneDelegate, HdMaterialNetworkMap const& materialNetwork);
     RprUsdMaterial* CreatePointsMaterial(VtVec3fArray const& colors);
     RprUsdMaterial* CreateDiffuseMaterial(GfVec3f const& color);
+    RprUsdMaterial* CreatePrimvarColorLookupMaterial();
     void Release(RprUsdMaterial* material);
 
     rpr::Shape* CreateMesh(VtVec3fArray const& points, VtIntArray const& pointIndexes, VtVec3fArray const& normals, VtIntArray const& normalIndexes, VtVec2fArray const& uvs, VtIntArray const& uvIndexes, VtIntArray const& vpf, TfToken const& polygonWinding);
@@ -123,7 +124,7 @@ public:
     void SetMeshVisibility(rpr::Shape* mesh, uint32_t visibilityMask);
     void SetMeshId(rpr::Shape* mesh, uint32_t id);
     void SetMeshIgnoreContour(rpr::Shape* mesh, bool ignoreContour);
-    void SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation);
+    bool SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation);
     void Release(rpr::Shape* shape);
 
     rpr::Curve* CreateCurve(VtVec3fArray const& points, VtIntArray const& indices, VtFloatArray const& radiuses, VtVec2fArray const& uvs, VtIntArray const& segmentPerCurve);


### PR DESCRIPTION
### PURPOSE
Vertex color primvars are not supported in HdRPR

### EFFECT OF CHANGE
Now HdRPR can support "displayColor" primvars.

### NOTES FOR REVIEWERS
1) This feature works only with Northstar renderer.
2) Instance interpolation is not supported by RPR. Now it's being ignored
