### PR TITLE
Depth AOV fix

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1509,6 +1509,9 @@ public:
             if (outRb.mappedData && (m_isFirstSample || outRb.isMultiSampled)) {
                 outRb.rprAov->GetData(outRb.mappedData, outRb.mappedDataSize);
             }
+            if (outRb.rprAov && outRb.rprAov->GetAovFb() && outRb.rprAov->GetAovFb()->GetRprObject()) {
+                outRb.rprAov->GetAovFb()->GetRprObject()->SaveToFile("C:\\Projects\\Aovs\\fileDump.jpg");
+            }
         }
 
         m_isFirstSample = false;

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1509,9 +1509,6 @@ public:
             if (outRb.mappedData && (m_isFirstSample || outRb.isMultiSampled)) {
                 outRb.rprAov->GetData(outRb.mappedData, outRb.mappedDataSize);
             }
-            if (outRb.rprAov && outRb.rprAov->GetAovFb() && outRb.rprAov->GetAovFb()->GetRprObject()) {
-                outRb.rprAov->GetAovFb()->GetRprObject()->SaveToFile("C:\\Projects\\Aovs\\fileDump.jpg");
-            }
         }
 
         m_isFirstSample = false;

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1400,7 +1400,7 @@ public:
     }
 
     GfMatrix4d GetCameraViewMatrix() const {
-        return m_hdCamera ? m_hdCamera->GetTransform().GetInverse() : GfMatrix4d(1.0);
+        return m_hdCamera ? (m_hdCamera->GetTransform() * m_unitSizeTransform).GetInverse() : GfMatrix4d(1.0);
     }
 
     const GfMatrix4d& GetCameraProjectionMatrix() const {


### PR DESCRIPTION
### PURPOSE
Delegate produces incorrect depth AOV if scene unit size is not equal 1

### EFFECT OF CHANGE
Now depth AOV is correct with all unit sizes

### TECHNICAL STEPS
Depth image is being calculated by RIF using world coordinates and camera view matrix. This PR applies scene unit size to view matrix.
