### PR TITLE
Allow materialX to read texture coordinates that are not named "st"

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -367,9 +367,18 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         auto rprMaterial = material->GetRprMaterialObject();
 
         auto uvPrimvarName = &rprMaterial->GetUvPrimvarName();
+        // This will currently be empty for MaterialX.
         if (uvPrimvarName->IsEmpty()) {
             static TfToken st("st", TfToken::Immortal);
             uvPrimvarName = &st;
+
+            // If "st" doesn't exist then search for any other primvar with "texcoord2?" role.
+            if (!HdRprIsPrimvarExists(st, primvarDescsPerInterpolation)) {
+                if (const auto texcoordPrimvar = HdRprFindFirstPrimvarRole(primvarDescsPerInterpolation, "textureCoordinate"))
+                {
+                    uvPrimvarName = &texcoordPrimvar->name;
+                }
+            }
         }
 
         if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, *uvPrimvarName)) {

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.cpp
@@ -104,6 +104,21 @@ void HdRprFillPrimvarDescsPerInterpolation(
     }
 }
 
+const HdPrimvarDescriptor* HdRprFindFirstPrimvarRole(
+    std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation,
+    const std::string& role)
+{
+    for (const auto& primvarDescs : primvarDescsPerInterpolation) {
+        for (const auto& primvar : primvarDescs.second) {
+            if (primvar.role == role) {
+                // Just take the first one.
+                return &primvar;
+            }
+        }
+    }
+    return nullptr;
+}
+
 bool HdRprIsPrimvarExists(
     TfToken const& primvarName,
     std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation,

--- a/pxr/imaging/plugin/hdRpr/primvarUtil.h
+++ b/pxr/imaging/plugin/hdRpr/primvarUtil.h
@@ -24,6 +24,10 @@ void HdRprFillPrimvarDescsPerInterpolation(
     HdSceneDelegate* sceneDelegate, SdfPath const& id,
     std::map<HdInterpolation, HdPrimvarDescriptorVector>* primvarDescsPerInterpolation);
 
+const HdPrimvarDescriptor* HdRprFindFirstPrimvarRole(
+    std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation,
+    const std::string& role);
+
 bool HdRprIsPrimvarExists(
     TfToken const& primvarName,
     std::map<HdInterpolation, HdPrimvarDescriptorVector> const& primvarDescsPerInterpolation,


### PR DESCRIPTION
### PURPOSE
See description.

### EFFECT OF CHANGE
If the mesh doesn't have a primvar named "st" then it will find the next primvar with the texture coordinate [roll](https://graphics.pixar.com/usd/dev/api/_usd__page__datatypes.html#Usd_Roles).

### TECHNICAL STEPS
See 'Effect of Change'

### NOTES FOR REVIEWERS
The primary downside to this approach is if the mesh has multiple texcoords it will pick just the first one, which may not be what the materialX needs.  But since hdRPR currently doesn't support multiple texcoords I think this is acceptable.
