### PR TITLE
MaterialX performance improvement

### DIFF
--- a/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.cpp
@@ -31,31 +31,11 @@ rpr::MaterialNode* RprUsd_CreateRprMtlxFromString(std::string const& mtlxString,
     }
 
     rpr_material_node matxNodeHandle = rpr::GetRprObject(matxNode.get());
-    // TODO: use rprMaterialXSetFileAsBuffer when supported
-    /*status = rprMaterialXSetFileAsBuffer(matxNodeHandle, mtlxString.c_str(), mtlxString.size());
+
+    status = rprMaterialXSetFileAsBuffer(matxNodeHandle, mtlxString.c_str(), mtlxString.size());
     if (status != RPR_SUCCESS) {
         RPR_ERROR_CHECK(status, "Failed to set matx node file from buffer");
         return nullptr;
-    }*/
-
-    // For now, as we have only rprMaterialXSetFile working, create a temporary file
-    {
-        std::string temporaryFilePath = ArchMakeTmpFileName("tmpMaterial", ".mtlx");
-
-        FILE* fout = fopen(temporaryFilePath.c_str(), "w");
-        if (!fout) {
-            return nullptr;
-        }
-
-        fwrite(mtlxString.c_str(), 1, mtlxString.size(), fout);
-        fclose(fout);
-
-        status = rprMaterialXSetFile(matxNodeHandle, temporaryFilePath.c_str());
-        if (status != RPR_SUCCESS) {
-            RPR_ERROR_CHECK(status, "Failed to set matx node file");
-            ArchUnlinkFile(temporaryFilePath.c_str());
-            return nullptr;
-        }
     }
 
     return matxNode.release();

--- a/pxr/imaging/rprUsd/materialRegistry.cpp
+++ b/pxr/imaging/rprUsd/materialRegistry.cpp
@@ -424,6 +424,7 @@ RprUsdMaterial* CreateMaterialXFromUsdShade(
         return nullptr;
     }
 
+    // TODO: move lib initialization to class constructor
     if (!stdLibraries) {
         std::string materialXStdlibPath;
 

--- a/pxr/imaging/rprUsd/materialRegistry.cpp
+++ b/pxr/imaging/rprUsd/materialRegistry.cpp
@@ -400,7 +400,7 @@ void DumpMaterialNetwork(HdMaterialNetworkMap const& networkMap) {
 RprUsdMaterial* CreateMaterialXFromUsdShade(
     SdfPath const& materialPath,
     RprUsd_MaterialBuilderContext const& context,
-    std::string* materialXStdlibPath) {
+    mx::DocumentPtr& stdLibraries) {
 
 #ifdef USE_USDSHADE_MTLX
     auto terminalIt = context.materialNetwork->terminals.find(UsdShadeTokens->surface);
@@ -424,23 +424,25 @@ RprUsdMaterial* CreateMaterialXFromUsdShade(
         return nullptr;
     }
 
-    if (materialXStdlibPath->empty()) {
+    if (!stdLibraries) {
+        std::string materialXStdlibPath;
+
         const TfType schemaBaseType = TfType::Find<UsdSchemaBase>();
         PlugPluginPtr usdPlugin = PlugRegistry::GetInstance().GetPluginForType(schemaBaseType);
         if (usdPlugin) {
             std::string usdLibPath = usdPlugin->GetPath();
             std::string usdDir = TfNormPath(TfGetPathName(usdLibPath) + "..");
-            *materialXStdlibPath = usdDir;
+            materialXStdlibPath = usdDir;
         }
-    }
-    
-    mx::DocumentPtr stdLibraries = mx::createDocument();
 
-    if (!materialXStdlibPath->empty()) {
-        mx::FilePathVec libraryFolders = {"libraries"};
-        mx::FileSearchPath searchPath;
-        searchPath.append(mx::FilePath(*materialXStdlibPath));
-        mx::loadLibraries(libraryFolders, searchPath, stdLibraries);
+        stdLibraries = mx::createDocument();
+
+        if (!materialXStdlibPath.empty()) {
+            mx::FilePathVec libraryFolders = {"libraries"};
+            mx::FileSearchPath searchPath;
+            searchPath.append(mx::FilePath(materialXStdlibPath));
+            mx::loadLibraries(libraryFolders, searchPath, stdLibraries);
+        }
     }
 
     MaterialX::StringMap textureMap;
@@ -512,7 +514,7 @@ RprUsdMaterial* RprUsdMaterialRegistry::CreateMaterial(
 #endif // USE_CUSTOM_MATERIALX_LOADER
 
     if (!isVolume) {
-        if (auto usdShadeMtlxMaterial = CreateMaterialXFromUsdShade(materialId, context, &m_materialXStdlibPath)) {
+        if (auto usdShadeMtlxMaterial = CreateMaterialXFromUsdShade(materialId, context, m_stdLibraries)) {
             return usdShadeMtlxMaterial;
         }
     }

--- a/pxr/imaging/rprUsd/materialRegistry.h
+++ b/pxr/imaging/rprUsd/materialRegistry.h
@@ -20,6 +20,8 @@ limitations under the License.
 #include "pxr/base/arch/demangle.h"
 #include "pxr/base/tf/singleton.h"
 
+#include <MaterialXCore/Document.h>
+
 #include <RadeonProRender.hpp>
 
 class RPRMtlxLoader;
@@ -145,7 +147,7 @@ private:
     std::unique_ptr<RPRMtlxLoader> m_mtlxLoader;
 #endif
 
-    std::string m_materialXStdlibPath;
+    MaterialX::DocumentPtr m_stdLibraries;
 
     std::vector<std::unique_ptr<RprUsd_MtlxNodeInfo>> m_mtlxInfos;
     bool m_mtlxDefsDirty = true;


### PR DESCRIPTION
### PURPOSE
MaterialX sync process takes a lot of time when scene has mane MaterialX nodes

### EFFECT OF CHANGE
Now sync speed is increased on about 40%

### TECHNICAL STEPS
In previous version common libraries are being loaded for each node. In this PR library loading moved to common class. Also now rpr node can be created from matX string without a temp file
