### PR TITLE
Reder devices change

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -74,7 +74,6 @@ render_setting_categories = [
                     SettingValue('Medium', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
                     SettingValue('High', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
                     SettingValue('HybridPro', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
-                    SettingValue('Full', 'Full (Legacy)'),
                     SettingValue('Northstar', 'Full')
                 ]
             }

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1690,9 +1690,7 @@ public:
 
             if (m_state == kStateRender && config->IsDirty(HdRprConfig::DirtyRenderQuality)) {
                 TfToken activeRenderQuality;
-                if (m_rprContextMetadata.pluginType == kPluginTahoe) {
-                    activeRenderQuality = HdRprCoreRenderQualityTokens->Full;
-                } else if (m_rprContextMetadata.pluginType == kPluginNorthstar) {
+                if (m_rprContextMetadata.pluginType == kPluginNorthstar) {
                     activeRenderQuality = HdRprCoreRenderQualityTokens->Northstar;
                 } else if (m_rprContextMetadata.pluginType == kPluginHybridPro) {
                     activeRenderQuality = HdRprCoreRenderQualityTokens->HybridPro;
@@ -3377,9 +3375,7 @@ Don't show this message again?
 
 private:
     static RprUsdPluginType GetPluginType(TfToken const& renderQuality) {
-        if (renderQuality == HdRprCoreRenderQualityTokens->Full) {
-            return kPluginTahoe;
-        } else if (renderQuality == HdRprCoreRenderQualityTokens->Northstar) {
+        if (renderQuality == HdRprCoreRenderQualityTokens->Northstar) {
             return kPluginNorthstar;
         } else if (renderQuality == HdRprCoreRenderQualityTokens->HybridPro) {
             return kPluginHybridPro;

--- a/pxr/imaging/rprUsd/devicesConfiguration.py
+++ b/pxr/imaging/rprUsd/devicesConfiguration.py
@@ -183,7 +183,7 @@ class _Configuration:
     @staticmethod
     def default(context):
         plugin_configurations = list()
-        for plugin_type in [RprUsd.kPluginNorthstar, RprUsd.kPluginTahoe, RprUsd.kPluginHybrid]:
+        for plugin_type in [RprUsd.kPluginNorthstar, RprUsd.kPluginHybridPro, RprUsd.kPluginHybrid]:
             if plugin_type in _devices_info:
                 plugin_configurations.append(_PluginConfiguration.default(plugin_type, _devices_info[plugin_type]))
         return _Configuration(context=context, plugin_configurations=plugin_configurations)
@@ -315,8 +315,8 @@ class _PluginConfigurationWidget(BorderWidget):
         self.plugin_type = plugin_configuration.plugin_type
         if self.plugin_type == RprUsd.kPluginHybrid:
             plugin_qualities = 'Low-High Qualities'
-        elif self.plugin_type == RprUsd.kPluginTahoe:
-            plugin_qualities = 'Full (Legacy) Quality'
+        elif self.plugin_type == RprUsd.kPluginHybridPro:
+            plugin_qualities = 'Hybrid Pro Quality'
         elif self.plugin_type == RprUsd.kPluginNorthstar:
             plugin_qualities = 'Full Quality'
 

--- a/pxr/imaging/rprUsd/wrapContextHelpers.cpp
+++ b/pxr/imaging/rprUsd/wrapContextHelpers.cpp
@@ -32,6 +32,7 @@ TF_REGISTRY_FUNCTION(TfEnum) {
     TF_ADD_ENUM_NAME(kPluginTahoe);
     TF_ADD_ENUM_NAME(kPluginNorthstar);
     TF_ADD_ENUM_NAME(kPluginHybrid);
+    TF_ADD_ENUM_NAME(kPluginHybridPro);
 }
 
 void wrapContextHelpers() {


### PR DESCRIPTION
### PURPOSE
Plugin has render device settings for outdated Tahoe engine, but doesn't have device option for HybridPro

### EFFECT OF CHANGE
1) Tahoe (legacy Full) engine has been removed from available renderers list
2) Tahoe has been removed from render device settings
3) HybridPro has been added to render device settings
