### PR TITLE
remove tahoe from render settings

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -74,7 +74,6 @@ render_setting_categories = [
                     SettingValue('Medium', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
                     SettingValue('High', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
                     SettingValue('HybridPro', enable_py_condition=HYBRID_IS_AVAILABLE_PY_CONDITION),
-                    SettingValue('Full', 'Full (Legacy)'),
                     SettingValue('Northstar', 'Full')
                 ]
             }

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -1690,9 +1690,7 @@ public:
 
             if (m_state == kStateRender && config->IsDirty(HdRprConfig::DirtyRenderQuality)) {
                 TfToken activeRenderQuality;
-                if (m_rprContextMetadata.pluginType == kPluginTahoe) {
-                    activeRenderQuality = HdRprCoreRenderQualityTokens->Full;
-                } else if (m_rprContextMetadata.pluginType == kPluginNorthstar) {
+                if (m_rprContextMetadata.pluginType == kPluginNorthstar) {
                     activeRenderQuality = HdRprCoreRenderQualityTokens->Northstar;
                 } else if (m_rprContextMetadata.pluginType == kPluginHybridPro) {
                     activeRenderQuality = HdRprCoreRenderQualityTokens->HybridPro;
@@ -3377,9 +3375,7 @@ Don't show this message again?
 
 private:
     static RprUsdPluginType GetPluginType(TfToken const& renderQuality) {
-        if (renderQuality == HdRprCoreRenderQualityTokens->Full) {
-            return kPluginTahoe;
-        } else if (renderQuality == HdRprCoreRenderQualityTokens->Northstar) {
+        if (renderQuality == HdRprCoreRenderQualityTokens->Northstar) {
             return kPluginNorthstar;
         } else if (renderQuality == HdRprCoreRenderQualityTokens->HybridPro) {
             return kPluginHybridPro;

--- a/pxr/imaging/rprUsd/devicesConfiguration.py
+++ b/pxr/imaging/rprUsd/devicesConfiguration.py
@@ -183,7 +183,7 @@ class _Configuration:
     @staticmethod
     def default(context):
         plugin_configurations = list()
-        for plugin_type in [RprUsd.kPluginHybridPro, RprUsd.kPluginNorthstar, RprUsd.kPluginTahoe, RprUsd.kPluginHybrid]:
+        for plugin_type in [RprUsd.kPluginHybridPro, RprUsd.kPluginNorthstar, RprUsd.kPluginHybrid]:
             if plugin_type in _devices_info:
                 plugin_configurations.append(_PluginConfiguration.default(plugin_type, _devices_info[plugin_type]))
         return _Configuration(context=context, plugin_configurations=plugin_configurations)
@@ -319,8 +319,6 @@ class _PluginConfigurationWidget(BorderWidget):
             plugin_qualities = 'Northstar'
         elif self.plugin_type == RprUsd.kPluginHybrid:
             plugin_qualities = 'Low-High Qualities'
-        elif self.plugin_type == RprUsd.kPluginTahoe:
-            plugin_qualities = 'Full (Legacy) Quality'
 
         self.labels_widget = QtWidgets.QWidget(self)
         self.main_layout.addWidget(self.labels_widget)


### PR DESCRIPTION
### PURPOSE
Legacy Tahoe plugin is in render settings

### EFFECT OF CHANGE
Now Tahoe has been removed from settings

### NOTES FOR REVIEWERS
This PR makes Tahoe fully unavailable! Other Tahoe code will be deleted later
