### PR TITLE
Add some render statistics

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -359,10 +359,10 @@ VtDictionary HdRprDelegate::GetRenderStats() const {
     stats["averageRenderTimePerSample"] = rprStats.averageRenderTimePerSample;
     stats["averageResolveTimePerSample"] = rprStats.averageResolveTimePerSample;
 
-	stats["gpuUsedNames"] = m_rprApi->GetGpuUsedNames();
-	stats["threadCountUsed"] = m_rprApi->GetCpuThreadCountUsed();
+    stats["gpuUsedNames"] = m_rprApi->GetGpuUsedNames();
+    stats["threadCountUsed"] = m_rprApi->GetCpuThreadCountUsed();
 
-	stats["firstIterationRenderTime"] = m_rprApi->GetFirstIterationRenerTime();
+    stats["firstIterationRenderTime"] = m_rprApi->GetFirstIterationRenerTime();
 
     return stats;
 }

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -358,6 +358,10 @@ VtDictionary HdRprDelegate::GetRenderStats() const {
     stats[_tokens->percentDone.GetString()] = rprStats.percentDone;
     stats["averageRenderTimePerSample"] = rprStats.averageRenderTimePerSample;
     stats["averageResolveTimePerSample"] = rprStats.averageResolveTimePerSample;
+
+	stats["gpuUsedNames"] = m_rprApi->GetGpuUsedNames();
+	stats["threadCountUsed"] = m_rprApi->GetCpuThreadCountUsed();
+
     return stats;
 }
 

--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -362,6 +362,8 @@ VtDictionary HdRprDelegate::GetRenderStats() const {
 	stats["gpuUsedNames"] = m_rprApi->GetGpuUsedNames();
 	stats["threadCountUsed"] = m_rprApi->GetCpuThreadCountUsed();
 
+	stats["firstIterationRenderTime"] = m_rprApi->GetFirstIterationRenerTime();
+
     return stats;
 }
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -3398,7 +3398,7 @@ Don't show this message again?
 
         for (RprUsdDevicesInfo::GPU gpu : m_rprContextMetadata.devicesActuallyUsed.gpus) {
             gpuNamesUsed.push_back(gpu.name);
-	    }
+        }
 
 	    return gpuNamesUsed;
     }
@@ -4184,7 +4184,7 @@ private:
     RprUsdContextMetadata m_rprContextMetadata;
     bool m_isOutputFlipped;
 
-	float m_firstIterationRenderTime = 0.0f;
+    float m_firstIterationRenderTime = 0.0f;
 
     std::unique_ptr<rif::Context> m_rifContext;
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -2418,8 +2418,8 @@ public:
         RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_RENDER_UPDATE_CALLBACK_FUNC, (void*)rucFunc), "Failed to set northstar RUC func");
         RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_RENDER_UPDATE_CALLBACK_DATA, &m_rucData), "Failed to set northstar RUC data");
 
-		RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_FIRST_ITERATION_TIME_CALLBACK_FUNC, (void*)FirstIterationRenderCallback), "Failed to set first iteration callback func");
-		RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_FIRST_ITERATION_TIME_CALLBACK_DATA, &m_firstIterationRenderTime), "Failed to set first iteration callback data");
+        RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_FIRST_ITERATION_TIME_CALLBACK_FUNC, (void*)FirstIterationRenderCallback), "Failed to set first iteration callback func");
+        RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_FIRST_ITERATION_TIME_CALLBACK_DATA, &m_firstIterationRenderTime), "Failed to set first iteration callback data");
 
         m_isRenderUpdateCallbackEnabled = true;
     }
@@ -3314,9 +3314,6 @@ Don't show this message again?
     HdRprApi::RenderStats GetRenderStats() const {
         HdRprApi::RenderStats stats = {};
 
-		//m_contextmetadata
-
-
         // rprsExport has no progress callback
         if (!m_rprSceneExportPath.empty()) {
             return stats;
@@ -3396,23 +3393,23 @@ Don't show this message again?
         return m_currentRenderQuality;
     }
 
-	std::vector<std::string> GetGpuUsedNames() const {
-		std::vector<std::string> gpuNamesUsed;
+    std::vector<std::string> GetGpuUsedNames() const {
+        std::vector<std::string> gpuNamesUsed;
 
-		for (RprUsdDevicesInfo::GPU gpu : m_rprContextMetadata.devicesActuallyUsed.gpus) {
-			gpuNamesUsed.push_back(gpu.name);
-		}
+        for (RprUsdDevicesInfo::GPU gpu : m_rprContextMetadata.devicesActuallyUsed.gpus) {
+            gpuNamesUsed.push_back(gpu.name);
+	    }
 
-		return gpuNamesUsed;
-	}
+	    return gpuNamesUsed;
+    }
 
-	int GetCpuThreadCountUsed() const {
-		return m_rprContextMetadata.devicesActuallyUsed.cpu.numThreads;
-	}
+    int GetCpuThreadCountUsed() const {
+        return m_rprContextMetadata.devicesActuallyUsed.cpu.numThreads;
+    }
 
-	float GetFirstIterationRenerTime() const {
-		return m_firstIterationRenderTime;
-	}
+    float GetFirstIterationRenerTime() const {
+        return m_firstIterationRenderTime;
+    }
 
     void SetInteropInfo(void* interopInfo, std::condition_variable* presentedConditionVariable, bool* presentedCondition) {
 #ifdef HDRPR_ENABLE_VULKAN_INTEROP_SUPPORT
@@ -4676,15 +4673,15 @@ void HdRprApi::SetInteropInfo(void* interopInfo, std::condition_variable* presen
 }
 
 std::vector<std::string> HdRprApi::GetGpuUsedNames() const {
-	return m_impl->GetGpuUsedNames();
+    return m_impl->GetGpuUsedNames();
 }
 
 int HdRprApi::GetCpuThreadCountUsed() const {
-	return m_impl->GetCpuThreadCountUsed();
+    return m_impl->GetCpuThreadCountUsed();
 }
 
 float HdRprApi::GetFirstIterationRenerTime() const {
-	return m_impl->GetFirstIterationRenerTime();
+    return m_impl->GetFirstIterationRenerTime();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -3306,6 +3306,9 @@ Don't show this message again?
     HdRprApi::RenderStats GetRenderStats() const {
         HdRprApi::RenderStats stats = {};
 
+		//m_contextmetadata
+
+
         // rprsExport has no progress callback
         if (!m_rprSceneExportPath.empty()) {
             return stats;
@@ -3384,6 +3387,20 @@ Don't show this message again?
     TfToken const& GetCurrentRenderQuality() const {
         return m_currentRenderQuality;
     }
+
+	std::vector<std::string> GetGpuUsedNames() const {
+		std::vector<std::string> gpuNamesUsed;
+
+		for (RprUsdDevicesInfo::GPU gpu : m_rprContextMetadata.devicesActuallyUsed.gpus) {
+			gpuNamesUsed.push_back(gpu.name);
+		}
+
+		return gpuNamesUsed;
+	}
+
+	int GetCpuThreadCountUsed() const {
+		return m_rprContextMetadata.devicesActuallyUsed.cpu.numThreads;
+	}
 
     void SetInteropInfo(void* interopInfo, std::condition_variable* presentedConditionVariable, bool* presentedCondition) {
 #ifdef HDRPR_ENABLE_VULKAN_INTEROP_SUPPORT
@@ -4642,6 +4659,14 @@ void HdRprApi::SetInteropInfo(void* interopInfo, std::condition_variable* presen
 
     // Temporary should be force inited here, because otherwise has issues with GPU synchronization
     m_impl->InitIfNeeded();
+}
+
+std::vector<std::string> HdRprApi::GetGpuUsedNames() const {
+	return m_impl->GetGpuUsedNames();
+}
+
+int HdRprApi::GetCpuThreadCountUsed() const {
+	return m_impl->GetCpuThreadCountUsed();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -3400,7 +3400,7 @@ Don't show this message again?
             gpuNamesUsed.push_back(gpu.name);
         }
 
-	    return gpuNamesUsed;
+        return gpuNamesUsed;
     }
 
     int GetCpuThreadCountUsed() const {

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -2417,6 +2417,10 @@ public:
         m_rucData.rprApi = this;
         RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_RENDER_UPDATE_CALLBACK_FUNC, (void*)rucFunc), "Failed to set northstar RUC func");
         RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_RENDER_UPDATE_CALLBACK_DATA, &m_rucData), "Failed to set northstar RUC data");
+
+		RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_FIRST_ITERATION_TIME_CALLBACK_FUNC, (void*)FirstIterationRenderCallback), "Failed to set first iteration callback func");
+		RPR_ERROR_CHECK_THROW(m_rprContext->SetParameter(RPR_CONTEXT_FIRST_ITERATION_TIME_CALLBACK_DATA, &m_firstIterationRenderTime), "Failed to set first iteration callback data");
+
         m_isRenderUpdateCallbackEnabled = true;
     }
 
@@ -2818,6 +2822,10 @@ public:
 
         data->previousProgress = progress;
     }
+
+	static void FirstIterationRenderCallback(float firstIterationTimeMs, void* dataPtr) {
+		*(float*)(dataPtr) = firstIterationTimeMs;
+	}
 
     void RenderImpl(HdRprRenderThread* renderThread) {
         if (!CommonRenderImplPrologue()) {
@@ -3400,6 +3408,10 @@ Don't show this message again?
 
 	int GetCpuThreadCountUsed() const {
 		return m_rprContextMetadata.devicesActuallyUsed.cpu.numThreads;
+	}
+
+	float GetFirstIterationRenerTime() const {
+		return m_firstIterationRenderTime;
 	}
 
     void SetInteropInfo(void* interopInfo, std::condition_variable* presentedConditionVariable, bool* presentedCondition) {
@@ -4175,6 +4187,8 @@ private:
     RprUsdContextMetadata m_rprContextMetadata;
     bool m_isOutputFlipped;
 
+	float m_firstIterationRenderTime = 0.0f;
+
     std::unique_ptr<rif::Context> m_rifContext;
 
     std::unique_ptr<rpr::Scene> m_scene;
@@ -4667,6 +4681,10 @@ std::vector<std::string> HdRprApi::GetGpuUsedNames() const {
 
 int HdRprApi::GetCpuThreadCountUsed() const {
 	return m_impl->GetCpuThreadCountUsed();
+}
+
+float HdRprApi::GetFirstIterationRenerTime() const {
+	return m_impl->GetFirstIterationRenerTime();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -160,9 +160,9 @@ public:
     };
     RenderStats GetRenderStats() const;
 
-	std::vector<std::string> GetGpuUsedNames() const;
-	int GetCpuThreadCountUsed() const;
-	float GetFirstIterationRenerTime() const;
+    std::vector<std::string> GetGpuUsedNames() const;
+    int GetCpuThreadCountUsed() const;
+    float GetFirstIterationRenerTime() const;
 
     void CommitResources();
     void Resolve(SdfPath const& aovId);

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -161,8 +161,8 @@ public:
     RenderStats GetRenderStats() const;
 
 	std::vector<std::string> GetGpuUsedNames() const;
-
 	int GetCpuThreadCountUsed() const;
+	float GetFirstIterationRenerTime() const;
 
     void CommitResources();
     void Resolve(SdfPath const& aovId);

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -160,6 +160,10 @@ public:
     };
     RenderStats GetRenderStats() const;
 
+	std::vector<std::string> GetGpuUsedNames() const;
+
+	int GetCpuThreadCountUsed() const;
+
     void CommitResources();
     void Resolve(SdfPath const& aovId);
     void Render(HdRprRenderThread* renderThread);

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -228,7 +228,7 @@ RprUsdDevicesInfo LoadDevicesConfiguration(RprUsdPluginType pluginType, std::str
         return {};
     }
 
-	RprUsdDevicesInfo ret;
+    RprUsdDevicesInfo ret;
 
     auto isLoaded = [&]() {
         try {

--- a/pxr/imaging/rprUsd/contextHelpers.cpp
+++ b/pxr/imaging/rprUsd/contextHelpers.cpp
@@ -317,7 +317,7 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
         return nullptr;
     }
 
-	RprUsdDevicesInfo devicesConfiguration = LoadDevicesConfiguration(metadata->pluginType, deviceConfigurationFilepath);
+    RprUsdDevicesInfo devicesConfiguration = LoadDevicesConfiguration(metadata->pluginType, deviceConfigurationFilepath);
 
     std::vector<rpr_context_properties> contextProperties;
     auto appendContextProperty = [&contextProperties](uint64_t propertyKey, void* propertyValue) {
@@ -398,7 +398,7 @@ rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata) {
         RPR_ERROR_CHECK(context->SetParameter(RPR_CONTEXT_TEXTURE_CACHE_PATH, textureCachePath.c_str()), "Failed to set texture cache path");
 
         metadata->creationFlags = creationFlags;
-		metadata->devicesActuallyUsed = devicesConfiguration;
+        metadata->devicesActuallyUsed = devicesConfiguration;
     } else {
         RPR_ERROR_CHECK(status, "Failed to create RPR context");
     }

--- a/pxr/imaging/rprUsd/contextHelpers.h
+++ b/pxr/imaging/rprUsd/contextHelpers.h
@@ -17,36 +17,12 @@ limitations under the License.
 #include "pxr/imaging/rprUsd/api.h"
 #include "pxr/imaging/rprUsd/contextMetadata.h"
 
-#include <string>
-#include <vector>
-
 namespace rpr { class Context; }
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 RPRUSD_API
 rpr::Context* RprUsdCreateContext(RprUsdContextMetadata* metadata);
-
-struct RprUsdDevicesInfo {
-    struct CPU {
-        int numThreads;
-        CPU(int numThreads = 0) : numThreads(numThreads) {}
-        bool operator==(CPU const& rhs) { return numThreads == rhs.numThreads; }
-    };
-    CPU cpu;
-
-    struct GPU {
-        int index;
-        std::string name;
-        GPU(int index = -1, std::string name = {}) : index(index), name(name) {}
-        bool operator==(GPU const& rhs) { return index == rhs.index && name == rhs.name; }
-    };
-    std::vector<GPU> gpus;
-
-    bool IsValid() const {
-        return cpu.numThreads > 0 || !gpus.empty();
-    }
-};
 
 RPRUSD_API
 RprUsdDevicesInfo RprUsdGetDevicesInfo(RprUsdPluginType pluginType);

--- a/pxr/imaging/rprUsd/contextMetadata.h
+++ b/pxr/imaging/rprUsd/contextMetadata.h
@@ -34,24 +34,24 @@ enum RprUsdPluginType {
 };
 
 struct RprUsdDevicesInfo {
-	struct CPU {
-		int numThreads;
-		CPU(int numThreads = 0) : numThreads(numThreads) {}
-		bool operator==(CPU const& rhs) { return numThreads == rhs.numThreads; }
-	};
-	CPU cpu;
+    struct CPU {
+	    int numThreads;
+	    CPU(int numThreads = 0) : numThreads(numThreads) {}
+	    bool operator==(CPU const& rhs) { return numThreads == rhs.numThreads; }
+    };
+    CPU cpu;
 
-	struct GPU {
-		int index;
-		std::string name;
-		GPU(int index = -1, std::string name = {}) : index(index), name(name) {}
-		bool operator==(GPU const& rhs) { return index == rhs.index && name == rhs.name; }
-	};
-	std::vector<GPU> gpus;
+    struct GPU {
+        int index;
+        std::string name;
+        GPU(int index = -1, std::string name = {}) : index(index), name(name) {}
+        bool operator==(GPU const& rhs) { return index == rhs.index && name == rhs.name; }
+    };
+    std::vector<GPU> gpus;
 
-	bool IsValid() const {
-		return cpu.numThreads > 0 || !gpus.empty();
-	}
+    bool IsValid() const {
+        return cpu.numThreads > 0 || !gpus.empty();
+    }
 };
 
 struct RprUsdContextMetadata {
@@ -61,7 +61,7 @@ struct RprUsdContextMetadata {
     rpr::CreationFlags creationFlags = 0;
 
 	// additional info about hardware actually used in render context creation
-	RprUsdDevicesInfo devicesActuallyUsed;
+    RprUsdDevicesInfo devicesActuallyUsed;
 };
 
 RPRUSD_API

--- a/pxr/imaging/rprUsd/contextMetadata.h
+++ b/pxr/imaging/rprUsd/contextMetadata.h
@@ -19,6 +19,10 @@ limitations under the License.
 
 #include <RadeonProRender.hpp>
 
+#include <string>
+#include <vector>
+
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 enum RprUsdPluginType {
@@ -29,11 +33,35 @@ enum RprUsdPluginType {
     kPluginsCount
 };
 
+struct RprUsdDevicesInfo {
+	struct CPU {
+		int numThreads;
+		CPU(int numThreads = 0) : numThreads(numThreads) {}
+		bool operator==(CPU const& rhs) { return numThreads == rhs.numThreads; }
+	};
+	CPU cpu;
+
+	struct GPU {
+		int index;
+		std::string name;
+		GPU(int index = -1, std::string name = {}) : index(index), name(name) {}
+		bool operator==(GPU const& rhs) { return index == rhs.index && name == rhs.name; }
+	};
+	std::vector<GPU> gpus;
+
+	bool IsValid() const {
+		return cpu.numThreads > 0 || !gpus.empty();
+	}
+};
+
 struct RprUsdContextMetadata {
     RprUsdPluginType pluginType = kPluginInvalid;
     bool isGlInteropEnabled = false;
     void* interopInfo = nullptr;
     rpr::CreationFlags creationFlags = 0;
+
+	// additional info about hardware actually used in render context creation
+	RprUsdDevicesInfo devicesActuallyUsed;
 };
 
 RPRUSD_API

--- a/pxr/imaging/rprUsd/contextMetadata.h
+++ b/pxr/imaging/rprUsd/contextMetadata.h
@@ -60,7 +60,7 @@ struct RprUsdContextMetadata {
     void* interopInfo = nullptr;
     rpr::CreationFlags creationFlags = 0;
 
-	// additional info about hardware actually used in render context creation
+    // additional info about hardware actually used in render context creation
     RprUsdDevicesInfo devicesActuallyUsed;
 };
 


### PR DESCRIPTION
### PURPOSE
This PR adds some render info and render statistics information to be available outside hdRPR via GetRenderStats function.

 - GPU names which were actually used for context creation.
 -  CPU thread count.
 - First iteration render time (which is approximation for cache creation time).

### EFFECT OF CHANGE
Plugin which uses hdRPR can now get some render data and statistics from it.

### TECHNICAL STEPS
I used GetRenderStats() function of hydra render delegate interface to provide necessary information for the plugins which use hdRPR.
