### PR TITLE
Shadow catcher cpu combine

### DIFF
--- a/pxr/imaging/plugin/hdRpr/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdRpr/CMakeLists.txt
@@ -15,6 +15,13 @@ if(OpenVDB_FOUND)
     set(OptClass ${OptClass} field volume)
 endif(OpenVDB_FOUND)
 
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
+
 set(_sep ${PXR_RESOURCE_FILE_SRC_DST_SEPARATOR})
 if(HoudiniUSD_FOUND)
     list(APPEND OptLibs Houdini)

--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
@@ -93,6 +93,7 @@ HdRprAovRegistry::HdRprAovRegistry() {
     m_computedAovDescriptors[kMaterialIdMask] = HdRprAovDescriptor(kMaterialIdMask, false, HdFormatFloat32Vec4, GfVec4f(0.0f), true);
     m_computedAovDescriptors[kObjectIdMask] = HdRprAovDescriptor(kObjectIdMask, false, HdFormatFloat32Vec4, GfVec4f(0.0f), true);
     m_computedAovDescriptors[kObjectGroupIdMask] = HdRprAovDescriptor(kObjectGroupIdMask, false, HdFormatFloat32Vec4, GfVec4f(0.0f), true);
+    m_computedAovDescriptors[kScTransparentBackground] = HdRprAovDescriptor(kScTransparentBackground, true, HdFormatFloat32Vec4, GfVec4f(0.0f), true);
 
     auto addAovNameLookup = [this](TfToken const& name, HdRprAovDescriptor const& descriptor) {
         auto status = m_aovNameLookup.emplace(name, AovNameLookupValue(descriptor.id, descriptor.computed));
@@ -157,6 +158,7 @@ HdRprAovRegistry::HdRprAovRegistry() {
     addAovNameLookup(HdRprAovTokens->materialIdMask, m_computedAovDescriptors[kMaterialIdMask]);
     addAovNameLookup(HdRprAovTokens->objectIdMask, m_computedAovDescriptors[kObjectIdMask]);
     addAovNameLookup(HdRprAovTokens->objectGroupIdMask, m_computedAovDescriptors[kObjectGroupIdMask]);
+    addAovNameLookup(HdRprAovTokens->scTransparentBackground, m_computedAovDescriptors[kScTransparentBackground]);
 }
 
 HdRprAovDescriptor const& HdRprAovRegistry::GetAovDesc(TfToken const& name) {

--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.h
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.h
@@ -75,6 +75,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (materialIdMask) \
     (objectIdMask) \
     (objectGroupIdMask) \
+    (scTransparentBackground) \
 
 TF_DECLARE_PUBLIC_TOKENS(HdRprAovTokens, HDRPR_AOV_TOKENS);
 
@@ -86,6 +87,7 @@ enum ComputedAovs {
     kMaterialIdMask,
     kObjectIdMask,
     kObjectGroupIdMask,
+    kScTransparentBackground,
     kComputedAovsCount
 };
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -3916,6 +3916,26 @@ private:
                     }
 
                     newAov = new HdRprApiDepthAov(width, height, format, std::move(worldCoordinateAov), std::move(opacityAov), m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
+                }
+                else if (aovName == HdRprAovTokens->scTransparentBackground) {
+                    auto rawColorAov = GetAov(HdRprAovTokens->rawColor, width, height, HdFormatFloat32Vec4);
+                    if (!rawColorAov) {
+                        TF_RUNTIME_ERROR("Failed to create scTransparentBackground AOV: can't create rawColor AOV");
+                        return nullptr;
+                    }
+                    auto opacityAov = GetAov(HdRprAovTokens->opacity, width, height, HdFormatFloat32Vec4);
+                    if (!opacityAov) {
+                        TF_RUNTIME_ERROR("Failed to create scTransparentBackground AOV: can't create opacity AOV");
+                        return nullptr;
+                    }
+                    auto shadowCatcherAov = GetAov(HdRprAovTokens->shadowCatcher, width, height, HdFormatFloat32Vec4);
+                    if (!shadowCatcherAov) {
+                        TF_RUNTIME_ERROR("Failed to create scTransparentBackground AOV: can't create shadowCatcher AOV");
+                        return nullptr;
+                    }
+
+                    newAov = new HdRprApiScCompositeAOV(width, height, format, std::move(rawColorAov), std::move(opacityAov), std::move(shadowCatcherAov), m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
+
                 } else if (TfStringStartsWith(aovName.GetString(), "lpe")) {
                     newAov = new HdRprApiAov(rpr::Aov(aovDesc.id), width, height, format, m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
                     aovCustomDestructor = [this](HdRprApiAov* aov) {

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
@@ -711,4 +711,20 @@ void HdRprApiIdMaskAov::Update(HdRprApi const* rprApi, rif::Context* rifContext)
     }
 }
 
+HdRprApiScCompositeAOV::HdRprApiScCompositeAOV(int width, int height, HdFormat format,
+    std::shared_ptr<HdRprApiAov> rawColorAov,
+    std::shared_ptr<HdRprApiAov> opacityAov,
+    std::shared_ptr<HdRprApiAov> scAov,
+    rpr::Context* rprContext, RprUsdContextMetadata const& rprContextMetadata, rif::Context* rifContext)
+    : HdRprApiAov(HdRprAovRegistry::GetInstance().GetAovDesc(rpr::Aov(kScTransparentBackground), true), format)
+    , m_retainedRawColorAov(rawColorAov)
+    , m_retainedOpacityAov(opacityAov)
+    , m_retainedScAov(scAov)
+{
+} 
+
+bool HdRprApiScCompositeAOV::GetData(void* dstBuffer, size_t dstBufferSize) {
+    return m_retainedRawColorAov->GetData(dstBuffer, dstBufferSize);
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
@@ -723,8 +723,8 @@ HdRprApiScCompositeAOV::HdRprApiScCompositeAOV(int width, int height, HdFormat f
 {
 } 
 
-bool HdRprApiScCompositeAOV::GetData(void* dstBuffer, size_t dstBufferSize) {
-    return m_retainedRawColorAov->GetData(dstBuffer, dstBufferSize);
+bool HdRprApiScCompositeAOV::GetDataImpl(void* dstBuffer, size_t dstBufferSize) {
+    return m_retainedRawColorAov->GetDataImpl(dstBuffer, dstBufferSize);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
@@ -746,6 +746,7 @@ bool HdRprApiScCompositeAOV::GetDataImpl(void* dstBuffer, size_t dstBufferSize) 
 
     auto dstValue = reinterpret_cast<GfVec4f*>(dstBuffer);
 
+    #pragma omp parallel for
     for (int i = 0; i < dstBufferSize / sizeof(GfVec4f); i++) {  // on this stage format is always HdFormatFloat32Vec4
         float opacity = m_tempOpacityBuffer[i][0];
         float sc = m_tempScBuffer[i][0];

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.cpp
@@ -746,23 +746,22 @@ bool HdRprApiScCompositeAOV::GetDataImpl(void* dstBuffer, size_t dstBufferSize) 
 
     auto dstValue = reinterpret_cast<GfVec4f*>(dstBuffer);
 
+    // On this stage format is always HdFormatFloat32Vec4
     #pragma omp parallel for
-    for (int i = 0; i < dstBufferSize / sizeof(GfVec4f); i++) {  // on this stage format is always HdFormatFloat32Vec4
+    for (int i = 0; i < dstBufferSize / sizeof(GfVec4f); i++) 
+    {  
         float opacity = m_tempOpacityBuffer[i][0];
         float sc = m_tempScBuffer[i][0];
+        constexpr float OneMinusEpsilon = 1.0f - 1e-5f;
 
-        if (opacity > 0) {
-            dstValue[i] = {m_tempColorBuffer[i][0], m_tempColorBuffer[i][1], m_tempColorBuffer[i][2], opacity};
-        }
+        if (opacity > OneMinusEpsilon)
+        {
+            dstValue[i] = { m_tempColorBuffer[i][0], m_tempColorBuffer[i][1], m_tempColorBuffer[i][2], opacity };
+		}
         else
         {
-            if (sc > 0) {
-                dstValue[i] = {(1.f - sc), (1.f - sc), (1.f - sc), sc};
-            }
-            else
-            {
-                dstValue[i] = { 0, 0, 0, 0 }; // Make background black and transparent
-            }
+            // Add shadows from the shadow catcher to the final image + Make the background transparent;
+            dstValue[i] = { 0.0f, 0.0f, 0.0f, sc };         
         }
     }
 

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -229,6 +229,22 @@ private:
     std::shared_ptr<HdRprApiAov> m_baseIdAov;
 };
 
+class HdRprApiScCompositeAOV : public HdRprApiAov {
+public:
+    HdRprApiScCompositeAOV(int width, int height, HdFormat format,
+                         std::shared_ptr<HdRprApiAov> rawColorAov,
+                         std::shared_ptr<HdRprApiAov> opacityAov,
+                         std::shared_ptr<HdRprApiAov> scAov,
+                         rpr::Context* rprContext, RprUsdContextMetadata const& rprContextMetadata, rif::Context* rifContext);
+
+    bool GetData(void* dstBuffer, size_t dstBufferSize) override;
+
+private:
+    std::shared_ptr<HdRprApiAov> m_retainedRawColorAov;
+    std::shared_ptr<HdRprApiAov> m_retainedOpacityAov;
+    std::shared_ptr<HdRprApiAov> m_retainedScAov;
+};
+
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif // HDRPR_RPR_API_AOV_H

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -242,6 +242,8 @@ private:
     std::shared_ptr<HdRprApiAov> m_retainedRawColorAov;
     std::shared_ptr<HdRprApiAov> m_retainedOpacityAov;
     std::shared_ptr<HdRprApiAov> m_retainedScAov;
+
+    std::vector<char> m_tempCombinationBuffer;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -46,6 +46,8 @@ public:
     HdRprApiFramebuffer* GetAovFb() { return m_aov.get(); };
     HdRprApiFramebuffer* GetResolvedFb();
 
+    virtual bool GetDataImpl(void* dstBuffer, size_t dstBufferSize);
+
 protected:
     HdRprApiAov(HdRprAovDescriptor const& aovDescriptor, HdFormat format)
         : m_aovDescriptor(aovDescriptor), m_format(format) {};
@@ -68,9 +70,6 @@ protected:
         DirtyFormat = 1 << 1,
     };
     uint32_t m_dirtyBits = AllDirty;
-
-private:
-    bool GetDataImpl(void* dstBuffer, size_t dstBufferSize);
 };
 
 class HdRprApiColorAov : public HdRprApiAov {
@@ -237,7 +236,7 @@ public:
                          std::shared_ptr<HdRprApiAov> scAov,
                          rpr::Context* rprContext, RprUsdContextMetadata const& rprContextMetadata, rif::Context* rifContext);
 
-    bool GetData(void* dstBuffer, size_t dstBufferSize) override;
+    bool GetDataImpl(void* dstBuffer, size_t dstBufferSize) override;
 
 private:
     std::shared_ptr<HdRprApiAov> m_retainedRawColorAov;

--- a/pxr/imaging/plugin/hdRpr/rprApiAov.h
+++ b/pxr/imaging/plugin/hdRpr/rprApiAov.h
@@ -243,7 +243,9 @@ private:
     std::shared_ptr<HdRprApiAov> m_retainedOpacityAov;
     std::shared_ptr<HdRprApiAov> m_retainedScAov;
 
-    std::vector<char> m_tempCombinationBuffer;
+    std::vector<GfVec4f> m_tempColorBuffer;
+    std::vector<GfVec4f> m_tempOpacityBuffer;
+    std::vector<GfVec4f> m_tempScBuffer;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### WHY
Customers need to get shadow catcher image with transparent background

### WHAT
Added new AOV (scTransparentBackground) which can display schadow catcher composite image with transparent background

### HOW
We make composition using color, opacity and shadow catcher AOVs. Composition is on CPU to avoid using RIF
