### PR TITLE
HybridPro MaterialX temp fix

### DIFF
--- a/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.cpp
@@ -32,10 +32,33 @@ rpr::MaterialNode* RprUsd_CreateRprMtlxFromString(std::string const& mtlxString,
 
     rpr_material_node matxNodeHandle = rpr::GetRprObject(matxNode.get());
 
-    status = rprMaterialXSetFileAsBuffer(matxNodeHandle, mtlxString.c_str(), mtlxString.size());
+    // TODO: use rprMaterialXSetFileAsBuffer when fixed in HybridPro
+    /*status = rprMaterialXSetFileAsBuffer(matxNodeHandle, mtlxString.c_str(), mtlxString.size());
+    
     if (status != RPR_SUCCESS) {
         RPR_ERROR_CHECK(status, "Failed to set matx node file from buffer");
         return nullptr;
+    }
+    */
+
+    // For now, as we have only rprMaterialXSetFile working, create a temporary file
+    {
+        std::string temporaryFilePath = ArchMakeTmpFileName("tmpMaterial", ".mtlx");
+
+        FILE* fout = fopen(temporaryFilePath.c_str(), "w");
+        if (!fout) {
+            return nullptr;
+        }
+
+        fwrite(mtlxString.c_str(), 1, mtlxString.size(), fout);
+        fclose(fout);
+
+        status = rprMaterialXSetFile(matxNodeHandle, temporaryFilePath.c_str());
+        if (status != RPR_SUCCESS) {
+            RPR_ERROR_CHECK(status, "Failed to set matx node file");
+            ArchUnlinkFile(temporaryFilePath.c_str());
+            return nullptr;
+        }
     }
 
     return matxNode.release();


### PR DESCRIPTION
### WHY
HybridPro has rendering artefacts with MaterialX 

### WHAT
Now hybrid pro can work correctly 

### HOW 
Loading MaterialX file using temp file had been added. It will be removed after fix on HybridPro side
