### PR TITLE
apply changes from MS team

### DIFF
--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
@@ -158,7 +158,7 @@ HdRprAovRegistry::HdRprAovRegistry() {
     addAovNameLookup(HdRprAovTokens->materialIdMask, m_computedAovDescriptors[kMaterialIdMask]);
     addAovNameLookup(HdRprAovTokens->objectIdMask, m_computedAovDescriptors[kObjectIdMask]);
     addAovNameLookup(HdRprAovTokens->objectGroupIdMask, m_computedAovDescriptors[kObjectGroupIdMask]);
-    addAovNameLookup(HdRprAovTokens->scTransparentBackground, m_computedAovDescriptors[kScTransparentBackground]);
+    addAovNameLookup(HdRprAovTokens->colorWithTransparency, m_computedAovDescriptors[kScTransparentBackground]);
 }
 
 HdRprAovDescriptor const& HdRprAovRegistry::GetAovDesc(TfToken const& name) {

--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.h
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.h
@@ -75,7 +75,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (materialIdMask) \
     (objectIdMask) \
     (objectGroupIdMask) \
-    (scTransparentBackground) \
+    (colorWithTransparency) \
 
 TF_DECLARE_PUBLIC_TOKENS(HdRprAovTokens, HDRPR_AOV_TOKENS);
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -3946,7 +3946,7 @@ private:
 
                     newAov = new HdRprApiDepthAov(width, height, format, std::move(worldCoordinateAov), std::move(opacityAov), m_rprContext.get(), m_rprContextMetadata, m_rifContext.get());
                 }
-                else if (aovName == HdRprAovTokens->scTransparentBackground) {
+                else if (aovName == HdRprAovTokens->colorWithTransparency) {
                     auto rawColorAov = GetAov(HdRprAovTokens->rawColor, width, height, HdFormatFloat32Vec4);
                     if (!rawColorAov) {
                         TF_RUNTIME_ERROR("Failed to create scTransparentBackground AOV: can't create rawColor AOV");


### PR DESCRIPTION
### WHY
Customers need to rename shadow catcher with transparency AOV to colorWithTransparency

### WHAT
AOV scTransparentBackground had been renamed to colorWithTransparency
