### PR TITLE
Additional settings for toon shader

### DIFF
--- a/pxr/imaging/plugin/hdRpr/light.cpp
+++ b/pxr/imaging/plugin/hdRpr/light.cpp
@@ -19,6 +19,8 @@ limitations under the License.
 #include "pxr/imaging/rprUsd/debugCodes.h"
 #include "pxr/imaging/rprUsd/tokens.h"
 
+#include "pxr/imaging/rprUsd/lightRegistry.h"
+
 #include "pxr/base/tf/envSetting.h"
 #include "pxr/base/gf/rotation.h"
 #include "pxr/base/gf/matrix4d.h"
@@ -427,6 +429,7 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
         }
 
         bool newLight = false;
+        rpr::Light* lightPtr = nullptr;
         auto iesFile = HdRpr_GetParam(sceneDelegate, id, USD_LUX_TOKEN_SHAPING_IES_FILE);
         if (iesFile.IsHolding<SdfAssetPath>()) {
             auto& path = iesFile.UncheckedGet<SdfAssetPath>();
@@ -434,6 +437,7 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
                 if (auto light = rprApi->CreateIESLight(path.GetResolvedPath())) {
                     m_light = light;
                     newLight = true;
+                    lightPtr = light;
                 }
             }
         } else {
@@ -443,11 +447,13 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
                 if (auto light = rprApi->CreateSpotLight(coneAngle.UncheckedGet<float>(), coneSoftness.UncheckedGet<float>())) {
                     m_light = light;
                     newLight = true;
+                    lightPtr = light;
                 }
             } else if (HdRpr_GetParam(sceneDelegate, id, UsdLuxTokens->treatAsPoint).GetWithDefault(false)) {
                 if (auto light = rprApi->CreatePointLight()) {
                     m_light = light;
                     newLight = true;
+                    lightPtr = light;
                 }
             } else {
                 if (rprApi->IsSphereAndDiskLightSupported() &&
@@ -460,6 +466,7 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
 
                             m_light = light;
                             newLight = true;
+                            lightPtr = light;
                         }
                     } else {
                         if (auto light = rprApi->CreateDiskLight()) {
@@ -468,6 +475,7 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
 
                             m_light = light;
                             newLight = true;
+                            lightPtr = light;
                         }
                     }
 
@@ -510,6 +518,10 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
         if (newLight && RprUsdIsLeakCheckEnabled()) {
             BOOST_NS::apply_visitor(LightNameSetter{rprApi, id.GetText()}, m_light);
         }
+
+        if (newLight) {
+            RprUsdLightRegistry::Register(id, lightPtr);
+        }
     }
 
     if (bits & (DirtyTransform | DirtyParams)) {
@@ -544,6 +556,7 @@ struct HdRprLight::LightReleaser : public BOOST_NS::static_visitor<> {
 };
 
 void HdRprLight::ReleaseLight(HdRprApi* rprApi) {
+    RprUsdLightRegistry::Release(GetId());
     BOOST_NS::apply_visitor(LightReleaser{rprApi}, m_light);
     m_light = LightVariantEmpty{};
 }

--- a/pxr/imaging/rprUsd/CMakeLists.txt
+++ b/pxr/imaging/rprUsd/CMakeLists.txt
@@ -124,6 +124,7 @@ pxr_library(rprUsd
         material
         materialMappings
         materialRegistry
+        lightRegistry
 
     PUBLIC_HEADERS
         contextMetadata.h

--- a/pxr/imaging/rprUsd/lightRegistry.cpp
+++ b/pxr/imaging/rprUsd/lightRegistry.cpp
@@ -21,7 +21,13 @@ TF_INSTANTIATE_SINGLETON(RprUsdLightRegistry);
 
 void RprUsdLightRegistry::Register(const SdfPath& id, rpr::Light* light) {
     RprUsdLightRegistry& self = RprUsdLightRegistry::GetInstance();
-    self.m_Registry.insert_or_assign(id.GetString(), light);
+    auto rit = self.m_Registry.find(id.GetString());
+    if (rit != self.m_Registry.end()) {
+        (*rit).second = light;
+    }
+    else {
+        self.m_Registry.emplace(id.GetString(), light);
+    }
     
     auto cit = self.m_Clients.find(id.GetString());
     if (cit != self.m_Clients.end()) {
@@ -53,12 +59,18 @@ rpr::Light* RprUsdLightRegistry::Get(const std::string& id, std::function<void(r
     if (cit != self.m_Clients.end())
     {
         auto clientsAndCallbacks = (*cit).second;
-        clientsAndCallbacks.insert_or_assign(client, callback);
+        auto cbit = clientsAndCallbacks.find(client);
+        if (cbit != clientsAndCallbacks.end()) {
+            (*cbit).second = callback;
+        }
+        else {
+            clientsAndCallbacks.emplace(client, callback);
+        }
     }
     else {
         std::map<void*, std::function<void(rpr::Light*)>> clientsAndCallbacks;
-        clientsAndCallbacks.insert_or_assign(client, callback);
-        self.m_Clients.insert_or_assign(id, clientsAndCallbacks);
+        clientsAndCallbacks.emplace(client, callback);
+        self.m_Clients.emplace(id, clientsAndCallbacks);
     }
 
     auto rit = self.m_Registry.find(id);

--- a/pxr/imaging/rprUsd/lightRegistry.cpp
+++ b/pxr/imaging/rprUsd/lightRegistry.cpp
@@ -1,0 +1,86 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#include "lightRegistry.h"
+#include "pxr/base/tf/instantiateSingleton.h"
+#include <RadeonProRender.hpp>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_INSTANTIATE_SINGLETON(RprUsdLightRegistry);
+
+void RprUsdLightRegistry::Register(const SdfPath& id, rpr::Light* light) {
+    RprUsdLightRegistry& self = RprUsdLightRegistry::GetInstance();
+    self.m_Registry.insert_or_assign(id.GetString(), light);
+    
+    auto cit = self.m_Clients.find(id.GetString());
+    if (cit != self.m_Clients.end()) {
+        for (const auto& clientAndCallback : (*cit).second) {
+            clientAndCallback.second(light);
+        }
+    }
+}
+
+void RprUsdLightRegistry::Release(const SdfPath& id) {
+    RprUsdLightRegistry& self = RprUsdLightRegistry::GetInstance();
+    auto rit = self.m_Registry.find(id.GetString());
+    if (rit != self.m_Registry.end()) {
+        self.m_Registry.erase(rit);
+    }
+
+    auto cit = self.m_Clients.find(id.GetString());
+    if (cit != self.m_Clients.end()) {
+        for (const auto& clientAndCallback : (*cit).second) {
+            clientAndCallback.second(nullptr);
+        }
+    }
+}
+
+rpr::Light* RprUsdLightRegistry::Get(const std::string& id, std::function<void(rpr::Light*)> callback, void* client) {
+    RprUsdLightRegistry& self = RprUsdLightRegistry::GetInstance();
+
+    auto cit = self.m_Clients.find(id);
+    if (cit != self.m_Clients.end())
+    {
+        auto clientsAndCallbacks = (*cit).second;
+        clientsAndCallbacks.insert_or_assign(client, callback);
+    }
+    else {
+        std::map<void*, std::function<void(rpr::Light*)>> clientsAndCallbacks;
+        clientsAndCallbacks.insert_or_assign(client, callback);
+        self.m_Clients.insert_or_assign(id, clientsAndCallbacks);
+    }
+
+    auto rit = self.m_Registry.find(id);
+    return (rit != self.m_Registry.end()) ? (*rit).second : nullptr;
+}
+
+void RprUsdLightRegistry::ReleaseClient(void* client) {
+    RprUsdLightRegistry& self = RprUsdLightRegistry::GetInstance();
+    for (auto cit = self.m_Clients.begin(); cit != self.m_Clients.end(); ) {
+        auto clientsAndCallbacks = (*cit).second;
+        auto it = clientsAndCallbacks.find(client);
+        if (it != clientsAndCallbacks.end()) {
+            clientsAndCallbacks.erase(it);
+        }
+        
+        if (clientsAndCallbacks.empty()) {
+            cit = self.m_Clients.erase(cit);
+        }
+        else {
+            ++cit;
+        }
+    }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/lightRegistry.h
+++ b/pxr/imaging/rprUsd/lightRegistry.h
@@ -1,0 +1,63 @@
+/************************************************************************
+Copyright 2020 Advanced Micro Devices, Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+************************************************************************/
+
+#ifndef RPRUSD_LIGHT_REGISTRY_H
+#define RPRUSD_LIGHT_REGISTRY_H
+
+#include <map>
+#include <functional>
+#include "pxr/base/tf/singleton.h"
+#include "pxr/usd/sdf/path.h"
+#include "pxr/imaging/rprUsd/api.h"
+
+namespace rpr {
+    class Light;
+}
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// \class RprUsdLightRegistry
+///
+/// Stores connection between lights in the scene and their USD paths
+/// Also stores callbacks to update its clients when the light is changed
+///
+class RprUsdLightRegistry {
+public:
+    RPRUSD_API
+    static void Register(const SdfPath& id, rpr::Light* light);
+
+    RPRUSD_API
+    static void Release(const SdfPath& id);
+
+    static rpr::Light* Get(const std::string& id, std::function<void(rpr::Light*)> callback, void* client);
+    static void ReleaseClient(void* client);
+private:
+    RprUsdLightRegistry() = default;
+    ~RprUsdLightRegistry() = default;
+    RprUsdLightRegistry(RprUsdLightRegistry const&) = delete;
+    RprUsdLightRegistry& operator=(RprUsdLightRegistry const&) = delete;
+    RprUsdLightRegistry(RprUsdLightRegistry&&) = delete;
+    RprUsdLightRegistry& operator=(RprUsdLightRegistry&&) = delete;
+
+    static RprUsdLightRegistry& GetInstance() {
+        return TfSingleton<RprUsdLightRegistry>::GetInstance();
+    }
+
+    std::map<std::string, rpr::Light*> m_Registry;                                      // Light path / pointer to the light
+    std::map<std::string, std::map<void*, std::function<void(rpr::Light*)>>> m_Clients; // Light path / (client / light update callback)
+    friend class TfSingleton<RprUsdLightRegistry>;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // RPRUSD_MATERIAL_REGISTRY_H

--- a/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 #include "nodeInfo.h"
 
 #include "pxr/imaging/rprUsd/materialHelpers.h"
+#include "pxr/imaging/rprUsd/lightRegistry.h"
 #include "pxr/base/arch/attributes.h"
 #include "pxr/base/gf/vec3f.h"
 
@@ -50,6 +51,12 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (interpolationMode)
     (Linear)
     (None)
+
+    (albedoMode)
+    (BaseColor)
+    (MidColor)
+
+    (light)
 );
 
 template <typename ExpectedType, typename SmartPtr>
@@ -87,7 +94,9 @@ public:
 
         m_rprContext = ctx->rprContext;
     }
-    ~RprUsd_RprToonNode() override = default;
+    ~RprUsd_RprToonNode() override {
+        RprUsdLightRegistry::ReleaseClient(this);
+    }
 
     VtValue GetOutput(TfToken const& outputId) override {
         if (m_blendNode) {
@@ -160,6 +169,28 @@ public:
             TF_RUNTIME_ERROR("Input `%s` has invalid type: %s, expected - `float`", id.GetText(), value.GetTypeName().c_str());
             return false;
         }
+        else if (id == _tokens->albedoMode) {
+            if (value.IsHolding<int>()) {
+                int albedoMode = value.UncheckedGet<int>();
+                return m_toonClosureNode->SetInput(RPR_MATERIAL_INPUT_MID_IS_ALBEDO, albedoMode) == RPR_SUCCESS;
+            }
+            TF_RUNTIME_ERROR("Input `%s` has invalid type: %s, expected - `int`", id.GetText(), value.GetTypeName().c_str());
+            return false;
+        }
+        else if (id == _tokens->light) {
+            if (value.IsHolding<std::string>()) {
+                std::weak_ptr<rpr::MaterialNode> toonClosureNodeWptr = m_toonClosureNode;
+                auto lightUpdateCallback = [toonClosureNodeWptr](rpr::Light* light) {
+                    std::shared_ptr<rpr::MaterialNode> toonClosureNode = toonClosureNodeWptr.lock();
+                    if (toonClosureNode) {
+                        toonClosureNode->SetInput(RPR_MATERIAL_INPUT_LIGHT, light);
+                    }
+                };
+                rpr::Light* light = RprUsdLightRegistry::Get(value.UncheckedGet<std::string>(), lightUpdateCallback, this);
+                return m_toonClosureNode->SetInput(RPR_MATERIAL_INPUT_LIGHT, light) == RPR_SUCCESS;
+            }
+            return true;    // possibly empty string
+        }
 
         TF_RUNTIME_ERROR("Unknown input `%s` for RPR Toon node", id.GetText());
         return false;
@@ -230,6 +261,17 @@ public:
         nodeInfo.inputs.emplace_back(_tokens->roughness, 1.0f);
         nodeInfo.inputs.emplace_back(_tokens->normal, GfVec3f(0.0f), RprUsdMaterialNodeElement::kVector3, "");
 
+        RprUsd_RprNodeInput albedoModeInput(_tokens->albedoMode, _tokens->BaseColor);
+        albedoModeInput.value = VtValue(0);
+        albedoModeInput.tokenValues = { _tokens->BaseColor, _tokens->MidColor };
+        nodeInfo.inputs.push_back(albedoModeInput);
+
+        RprUsd_RprNodeInput lightInput(RprUsdMaterialNodeElement::kString);
+        lightInput.name = _tokens->light;
+        lightInput.uiName = "light";
+        lightInput.valueString = "";
+        nodeInfo.inputs.push_back(lightInput);
+        
         RprUsd_RprNodeOutput output(RprUsdMaterialNodeElement::kSurfaceShader);
         output.name = "surface";
         nodeInfo.outputs.push_back(output);

--- a/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/toonNode.cpp
@@ -268,7 +268,7 @@ public:
 
         RprUsd_RprNodeInput lightInput(RprUsdMaterialNodeElement::kString);
         lightInput.name = _tokens->light;
-        lightInput.uiName = "light";
+        lightInput.uiName = "LinkedLight";
         lightInput.valueString = "";
         nodeInfo.inputs.push_back(lightInput);
         


### PR DESCRIPTION
### PURPOSE
Implemented flag to use mid color as albedo
Implemented toon light link setting
Resolves: https://amdrender.atlassian.net/browse/RPRHOUD-35

(Transparency and 5 colors setting are already implemented)

### EFFECT OF CHANGE
AlbedoMode setting, mid color used for albedo when selected
LinkedLight setting, when entered light path, it used for shader

### TECHNICAL STEPS
To have a connection between light objects and their path in the scene I dad to add a LightRegistry singleton class. HdRprLight updates it when light is synced/deleted. When a path to the light becomes updated in the toon shader it requests a pointer to the light by its path from the LightRegistry. It also passes a callback, wich updates toon closure node when the light changes.
