### PR TITLE
Make a fix for vertex color in geomsubset

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -576,7 +576,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
 
                         if (!m_colorSamples.empty()) {
                             if (newPoint) {
-                                for (int sampleIndex = 0; sampleIndex < m_uvSamples.size(); ++sampleIndex) {
+                                for (int sampleIndex = 0; sampleIndex < m_colorSamples.size(); ++sampleIndex) {
                                     subsetColorSamples[sampleIndex].push_back(m_colorSamples[sampleIndex][pointIndex]);
                                 }
                             }


### PR DESCRIPTION
WHAT:
There was a typo in vertex color assignment for geomsubset case. This is just a fix for typo
