### PR TITLE
IES light direction adjustment

### DIFF
--- a/pxr/imaging/plugin/hdRpr/light.cpp
+++ b/pxr/imaging/plugin/hdRpr/light.cpp
@@ -432,6 +432,7 @@ void HdRprLight::Sync(HdSceneDelegate* sceneDelegate,
             auto& path = iesFile.UncheckedGet<SdfAssetPath>();
             if (!path.GetResolvedPath().empty()) {
                 if (auto light = rprApi->CreateIESLight(path.GetResolvedPath())) {
+                    m_localTransform *= GfMatrix4f(1.0).SetRotate(GfRotation(GfVec3d(1, 0, 0), 90));
                     m_light = light;
                     newLight = true;
                 }


### PR DESCRIPTION
### PURPOSE
Resolves https://amdrender.atlassian.net/browse/RPRHOUD-39
IES profile direction used Y-direction, changed to Z-direction by prim rotation

