### PR TITLE
Add version info to package

### DIFF
--- a/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp
+++ b/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp
@@ -1,13 +1,31 @@
 #include "houdiniPluginActivator.cpp"
 
 int main() {
+    // Get version name from 
+    std::ifstream versionFile("version");
+    std::string coreVersion;
+    std::string pluginVersion;
+    const char* version = nullptr;
+
+    if (versionFile.is_open()) {
+        /* This file contains two strings like
+        core:<core version>
+        plugin:<plugin version>
+        */
+        versionFile >> coreVersion;
+        versionFile >> pluginVersion;
+        std::string findString = "plugin:";
+        pluginVersion = pluginVersion.substr(pluginVersion.find(findString) + findString.length(), pluginVersion.length() - findString.length());
+        version = pluginVersion.c_str();
+    }
+    
     int exitCode = ActivateHoudiniPlugin("RPR_for_Houdini", {
         {"HOUDINI_PATH", "/houdini"},
         {"PYTHONPATH", "/lib/python"},
 #if defined(_WIN32) || defined(_WIN64)
         {"PATH", "/lib"}
 #endif
-    });
+    }, version);
 
 #if defined(_WIN32) || defined(_WIN64)
     system("pause");

--- a/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp
+++ b/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp
@@ -17,6 +17,7 @@ int main() {
         std::string findString = "plugin:";
         pluginVersion = pluginVersion.substr(findString.length(), pluginVersion.length() - findString.length());
         version = pluginVersion.c_str();
+        versionFile.close();
     }
     
     int exitCode = ActivateHoudiniPlugin("RPR_for_Houdini", {

--- a/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp
+++ b/pxr/imaging/plugin/rprHoudini/activateHoudiniPlugin.cpp
@@ -15,7 +15,7 @@ int main() {
         versionFile >> coreVersion;
         versionFile >> pluginVersion;
         std::string findString = "plugin:";
-        pluginVersion = pluginVersion.substr(pluginVersion.find(findString) + findString.length(), pluginVersion.length() - findString.length());
+        pluginVersion = pluginVersion.substr(findString.length(), pluginVersion.length() - findString.length());
         version = pluginVersion.c_str();
     }
     

--- a/pxr/imaging/plugin/rprHoudini/houdiniPluginActivator.cpp.in
+++ b/pxr/imaging/plugin/rprHoudini/houdiniPluginActivator.cpp.in
@@ -305,7 +305,7 @@ fs::path GetLopScriptsDir(const char* hver) {
     return scriptsPath;
 }
 
-int ActivateHoudiniPlugin(std::string const& pluginName, std::vector<std::pair<const char*, const char*>> const& env) {
+int ActivateHoudiniPlugin(std::string const& pluginName, std::vector<std::pair<const char*, const char*>> const& env, const char* version=nullptr) {
     auto houdiniUserPrefDir = GetHoudiniUserPrefDir("@HOUDINI_MAJOR_MINOR_VERSION@");
     if (houdiniUserPrefDir.empty()) {
         std::cout << "Can not determine HOUDINI_USER_PREF_DIR. Please check your environment and specify HOUDINI_USER_PREF_DIR" << std::endl;
@@ -334,6 +334,12 @@ int ActivateHoudiniPlugin(std::string const& pluginName, std::vector<std::pair<c
     }
 
     packageJson << '{';
+	if(version) {
+		packageJson << '\"' << "version" << '\"';
+		packageJson << ':';
+		packageJson << '\"' << version << '\"';
+		packageJson << ',';
+	}
     packageJson << '\"' << "env" << '\"';
     packageJson << ':';
     packageJson << '[';


### PR DESCRIPTION
### WHY
Plugin package for Houdini does not contain version info

### WHAT
Now version info added to package metadata

### HOW
Information is being copied from version file during installation