### PR TITLE
Points material override

### DIFF
--- a/pxr/imaging/plugin/hdRpr/points.cpp
+++ b/pxr/imaging/plugin/hdRpr/points.cpp
@@ -153,7 +153,7 @@ void HdRprPoints::Sync(
             auto& topology = UsdImagingGetUnitSphereMeshTopology();
             auto& points = UsdImagingGetUnitSphereMeshPoints();
 
-            m_prototypeMesh = rprApi->CreateMesh(points, topology.GetFaceVertexIndices(), VtVec3fArray(), VtIntArray(), VtVec2fArray(), VtIntArray(), topology.GetFaceVertexCounts(), topology.GetOrientation());
+            m_prototypeMesh = rprApi->CreateMesh(points, topology.GetFaceVertexIndices(), points, topology.GetFaceVertexIndices(), VtVec2fArray(), VtIntArray(), topology.GetFaceVertexCounts(), topology.GetOrientation());
             rprApi->SetMeshVisibility(m_prototypeMesh, kInvisible);
             rprApi->SetMeshRefineLevel(m_prototypeMesh, m_subdivisionLevel);
 

--- a/pxr/imaging/plugin/hdRpr/points.cpp
+++ b/pxr/imaging/plugin/hdRpr/points.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 #include "rprApi.h"
 #include "primvarUtil.h"
 #include "renderParam.h"
+#include "material.h"
 
 #include "pxr/imaging/rprUsd/debugCodes.h"
 #include "pxr/imaging/hd/extComputationUtils.h"
@@ -23,7 +24,7 @@ limitations under the License.
 PXR_NAMESPACE_OPEN_SCOPE
 
 HdRprPoints::HdRprPoints(SdfPath const& id HDRPR_INSTANCER_ID_ARG_DECL)
-    : HdPoints(id HDRPR_INSTANCER_ID_ARG)
+    : HdRprBaseRprim(id HDRPR_INSTANCER_ID_ARG)
     , m_visibilityMask(kVisibleAll)
     , m_subdivisionLevel(0) {
 
@@ -79,6 +80,12 @@ void HdRprPoints::Sync(
             TF_WARN("[%s] Points does not have widths. Fallback value is 1.0f with a constant interpolation", id.GetText());
         }
     }
+
+    // By some undefined reason *dirtyBits & HdChangeTracker::DirtyMaterialId does not work for points. Then we need to track changes ourself
+    auto oldMaterialId = m_materialId;
+    UpdateMaterialId(sceneDelegate, rprRenderParam);
+    bool dirtyMaterialOverride = oldMaterialId != m_materialId;
+    bool materialOverrideExists = !m_materialId.IsEmpty();
 
     bool dirtyDisplayColors = HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->displayColor);
     if (dirtyDisplayColors) {
@@ -208,9 +215,19 @@ void HdRprPoints::Sync(
             }
         }
 
-        if (dirtyDisplayColors || dirtyInstances) {
+        if (!materialOverrideExists && (dirtyDisplayColors || dirtyInstances)) {
             for (size_t i = 0; i < m_instances.size(); ++i) {
                 rprApi->SetMeshMaterial(m_instances[i], m_material, false);
+            }
+        }
+        else if (materialOverrideExists && (dirtyMaterialOverride || dirtyInstances)) {
+            auto material = static_cast<const HdRprMaterial*>(
+                sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, m_materialId));
+
+            if (material && material->GetRprMaterialObject()) {
+                for (size_t i = 0; i < m_instances.size(); ++i) {
+                    rprApi->SetMeshMaterial(m_instances[i], material->GetRprMaterialObject(), false);
+                }
             }
         }
 

--- a/pxr/imaging/plugin/hdRpr/points.h
+++ b/pxr/imaging/plugin/hdRpr/points.h
@@ -15,6 +15,7 @@ limitations under the License.
 #define HDRPR_POINTS_H
 
 #include "renderDelegate.h"
+#include "baseRprim.h"
 
 #include "pxr/imaging/hd/points.h"
 
@@ -26,7 +27,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class RprUsdMaterial;
 
-class HdRprPoints : public HdPoints {
+class HdRprPoints : public HdRprBaseRprim<HdPoints> {
 public:
     HdRprPoints(SdfPath const& id HDRPR_INSTANCER_ID_ARG_DECL);
 


### PR DESCRIPTION
### WHY
In hdRPR Points objects does not support applying materials

### WHAT
Nowoverride of default material can be applied to points, also normals had been added to make sphere surfase more round