### PR TITLE
Replace multiple calls to AOVIndicesLookup

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -3587,7 +3587,7 @@ private:
 
         if (!RprUsdIsTracingEnabled()) {
             // We need it for correct rendering of ID AOVs (e.g. RPR_AOV_OBJECT_ID)
-            // XXX: only up to 2^16 indices, internal LUT limit. Each index is set as 4 float values
+            // XXX: only up to 2^16 indices, internal LUT limit
             std::vector<GfVec4f> values;
             values.reserve(1 << 16);
             for (uint32_t i = 0; i < (1 << 16); ++i) {
@@ -3601,7 +3601,7 @@ private:
                     float(((i + 1) >> 8) & 0xFF) / 255.0f,
                     0.0f, 0.0f));
             }
-            m_rprContext->SetAOVindicesLookup(0, (1 << 16), (float*)values.data());
+            m_rprContext->SetAOVindicesLookup(0, (1 << 16), (float*) values.data());
         }
 
         m_imageCache.reset(new RprUsdImageCache(m_rprContext.get()));

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -3587,20 +3587,21 @@ private:
 
         if (!RprUsdIsTracingEnabled()) {
             // We need it for correct rendering of ID AOVs (e.g. RPR_AOV_OBJECT_ID)
-            // XXX: it takes approximately 32ms due to RPR API indirection,
-            //      replace with rprContextSetAOVindexLookupRange when ready
-            // XXX: only up to 2^16 indices, internal LUT limit
+            // XXX: only up to 2^16 indices, internal LUT limit. Each index is set as 4 float values
+            std::vector<GfVec4f> values;
+            values.reserve(1 << 16);
             for (uint32_t i = 0; i < (1 << 16); ++i) {
                 // Split uint32_t into 4 float values - every 8 bits correspond to one float.
                 // Such an encoding scheme simplifies the conversion of RPR ID texture (float4) to the int32 texture (as required by Hydra).
                 // Conversion is currently implemented like this:
                 //   * convert float4 texture to uchar4 using RIF
                 //   * reinterpret uchar4 data as int32_t (works on little-endian CPU only)
-                m_rprContext->SetAOVindexLookup(rpr_int(i),
-                    float(((i + 1) >> 0) & 0xFF) / 255.0f,
+                values.push_back(GfVec4f(
+                    float(((i + 1) >> 0) & 0xFF) / 255.0f, 
                     float(((i + 1) >> 8) & 0xFF) / 255.0f,
-                    0.0f, 0.0f);
+                    0.0f, 0.0f));
             }
+            m_rprContext->SetAOVindicesLookup(0, (1 << 16), (float*)values.data());
         }
 
         m_imageCache.reset(new RprUsdImageCache(m_rprContext.get()));


### PR DESCRIPTION
### WHY
rprContextSetAOVindicesLookup function is faster than rprContextSetAOVindexLookup

### WHAT
Now rprContextSetAOVindexLookup is replaced with rprContextSetAOVindicesLookup. We can use single call to set up all index colors.
