### PR TITLE
usdview build quickfix

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rendererPlugin.h
+++ b/pxr/imaging/plugin/hdRpr/rendererPlugin.h
@@ -32,7 +32,7 @@ public:
 
     void DeleteRenderDelegate(HdRenderDelegate* renderDelegate) override;
 
-    bool IsSupported() const override { return true; }
+    bool IsSupported() const { return true; }
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### PURPOSE
IsSupported() function was removed in USD 23.02
removed override specifier to avoid build error