### PR TITLE
Restore mtlx string loading

### DIFF
--- a/pxr/imaging/plugin/hdRpr/rendererPlugin.h
+++ b/pxr/imaging/plugin/hdRpr/rendererPlugin.h
@@ -32,7 +32,7 @@ public:
 
     void DeleteRenderDelegate(HdRenderDelegate* renderDelegate) override;
 
-    bool IsSupported() const override { return true; }
+    bool IsSupported() const { return true; }
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rendererPlugin.h
+++ b/pxr/imaging/plugin/hdRpr/rendererPlugin.h
@@ -32,7 +32,11 @@ public:
 
     void DeleteRenderDelegate(HdRenderDelegate* renderDelegate) override;
 
-    bool IsSupported() const { return true; }
+#if PXR_VERSION < 2302
+    bool IsSupported() const override { return true; }
+#else
+    bool IsSupported(bool gpuEnabled = true) const override { return true; }
+#endif
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rendererPlugin.h
+++ b/pxr/imaging/plugin/hdRpr/rendererPlugin.h
@@ -32,11 +32,7 @@ public:
 
     void DeleteRenderDelegate(HdRenderDelegate* renderDelegate) override;
 
-#if PXR_VERSION < 2302
     bool IsSupported() const override { return true; }
-#else
-    bool IsSupported(bool gpuEnabled = true) const override { return true; }
-#endif
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.cpp
+++ b/pxr/imaging/rprUsd/materialNodes/rprApiMtlxNode.cpp
@@ -32,33 +32,11 @@ rpr::MaterialNode* RprUsd_CreateRprMtlxFromString(std::string const& mtlxString,
 
     rpr_material_node matxNodeHandle = rpr::GetRprObject(matxNode.get());
 
-    // TODO: use rprMaterialXSetFileAsBuffer when fixed in HybridPro
-    /*status = rprMaterialXSetFileAsBuffer(matxNodeHandle, mtlxString.c_str(), mtlxString.size());
+    status = rprMaterialXSetFileAsBuffer(matxNodeHandle, mtlxString.c_str(), mtlxString.size());
     
     if (status != RPR_SUCCESS) {
         RPR_ERROR_CHECK(status, "Failed to set matx node file from buffer");
         return nullptr;
-    }
-    */
-
-    // For now, as we have only rprMaterialXSetFile working, create a temporary file
-    {
-        std::string temporaryFilePath = ArchMakeTmpFileName("tmpMaterial", ".mtlx");
-
-        FILE* fout = fopen(temporaryFilePath.c_str(), "w");
-        if (!fout) {
-            return nullptr;
-        }
-
-        fwrite(mtlxString.c_str(), 1, mtlxString.size(), fout);
-        fclose(fout);
-
-        status = rprMaterialXSetFile(matxNodeHandle, temporaryFilePath.c_str());
-        if (status != RPR_SUCCESS) {
-            RPR_ERROR_CHECK(status, "Failed to set matx node file");
-            ArchUnlinkFile(temporaryFilePath.c_str());
-            return nullptr;
-        }
     }
 
     return matxNode.release();


### PR DESCRIPTION
### WHY
In latest Hybrid Pro release loading materialx as string was fixed

### WHAT
This PR enables loading materialX as string without temp files

