### PR TITLE
toon shader linking with distant and environment lights

### DIFF
--- a/pxr/imaging/plugin/hdRpr/distantLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/distantLight.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "rprApi.h"
 
 #include "pxr/imaging/rprUsd/debugCodes.h"
+#include "pxr/imaging/rprUsd/lightRegistry.h"
 #include "pxr/imaging/hd/light.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
 #include "pxr/usd/usdLux/blackbody.h"
@@ -93,6 +94,7 @@ void HdRprDistantLight::Sync(HdSceneDelegate* sceneDelegate,
         rprApi->SetDirectionalLightAttributes(m_rprLight, color * computedIntensity, angle * (M_PI / 180.0));
 
         newLight = true;
+        RprUsdLightRegistry::Register(id, m_rprLight);
     }
 
     if (newLight || ((bits & HdLight::DirtyTransform) && m_rprLight)) {
@@ -109,6 +111,7 @@ HdDirtyBits HdRprDistantLight::GetInitialDirtyBitsMask() const {
 
 void HdRprDistantLight::Finalize(HdRenderParam* renderParam) {
     if (m_rprLight) {
+        RprUsdLightRegistry::Release(GetId());
         auto rprRenderParam = static_cast<HdRprRenderParam*>(renderParam);
         rprRenderParam->AcquireRprApiForEdit()->Release(m_rprLight);
         m_rprLight = nullptr;

--- a/pxr/imaging/plugin/hdRpr/domeLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/domeLight.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "pxr/imaging/rprUsd/debugCodes.h"
 #include "pxr/imaging/rprUsd/tokens.h"
+#include "pxr/imaging/rprUsd/lightRegistry.h"
 
 #include "pxr/usd/ar/resolver.h"
 #include "pxr/imaging/hd/light.h"
@@ -177,6 +178,7 @@ void HdRprDomeLight::Sync(HdSceneDelegate* sceneDelegate,
             if (RprUsdIsLeakCheckEnabled()) {
                 rprApi->SetName(m_rprLight, id.GetText());
             }
+            RprUsdLightRegistry::Register(id, GetLightObject(m_rprLight));
         }
     }
 
@@ -195,6 +197,7 @@ void HdRprDomeLight::Finalize(HdRenderParam* renderParam) {
     auto rprRenderParam = static_cast<HdRprRenderParam*>(renderParam);
     
     if (m_rprLight) {
+        RprUsdLightRegistry::Release(GetId());
         rprRenderParam->AcquireRprApiForEdit()->Release(m_rprLight);
         m_rprLight = nullptr;
     }

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -4734,4 +4734,8 @@ float HdRprApi::GetFirstIterationRenerTime() const {
     return m_impl->GetFirstIterationRenerTime();
 }
 
+rpr::EnvironmentLight* GetLightObject(HdRprApiEnvironmentLight* envLight) {
+    return envLight->light.get();
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -184,6 +184,8 @@ private:
     HdRprApiImpl* m_impl = nullptr;
 };
 
+rpr::EnvironmentLight* GetLightObject(HdRprApiEnvironmentLight* envLight);
+
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif // HDRPR_RPR_API_H


### PR DESCRIPTION
### PURPOSE
added missing support for distant and environment lights
Resolves https://amdrender.atlassian.net/browse/RPRHOUD-50