### PR TITLE
IMath is required for bulding hdRPR against USD in maya 2024

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -162,7 +162,7 @@ endmacro()
 if (NOT MAYAUSD_OPENEXR_STATIC)
     find_exr(Half IlmImf Iex)
 else()
-    find_exr(Half IlmImf Iex IlmThread zlib)
+    find_exr(Half IlmImf Iex IlmThread zlib IMath)
 endif()
 
 set(RPR_EXR_EXPORT_ENABLED TRUE)


### PR DESCRIPTION
### PURPOSE
IMath lib is required for hdRPR built against Maya 2024.
So we need just add it to cmake scripts

