### PR TITLE
MaterialX crash fix

### DIFF
--- a/pxr/imaging/rprUsd/hdMtlxFixed.cpp
+++ b/pxr/imaging/rprUsd/hdMtlxFixed.cpp
@@ -301,6 +301,10 @@ _GatherUpstreamNodes(
                                  addedNodeNames, mxUpstreamNode, hdTextureNodes, 
                                  connName.GetString(), mxHdTextureMap);
 
+            if (!(*mxUpstreamNode)) {
+                continue;
+            }
+
             // Connect mxCurrNode to the mxUpstreamNode
             mx::NodePtr mxNextNode = *mxUpstreamNode;
 


### PR DESCRIPTION
### PURPOSE
I encountered a crash on some scenes inside hdRPR. Its related to how materialx nodes gets processed.

### TECHNICAL STEPS
I added a nullptr check to avoid a crash.

