### PR TITLE
sync and cache time

### DIFF
--- a/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderDelegate.cpp
@@ -351,6 +351,13 @@ HdRenderSettingDescriptorList HdRprDelegate::GetRenderSettingDescriptors() const
     return m_settingDescriptors;
 }
 
+std::string join(const std::vector<std::string>& vec, const std::string& delim)
+{
+    std::stringstream res;
+    copy(vec.begin(), vec.end(), std::ostream_iterator<std::string>(res, delim.c_str()));
+    return res.str();
+}
+
 VtDictionary HdRprDelegate::GetRenderStats() const {
     auto rprStats = m_rprApi->GetRenderStats();
 
@@ -359,7 +366,7 @@ VtDictionary HdRprDelegate::GetRenderStats() const {
     stats["averageRenderTimePerSample"] = rprStats.averageRenderTimePerSample;
     stats["averageResolveTimePerSample"] = rprStats.averageResolveTimePerSample;
 
-    stats["gpuUsedNames"] = m_rprApi->GetGpuUsedNames();
+    stats["gpuUsedNames"] = join(m_rprApi->GetGpuUsedNames(), ", ");
     stats["threadCountUsed"] = m_rprApi->GetCpuThreadCountUsed();
 
     stats["firstIterationRenderTime"] = m_rprApi->GetFirstIterationRenerTime();
@@ -368,6 +375,9 @@ VtDictionary HdRprDelegate::GetRenderStats() const {
     stats["frameRenderTotalTime"] = rprStats.frameRenderTotalTime;
     stats["frameResolveTotalTime"] = rprStats.frameResolveTotalTime;
     
+    stats["cacheCreationTime"] = rprStats.cacheCreationTime;
+    stats["syncTime"] = rprStats.syncTime;
+
     return stats;
 }
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -3353,7 +3353,7 @@ Don't show this message again?
     }
 
     void updateSyncTime() {
-        if (m_syncStartTime != std::chrono::steady_clock::time_point() && m_syncTime == Duration()) {
+        if (m_syncStartTime != std::chrono::high_resolution_clock::time_point() && m_syncTime == Duration()) {
             m_syncTime = std::chrono::high_resolution_clock::now().time_since_epoch() - m_syncStartTime.time_since_epoch();
         }
     }
@@ -4429,8 +4429,8 @@ private:
     using Duration = std::chrono::high_resolution_clock::duration;
     Duration m_frameRenderTotalTime;
     Duration m_frameResolveTotalTime;
-    std::chrono::steady_clock::time_point m_startTime = {};
-    std::chrono::steady_clock::time_point m_syncStartTime = {};
+    std::chrono::high_resolution_clock::time_point m_startTime = {};
+    std::chrono::high_resolution_clock::time_point m_syncStartTime = {};
     Duration m_syncTime;
     Duration m_cacheCreationTime;
     bool m_cacheCreationRequired = false;

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -160,6 +160,8 @@ public:
         double totalRenderTime;
         double frameRenderTotalTime;
         double frameResolveTotalTime;
+        double cacheCreationTime;
+        double syncTime;
     };
     RenderStats GetRenderStats() const;
 


### PR DESCRIPTION
### PURPOSE
Resolves: https://amdrender.atlassian.net/browse/RPRUS-158

Cache creation time is considered as the first render iteration time when the cache does not exist on renderer initialization. The iteration time is negligible in this case.
Sync time is considered as the time between the first call of sync and the renderer start.