### PR TITLE
emission mode fix

### DIFF
--- a/pxr/imaging/rprUsd/materialHelpers.h
+++ b/pxr/imaging/rprUsd/materialHelpers.h
@@ -26,12 +26,21 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 using RprMaterialNodePtr = std::shared_ptr<rpr::MaterialNode>;
 
+// Some enums may start not from zero, here we tune them manually
+inline rpr_uint TranslateEmumValue(rpr::MaterialNodeInput input, int value) {
+    switch (input) {
+    case RPR_MATERIAL_INPUT_UBER_EMISSION_MODE:
+        return value + 1;
+    default: return value;
+    }
+}
+
 inline rpr::Status SetRprInput(rpr::MaterialNode* node, rpr::MaterialNodeInput input, VtValue const& value) {
     rpr::Status status;
     if (value.IsHolding<uint32_t>()) {
         status = node->SetInput(input, value.UncheckedGet<uint32_t>());
     } else if (value.IsHolding<int>()) {
-        status = node->SetInput(input, rpr_uint(value.UncheckedGet<int>()));
+        status = node->SetInput(input, TranslateEmumValue(input, value.UncheckedGet<int>()));
     } else if (value.IsHolding<bool>()) {
         rpr_uint v = value.UncheckedGet<bool>() ? 1 : 0;
         status = node->SetInput(input, v);


### PR DESCRIPTION
### PURPOSE
Resolves https://amdrender.atlassian.net/browse/RPRUS-164

### TECHNICAL STEPS
The emission mode property setting requires 1 for single and 2 for double-sided mode; the default behavior for comboboxes/enums is to use an integer for each option starting from 0. Thus, for some inputs, the value must be tuned.