### PR TITLE
Expose Hybrid ray depth parameters

### DIFF
--- a/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
+++ b/pxr/imaging/plugin/hdRpr/python/generateRenderSettingFiles.py
@@ -331,9 +331,6 @@ render_setting_categories = [
     },
     {
         'name': 'Quality',
-        'houdini': {
-            'hidewhen': hidewhen_hybrid
-        },
         'settings': [
             {
                 'name': 'quality:rayDepth',
@@ -405,7 +402,10 @@ render_setting_categories = [
                 'help': 'Determines Pixel filter width (anti-aliasing).',
                 'defaultValue': 1.5,
                 'minValue': 0.0,
-                'maxValue': 5.0
+                'maxValue': 5.0,
+                'houdini': {
+                    'hidewhen': hidewhen_hybrid
+                }
             }
         ]
     },

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -2057,6 +2057,7 @@ public:
                 RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_MAX_DEPTH_GLOSSY, preferences.GetQualityRayDepthGlossy()), "Failed to set max depth glossy");
                 RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_MAX_DEPTH_REFRACTION, preferences.GetQualityRayDepthRefraction()), "Failed to set max depth refraction");
                 RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_MAX_DEPTH_GLOSSY_REFRACTION, preferences.GetQualityRayDepthGlossyRefraction()), "Failed to set max depth glossy refraction");
+                RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_MAX_DEPTH_SHADOW, preferences.GetQualityRayDepthShadow()), "Failed to set max depth shadow");
 
                 RPR_ERROR_CHECK(m_rprContext->SetParameter(RPR_CONTEXT_RAY_CAST_EPSILON, preferences.GetQualityRaycastEpsilon()), "Failed to set ray cast epsilon");
                 auto radianceClamp = preferences.GetQualityRadianceClamping() == 0 ? std::numeric_limits<float>::max() : preferences.GetQualityRadianceClamping();


### PR DESCRIPTION
### PURPOSE
For ticket https://amdrender.atlassian.net/jira/software/projects/RPRHOUD/boards/68?selectedIssue=RPRHOUD-63

### EFFECT OF CHANGE
Now ray depth parameters for HybridPro are available for user

