### PR TITLE
standard_surface thin_walled param hack

### DIFF
--- a/pxr/imaging/rprUsd/hdMtlxFixed.cpp
+++ b/pxr/imaging/rprUsd/hdMtlxFixed.cpp
@@ -380,12 +380,19 @@ HdMtlxCreateMtlxDocumentFromHdNetwork_Fixed(
 
         const std::string & mxInputName = currParameter.first.GetString();
         mx::InputPtr mxInput = mxShaderNode->addInput(mxInputName);
-        
+
         // Convert the parameter to the appropriate MaterialX input format
         VtValue hdParamValue = currParameter.second;
         if (hdParamValue.IsHolding<bool>()) {
             bool value = hdParamValue.UncheckedGet<bool>();
             mxInput->setValue(value);
+        }
+        // We have a trouble here: VtValue does not support ‘bool' type.
+        // There is only one input in all supported mtlx nodes that must be boolean - thin_walled in standard_surface node, 
+        // but it’s critical for HybridPro to be boolean, so here is the hack for it.
+        else if (hdMaterialXNode.nodeTypeId.GetString() == "ND_standard_surface_surfaceshader" && mxInputName == "thin_walled") {
+            int value = hdParamValue.UncheckedGet<int>();
+            mxInput->setValue(value == 1 ? true : false);
         }
         else if (hdParamValue.IsHolding<int>()) {
             int value = hdParamValue.UncheckedGet<int>();


### PR DESCRIPTION
### PURPOSE
Resolves https://amdrender.atlassian.net/browse/RPRHOUD-70

### TECHNICAL STEPS
VtValue does not support ‘bool' type, so when the materialx document for the renderer is building, boolean parameters are represented as ints. In fact, there is only one boolean input in all supported mtlx nodes - thin_walled in standard_surface, so here is an exception for it.