### PR TITLE
uber emission color intensity

### DIFF
--- a/pxr/imaging/rprUsd/materialMappings.h
+++ b/pxr/imaging/rprUsd/materialMappings.h
@@ -108,6 +108,7 @@ bool ToRpr(TfToken const& id, uint32_t* out, bool pedantic = true);
     (uber_sheen_weight) \
     (uber_emission_color) \
     (uber_emission_weight) \
+    (uber_emission_intensity) \
     (uber_emission_mode) \
     (uber_transparency) \
     (uber_sss_scatter_color) \

--- a/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Shaders/rpr_uber.mtlx
+++ b/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Shaders/rpr_uber.mtlx
@@ -46,6 +46,7 @@
 
       <input name="uber_emission_color" type="color3" value="1,1,1" uimin="0,0,0" uimax="1,1,1" uiname="Color" uifolder="Emission" doc=""/>
       <input name="uber_emission_weight" type="float" value="0.0" uimin="0.0" uisoftmax="1.0" uiname="Weight" uifolder="Emission" doc=""/>
+      <input name="uber_emission_intensity" type="float" value="1.0" uimin="0.0" uisoftmax="1.0" uiname="Intensity" uifolder="Emission" doc=""/>
       <input name="uber_emission_mode" type="string" value="Singlesided" enum="Singlesided,Doublesided" uiname="Mode" uifolder="Emission"/>
 
       <input name="uber_transparency" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Transparency" uifolder="Transparency" doc=""/>

--- a/pxr/imaging/rprUsd/materialNodes/rpr/baseNode.h
+++ b/pxr/imaging/rprUsd/materialNodes/rpr/baseNode.h
@@ -24,6 +24,8 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class UberNodeExtension;
+
 /// \class RprUsd_BaseRuntimeNode
 ///
 /// The node output of which is always rpr::MaterialNode*.
@@ -33,7 +35,7 @@ public:
         rpr::MaterialNodeType type,
         RprUsd_MaterialBuilderContext* ctx);
 
-    ~RprUsd_BaseRuntimeNode() override = default;
+    ~RprUsd_BaseRuntimeNode() override;
 
     bool SetInput(
         TfToken const& inputId,
@@ -48,6 +50,7 @@ protected:
     rpr::MaterialNodeType m_type;
     RprUsd_MaterialBuilderContext* m_ctx;
     std::shared_ptr<rpr::MaterialNode> m_rprNode;
+    std::unique_ptr<UberNodeExtension> m_extNode;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### PURPOSE
Resolves https://amdrender.atlassian.net/browse/RPRHOUD-66

### TECHNICAL STEPS
The intensity implementation is that the emission color should be multiplied by the intensity value (that's how it works in Blender plugin
To get this, BaseNode is extended with a class for the Uber node that adds an extra multiply node before the actual emission color node and redirects Uber's emission color and intensity inputs to this node.
