### PR TITLE
Restart render thread automatically after manipulations with HdRprApi

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -663,7 +663,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
         if (newMesh || (*dirtyBits & HdChangeTracker::DirtyMaterialId) ||
             (*dirtyBits & HdChangeTracker::DirtyDoubleSided) || // update twosided material node
             (*dirtyBits & HdChangeTracker::DirtyDisplayStyle) || isRefineLevelDirty) { // update displacement material
-            auto getMeshMaterial = [sceneDelegate, rprApi, dirtyBits, &primvarDescsPerInterpolation, this](SdfPath const& materialId) {
+            auto getMeshMaterial = [sceneDelegate, &rprApi, dirtyBits, &primvarDescsPerInterpolation, this](SdfPath const& materialId) {
                 auto material = static_cast<const HdRprMaterial*>(sceneDelegate->GetRenderIndex().GetSprim(HdPrimTypeTokens->material, materialId));
                 if (material && material->GetRprMaterialObject()) {
                     return material->GetRprMaterialObject();

--- a/pxr/imaging/plugin/hdRpr/renderPass.cpp
+++ b/pxr/imaging/plugin/hdRpr/renderPass.cpp
@@ -88,8 +88,8 @@ void HdRprRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState
         m_renderParam->AcquireRprApiForEdit()->SetCamera(renderPassState->GetCamera());
     }
 
-    if (rprApiConst->IsChanged() ||
-        m_renderParam->IsRenderShouldBeRestarted()) {
+    if (m_renderParam->IsRenderShouldBeRestarted() ||
+        rprApiConst->IsChanged()) {
         for (auto& aovBinding : renderPassState->GetAovBindings()) {
             if (aovBinding.renderBuffer) {
                 auto rprRenderBuffer = static_cast<HdRprRenderBuffer*>(aovBinding.renderBuffer);


### PR DESCRIPTION
### PURPOSE
Restart render thread automatically after manipulations with HdRprApi

### EFFECT OF CHANGE
RprApiSafeWrapper is created when RprApi is requested for editing. It stops the render thread and resumes it when the editing is finished. The change takes into account that RprApi can be requested simultaneously from multiple threads, and restarts the render thread only when the last instance of RprApiSafeWrapper is destroyed.
This change fixes the problem of the render thread not restarting if no changes are made.