### PR TITLE
render vars issue fix

### DIFF
--- a/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
+++ b/pxr/imaging/plugin/hdRpr/aovDescriptor.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-const HdRprAovDescriptor kInvalidDesc(0, true, HdFormatInvalid);
+const HdRprAovDescriptor kInvalidDesc;
 
 TF_INSTANTIATE_SINGLETON(HdRprAovRegistry);
 TF_DEFINE_PUBLIC_TOKENS(HdRprAovTokens, HDRPR_AOV_TOKENS);


### PR DESCRIPTION
### PURPOSE
Resolves https://amdrender.atlassian.net/browse/RPRHOUD-98

Cancels changes made in aovDescriptor, that lead to a failure for some reason. I'll investigate the cause later.