### PR TITLE
Fix materialX problems from PR 703

### DIFF
--- a/pxr/imaging/rprUsd/hdMtlxFixed.cpp
+++ b/pxr/imaging/rprUsd/hdMtlxFixed.cpp
@@ -316,15 +316,15 @@ _GatherUpstreamNodes(
             mx::NodePtr mxNextNode = *mxUpstreamNode;
 
             mx::OutputPtr mxOutput = mxNextNode->getOutput(currConnection.upstreamOutputName);
-            if (!mxOutput) {
-              mxOutput = mxNextNode->addOutput(currConnection.upstreamOutputName);
+            if (!mxOutput && mxNextNode->getType() == "multioutput") {
+                mxOutput = mxNextNode->addOutput(currConnection.upstreamOutputName);
             }
 
             // Make sure to not add the same input twice
             mx::InputPtr mxInput = mxCurrNode->getInput(connName);
             if (!mxInput){
-              mxInput = mxCurrNode->addInput(connName, mxNextNode->getType() == "multioutput" ?
-                mxOutput->getType() : mxNextNode->getType());
+                mxInput = mxCurrNode->addInput(connName, mxNextNode->getType() == "multioutput" ?
+                  mxOutput->getType() : mxNextNode->getType());
             }
             mxInput->setConnectedNode(mxNextNode);
         }


### PR DESCRIPTION
### PURPOSE
After merging PR 703 there was a problem with some materials in HybridPro

### EFFECT OF CHANGE
For now materialX materials can be rendered with HybridPro without any issues
