### PR TITLE
Remove RIF denoising and upscaling from schema

### DIFF
--- a/pxr/imaging/rprUsd/schema.usda
+++ b/pxr/imaging/rprUsd/schema.usda
@@ -461,7 +461,7 @@ class "RprRendererSettingsAPI" (
     )
 
     # Hybrid only
-    uniform token hybrid:upscalingQuality = "Ultra Performance" (
+    uniform token rpr:hybrid:upscalingQuality = "Ultra Performance" (
         allowedTokens = ["Ultra Quality", "Quality", "Balance", "Performance", "Ultra Performance"]
         displayName = "Viewport Upscaling Quality"
         displayGroup = "Postprocessing|Upscale"

--- a/pxr/imaging/rprUsd/schema.usda
+++ b/pxr/imaging/rprUsd/schema.usda
@@ -461,7 +461,7 @@ class "RprRendererSettingsAPI" (
     )
 
     # Hybrid only
-    uniform token rpr:viewportUpscalingQuality = "Ultra Performance" (
+    uniform token hybrid:upscalingQuality = "Ultra Performance" (
         allowedTokens = ["Ultra Quality", "Quality", "Balance", "Performance", "Ultra Performance"]
         displayName = "Viewport Upscaling Quality"
         displayGroup = "Postprocessing|Upscale"

--- a/pxr/imaging/rprUsd/schema.usda
+++ b/pxr/imaging/rprUsd/schema.usda
@@ -205,23 +205,6 @@ class "RprRendererSettingsAPI" (
         rprMinValue = 0
     )
 
-
-    # not for < High
-    uniform bool rpr:denoising:enable = false (
-        displayGroup = "Postprocessing|Denoise"
-        displayName = "Enable AI Denoise"
-    )
-    uniform int rpr:denoising:minIter = 4 (
-        displayGroup = "Postprocessing|Denoise"
-        displayName = "Min Iteration"
-        rprMinValue = 1
-    )
-    uniform int rpr:denoising:iterStep = 32 (
-        displayGroup = "Postprocessing|Denoise"
-        displayName = "Iteration Step"
-        rprMinValue = 1
-    )
-
     # not for low
     uniform int rpr:maxSamples = 128 (
         displayGroup = "Sampling"
@@ -476,11 +459,7 @@ class "RprRendererSettingsAPI" (
         displayGroup = "Export .rpr"
         rprHidden = 1
     )
-    
-    uniform bool rpr:viewportUpscaling = false (
-        displayGroup = "Postprocessing|Upscale"
-        displayName = "Viewport Upscaling"
-    )
+
     # Hybrid only
     uniform token rpr:viewportUpscalingQuality = "Ultra Performance" (
         allowedTokens = ["Ultra Quality", "Quality", "Balance", "Performance", "Ultra Performance"]


### PR DESCRIPTION
### PURPOSE
Schema contains descriptions for RIF upscaling and denoising, which were removed in PR #704

### EFFECT OF CHANGE
This PR removes outdated parameters from USD schema

