### PR TITLE
Vertex alpha

### DIFF
--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -851,6 +851,17 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
             }
         }
 
+        if (!newMesh && (*dirtyBits & HdChangeTracker::DirtyMaterialId)) {
+            for (auto& rprMesh : m_rprMeshes) {
+                if (!m_colorSamples.empty()) {
+                    m_colorsSet = rprApi->SetMeshVertexColor(rprMesh, m_colorSamples, m_colorInterpolation);
+                }
+                if (!m_opacitySamples.empty()) {
+                    m_opacitySet = rprApi->SetMeshVertexOpacity(rprMesh, m_opacitySamples, m_opacityInterpolation);
+                }
+            }
+        }
+
         if (updateTransform) {
             for (auto& rprMesh : m_rprMeshes) {
                 rprApi->SetTransform(rprMesh, m_transformSamples.count, m_transformSamples.times.data(), m_transformSamples.values.data());

--- a/pxr/imaging/plugin/hdRpr/mesh.cpp
+++ b/pxr/imaging/plugin/hdRpr/mesh.cpp
@@ -620,7 +620,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                             if (newPoint) {
                                 for (int sampleIndex = 0; sampleIndex < m_uvSamples.size(); ++sampleIndex) {
                                     if (sampleIndex >= m_colorSamples.size() || pointIndex >= m_colorSamples[sampleIndex].size()) {
-                                        TF_WARN("Failed verification sampleIndex >= m_colorSamples.size() || pointIndex >= m_colorSamples[sampleIndex].size()");
+                                        TF_WARN("Vertex index does not match displayColor primvar size");
                                         continue;
                                     }
                                     subsetColorSamples[sampleIndex].push_back(m_colorSamples[sampleIndex][pointIndex]);
@@ -632,7 +632,7 @@ void HdRprMesh::Sync(HdSceneDelegate* sceneDelegate,
                             if (newPoint) {
                                 for (int sampleIndex = 0; sampleIndex < m_uvSamples.size(); ++sampleIndex) {
                                     if (sampleIndex >= m_opacitySamples.size() || pointIndex >= m_opacitySamples[sampleIndex].size()) {
-                                        TF_WARN("Failed verification sampleIndex >= m_opacitySamples.size() || pointIndex >= m_opacitySamples[sampleIndex].size()");
+                                        TF_WARN("Vertex index does not match displayOpacity primvar size");
                                         continue;
                                     }
                                     subsetOpacitySamples[sampleIndex].push_back(m_opacitySamples[sampleIndex][pointIndex]);

--- a/pxr/imaging/plugin/hdRpr/mesh.h
+++ b/pxr/imaging/plugin/hdRpr/mesh.h
@@ -88,6 +88,11 @@ private:
     bool m_authoredColors = false;
     bool m_colorsSet = false;
 
+    VtArray<VtFloatArray> m_opacitySamples;
+    HdInterpolation m_opacityInterpolation;
+    bool m_authoredOpacity = false;
+    bool m_opacitySet = false;
+
     VtArray<VtVec2fArray> m_uvSamples;
     VtIntArray m_uvIndices;
 

--- a/pxr/imaging/plugin/hdRpr/rprApi.cpp
+++ b/pxr/imaging/plugin/hdRpr/rprApi.cpp
@@ -442,6 +442,9 @@ private:
 
 class HdRprApiImpl {
 public:
+    static const int colorPrimvarKey = 0;
+    static const int transparencyPrimvarKey = 1;
+
     HdRprApiImpl(HdRprDelegate* delegate)
         : m_delegate(delegate) {
         // Postpone initialization as further as possible to allow Hydra user to set custom render settings before creating a context
@@ -866,11 +869,33 @@ public:
         }
     }
 
+    bool convertInterpolation(HdInterpolation interpolation, rpr::PrimvarInterpolationType& rprInterpolation) {
+        switch (interpolation)
+        {
+        case HdInterpolationConstant:
+            rprInterpolation = RPR_PRIMVAR_INTERPOLATION_CONSTANT;
+            break;
+        case HdInterpolationUniform:
+            rprInterpolation = RPR_PRIMVAR_INTERPOLATION_UNIFORM;
+            break;
+        case HdInterpolationVertex:
+            rprInterpolation = RPR_PRIMVAR_INTERPOLATION_VERTEX;
+            break;
+        case HdInterpolationVarying:
+            rprInterpolation = RPR_PRIMVAR_INTERPOLATION_FACEVARYING_NORMAL;
+            break;
+        case HdInterpolationFaceVarying:
+            rprInterpolation = RPR_PRIMVAR_INTERPOLATION_FACEVARYING_UV;
+            break;
+        default:
+            // Rpr does not support HdInterpolationInstance
+            return false;
+        }
+
+        return true;
+    }
+
     bool SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation) {
-
-        // We use zero primvar channel to store vertex colors
-        const int colorPrimvarKey = 0;
-
         if (primvarSamples.empty()) {
             return false;
         }
@@ -878,26 +903,7 @@ public:
             LockGuard rprLock(m_rprContext->GetMutex());
 
             rpr::PrimvarInterpolationType rprInterpolation;
-
-            switch (interpolation)
-            {
-            case HdInterpolationConstant:
-                rprInterpolation = RPR_PRIMVAR_INTERPOLATION_CONSTANT;
-                break;
-            case HdInterpolationUniform:
-                rprInterpolation = RPR_PRIMVAR_INTERPOLATION_UNIFORM;
-                break;
-            case HdInterpolationVertex:
-                rprInterpolation = RPR_PRIMVAR_INTERPOLATION_VERTEX;
-                break;
-            case HdInterpolationVarying:
-                rprInterpolation = RPR_PRIMVAR_INTERPOLATION_FACEVARYING_NORMAL;
-                break;
-            case HdInterpolationFaceVarying:
-                rprInterpolation = RPR_PRIMVAR_INTERPOLATION_FACEVARYING_UV;
-                break;
-            default:
-                // Rpr does not support HdInterpolationInstance
+            if (!convertInterpolation(interpolation, rprInterpolation)) {
                 return false;
             }
             try {
@@ -905,6 +911,36 @@ public:
             }
             catch (RprUsdError& e) {
                 TF_RUNTIME_ERROR("Failed to set vertex color: %s", e.what());
+                return false;
+            }
+
+            m_dirtyFlags |= ChangeTracker::DirtyScene;
+            return true;
+        }
+        return false;
+    }
+
+    bool SetMeshVertexOpacity(rpr::Shape* mesh, VtArray<VtFloatArray> const& primvarSamples, HdInterpolation interpolation) {
+        if (primvarSamples.empty()) {
+            return false;
+        }
+        if (m_rprContextMetadata.pluginType == kPluginNorthstar) {
+            LockGuard rprLock(m_rprContext->GetMutex());
+
+            rpr::PrimvarInterpolationType rprInterpolation;
+            if (!convertInterpolation(interpolation, rprInterpolation)) {
+                return false;
+            }
+            try {
+                // converting opacity to transparency
+                VtFloatArray opacitySamples = primvarSamples[0];
+                for (size_t i = 0; i < opacitySamples.size(); ++i) {
+                    opacitySamples[i] = 1.0f - opacitySamples[i];
+                }
+                RPR_ERROR_CHECK_THROW(mesh->SetPrimvar(transparencyPrimvarKey, (rpr_float const*)opacitySamples.cdata(), opacitySamples.size(), 1, rprInterpolation), "Failed to set color primvars");
+            }
+            catch (RprUsdError& e) {
+                TF_RUNTIME_ERROR("Failed to set vertex opacity: %s", e.what());
                 return false;
             }
 
@@ -1419,47 +1455,56 @@ public:
         }
     }
 
-    RprUsdMaterial* CreatePrimvarColorLookupMaterial() {
+    RprUsdMaterial* CreatePrimvarColorLookupMaterial(bool isColorSet, bool isOpacitySet) {
         if (!m_rprContext) {
             return nullptr;
         }
 
         LockGuard rprLock(m_rprContext->GetMutex());
 
-        class HdRprApiPrimvarColorLookupMaterial : public RprUsdMaterial {
+        class HdRprApiPrimvarLookupMaterial : public RprUsdMaterial {
         public:
-            HdRprApiPrimvarColorLookupMaterial(rpr::Context* context) {
+            HdRprApiPrimvarLookupMaterial(rpr::Context* context, bool isColorSet, bool isOpacitySet) {
                 rpr::Status status;
-
-                m_primvarLookupNode.reset(context->CreateMaterialNode(RPR_MATERIAL_NODE_PRIMVAR_LOOKUP, &status));
-                if (!m_primvarLookupNode) {
-                    RPR_ERROR_CHECK_THROW(status, "Failed to create primvar lookup node");
-                }
-
-                // we use zero primvar channel to store vertex color values
-                status = m_primvarLookupNode->SetInput(RPR_MATERIAL_INPUT_VALUE, (rpr_uint) 0);
-                if (status != RPR_SUCCESS) {
-                    RPR_ERROR_CHECK_THROW(status, "Failed to set lookup node input value");
-                }
-
                 m_uberNode.reset(context->CreateMaterialNode(RPR_MATERIAL_NODE_UBERV2, &status));
                 if (!m_uberNode) {
                     RPR_ERROR_CHECK_THROW(status, "Failed to create uber node");
                 }
-                RPR_ERROR_CHECK_THROW(m_uberNode->SetInput(RPR_MATERIAL_INPUT_UBER_DIFFUSE_COLOR, m_primvarLookupNode.get()), "Failed to set root material diffuse color");
+                
+                if (isColorSet) {
+                    createLookupNode(context, m_primvarColorLookupNode, colorPrimvarKey);
+                    RPR_ERROR_CHECK_THROW(m_uberNode->SetInput(RPR_MATERIAL_INPUT_UBER_DIFFUSE_COLOR, m_primvarColorLookupNode.get()), "Failed to set root material diffuse color");
+                }
+                if (isOpacitySet) {
+                    createLookupNode(context, m_primvarOpacityLookupNode, transparencyPrimvarKey);
+                    RPR_ERROR_CHECK_THROW(m_uberNode->SetInput(RPR_MATERIAL_INPUT_UBER_TRANSPARENCY, m_primvarOpacityLookupNode.get()), "Failed to set root material transparancy");
+                }
 
                 m_surfaceNode = m_uberNode.get();
             };
 
-            ~HdRprApiPrimvarColorLookupMaterial() final = default;
+            ~HdRprApiPrimvarLookupMaterial() final = default;
 
         private:
-            std::unique_ptr<rpr::MaterialNode> m_primvarLookupNode;
+            void createLookupNode(rpr::Context* context, std::unique_ptr<rpr::MaterialNode>& lookupNode, rpr_uint key) {
+                rpr::Status status;
+                lookupNode.reset(context->CreateMaterialNode(RPR_MATERIAL_NODE_PRIMVAR_LOOKUP, &status));
+                if (!lookupNode) {
+                    RPR_ERROR_CHECK_THROW(status, "Failed to create primvar lookup node");
+                }
+                status = lookupNode->SetInput(RPR_MATERIAL_INPUT_VALUE, key);
+                if (status != RPR_SUCCESS) {
+                    RPR_ERROR_CHECK_THROW(status, "Failed to set lookup node input value");
+                }
+            }
+
+            std::unique_ptr<rpr::MaterialNode> m_primvarColorLookupNode;
+            std::unique_ptr<rpr::MaterialNode> m_primvarOpacityLookupNode;
             std::unique_ptr<rpr::MaterialNode> m_uberNode;
         };
 
         try {
-            return new HdRprApiPrimvarColorLookupMaterial(m_rprContext.get());
+            return new HdRprApiPrimvarLookupMaterial(m_rprContext.get(), isColorSet, isOpacitySet);
         }
         catch (RprUsdError& e) {
             TF_RUNTIME_ERROR("Failed to create points material: %s", e.what());
@@ -4815,9 +4860,9 @@ RprUsdMaterial* HdRprApi::CreateDiffuseMaterial(GfVec3f const& color) {
     });
 }
 
-RprUsdMaterial* HdRprApi::CreatePrimvarColorLookupMaterial(){
+RprUsdMaterial* HdRprApi::CreatePrimvarLookupMaterial(bool isColorSet, bool isOpacitySet){
     m_impl->InitIfNeeded();
-    return m_impl->CreatePrimvarColorLookupMaterial();
+    return m_impl->CreatePrimvarColorLookupMaterial(isColorSet, isOpacitySet);
 }
 
 void HdRprApi::SetMeshRefineLevel(rpr::Shape* mesh, int level, const float creaseWeight) {
@@ -4846,6 +4891,10 @@ void HdRprApi::SetMeshIgnoreContour(rpr::Shape* mesh, bool ignoreContour) {
 
 bool HdRprApi::SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation) {
     return m_impl->SetMeshVertexColor(mesh, primvarSamples, interpolation);
+}
+
+bool HdRprApi::SetMeshVertexOpacity(rpr::Shape* mesh, VtArray<VtFloatArray> const& primvarSamples, HdInterpolation interpolation) {
+    return m_impl->SetMeshVertexOpacity(mesh, primvarSamples, interpolation);
 }
 
 void HdRprApi::SetCurveMaterial(rpr::Curve* curve, RprUsdMaterial const* material) {

--- a/pxr/imaging/plugin/hdRpr/rprApi.h
+++ b/pxr/imaging/plugin/hdRpr/rprApi.h
@@ -118,7 +118,7 @@ public:
     RprUsdMaterial* CreateMaterial(SdfPath const& materialId, HdSceneDelegate* sceneDelegate, HdMaterialNetworkMap const& materialNetwork);
     RprUsdMaterial* CreatePointsMaterial(VtVec3fArray const& colors);
     RprUsdMaterial* CreateDiffuseMaterial(GfVec3f const& color);
-    RprUsdMaterial* CreatePrimvarColorLookupMaterial();
+    RprUsdMaterial* CreatePrimvarLookupMaterial(bool isColorSet, bool isOpacitySet);
     void Release(RprUsdMaterial* material);
 
     rpr::Shape* CreateMesh(VtVec3fArray const& points, VtIntArray const& pointIndexes, VtVec3fArray const& normals, VtIntArray const& normalIndexes, VtVec2fArray const& uvs, VtIntArray const& uvIndexes, VtIntArray const& vpf, TfToken const& polygonWinding);
@@ -131,6 +131,7 @@ public:
     void SetMeshId(rpr::Shape* mesh, uint32_t id);
     void SetMeshIgnoreContour(rpr::Shape* mesh, bool ignoreContour);
     bool SetMeshVertexColor(rpr::Shape* mesh, VtArray<VtVec3fArray> const& primvarSamples, HdInterpolation interpolation);
+    bool SetMeshVertexOpacity(rpr::Shape* mesh, VtArray<VtFloatArray> const& primvarSamples, HdInterpolation interpolation);
     void Release(rpr::Shape* shape);
 
     rpr::Curve* CreateCurve(VtVec3fArray const& points, VtIntArray const& indices, VtFloatArray const& radiuses, VtVec2fArray const& uvs, VtIntArray const& segmentPerCurve);

--- a/pxr/imaging/rprUsd/materialMappings.cpp
+++ b/pxr/imaging/rprUsd/materialMappings.cpp
@@ -43,6 +43,7 @@ bool ToRpr(TfToken const& id, rpr::MaterialNodeType* out, bool pedantic) {
         {RprUsdMaterialNodeTypeTokens->checker_texture, RPR_MATERIAL_NODE_CHECKER_TEXTURE},
         {RprUsdMaterialNodeTypeTokens->constant_texture, RPR_MATERIAL_NODE_CONSTANT_TEXTURE},
         {RprUsdMaterialNodeTypeTokens->input_lookup, RPR_MATERIAL_NODE_INPUT_LOOKUP},
+        {RprUsdMaterialNodeTypeTokens->primvar_lookup, RPR_MATERIAL_NODE_PRIMVAR_LOOKUP},
         {RprUsdMaterialNodeTypeTokens->blend_value, RPR_MATERIAL_NODE_BLEND_VALUE},
         {RprUsdMaterialNodeTypeTokens->passthrough, RPR_MATERIAL_NODE_PASSTHROUGH},
         {RprUsdMaterialNodeTypeTokens->orennayar, RPR_MATERIAL_NODE_ORENNAYAR},
@@ -207,6 +208,8 @@ bool ToRpr(TfToken const& id, uint32_t* out, bool pedantic) {
         {RprUsdMaterialInputModeTokens->cylindical, RPR_MATERIAL_NODE_UVTYPE_CYLINDICAL},
         {RprUsdMaterialInputModeTokens->spherical, RPR_MATERIAL_NODE_UVTYPE_SPHERICAL},
         {RprUsdMaterialInputModeTokens->project, RPR_MATERIAL_NODE_UVTYPE_PROJECT},
+        {RprUsdMaterialInputModeTokens->displayColor, 0},
+        {RprUsdMaterialInputModeTokens->displayOpacity, 1},
     };
 
     auto it = s_mapping.find(id);

--- a/pxr/imaging/rprUsd/materialMappings.h
+++ b/pxr/imaging/rprUsd/materialMappings.h
@@ -141,6 +141,7 @@ bool ToRpr(TfToken const& id, uint32_t* out, bool pedantic = true);
     (checker_texture) \
     (constant_texture) \
     (input_lookup) \
+    (primvar_lookup) \
     (blend_value) \
     (passthrough) \
     (orennayar) \

--- a/pxr/imaging/rprUsd/materialMappings.h
+++ b/pxr/imaging/rprUsd/materialMappings.h
@@ -183,6 +183,9 @@ bool ToRpr(TfToken const& id, uint32_t* out, bool pedantic = true);
     ((localPosition, "Local Position")) \
     ((shapeRandomColor, "Shape Random Color")) \
     ((objectId, "Object Id")) \
+    /* Lookup primvar */ \
+    ((displayColor, "displayColor")) \
+    ((displayOpacity, "displayOpacity")) \
     /* UV Type */ \
     ((planar, "Flat Plane")) \
     ((cylindical, "Cylinder (in xy direction)")) \

--- a/pxr/imaging/rprUsd/materialNodes/mtlxFiles/CMakeLists.txt
+++ b/pxr/imaging/rprUsd/materialNodes/mtlxFiles/CMakeLists.txt
@@ -14,6 +14,7 @@ set(MTLX_FILES
     Utilities/rpr_hsv_to_rgb.mtlx
 
     Utilities/rpr_input_lookup.mtlx
+    Utilities/rpr_primvar_lookup.mtlx
 
     Utilities/rpr_uv_triplanar.mtlx
     Utilities/rpr_uv_procedural.mtlx

--- a/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Utilities/rpr_primvar_lookup.mtlx
+++ b/pxr/imaging/rprUsd/materialNodes/mtlxFiles/Utilities/rpr_primvar_lookup.mtlx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<materialx version="1.37">
+  <nodedef name="ND_rpr_primvar_lookup" node="rpr_primvar_lookup" uiname="RPR Primvar Lookup" doc="Reads a value from Primvar channel.">
+      <input name="value" type="string" value="displayColor" enum="displayColor,displayOpacity" uiname="Value" doc="Value to lookup."/>
+      <output name="out" type="vector3" />
+  </nodedef>
+</materialx>


### PR DESCRIPTION
### PURPOSE
Resolves https://amdrender.atlassian.net/browse/RPRHOUD-43
Added support for displayOpacity in meshes, and lookup node to control color/opacity primvars

### NOTES FOR REVIEWERS
to use color/alpha vertex data, rpr_primvar_lookup node is implemented.
