### PR TITLE
Update Houdini integration for version 20 and elaborate README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ project(hdRpr)
 
 cmake_minimum_required(VERSION 3.15)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/defaults
                       ${CMAKE_SOURCE_DIR}/cmake/modules
                       ${CMAKE_SOURCE_DIR}/cmake/macros)
@@ -26,8 +29,6 @@ add_definitions(${_PXR_CXX_DEFINITIONS})
 set(CMAKE_CXX_FLAGS "${_PXR_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 include(Public)
-
-set(CMAKE_CXX_STANDARD 14)
 
 add_subdirectory(deps)
 add_subdirectory(pxr/imaging)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Cloning into 'RadeonProRenderUSD'...
 Provide USD in one of two ways:
 
 * An installation of USD. Define pxr_DIR to point to it when running cmake, if required. You can download USD to build yourself from [GitHub](https://www.github.com/PixarAnimationStudios/USD). It should be built with OpenEXR libraries and usdGenSchema tool.
-* The USD which is provided with Houdini. The HFS environment variable should point to the Houdini installation (the correct way is to run cmake from Houdini's `Command Line Tools` or by sourcing `houdini_setup`). You can download Houdini installer from [Downloads | SideFX](https://www.sidefx.com/download).
+* The USD which is provided with Houdini. The HFS environment variable should point to the Houdini installation (the correct way is to run cmake from Houdini's `Command Line Tools` or by sourcing `houdini_setup`). You can download Houdini installer from [Downloads | SideFX](https://www.sidefx.com/download). Providing correct `HFS` environment variable should also supply the Python version according to the Houdini engine.
 
 ##### MaterialX Component
 

--- a/cmake/modules/FindHoudiniUSD.cmake
+++ b/cmake/modules/FindHoudiniUSD.cmake
@@ -41,7 +41,7 @@ endif(APPLE)
 set(Houdini_Python_VARS Houdini_Python_INCLUDE_DIR Houdini_Python_LIB Houdini_Boostpython_LIB)
 list(APPEND HUSD_REQ_VARS ${Houdini_Python_VARS})
 
-foreach(python_major_minor "3;9" "3;7" "2;7")
+foreach(python_major_minor "3;12" "3;11" "3;10" "3;9" "3;7" "2;7")
     list(GET python_major_minor 0 py_major)
     list(GET python_major_minor 1 py_minor)
 

--- a/pxr/imaging/plugin/hdRpr/domeLight.cpp
+++ b/pxr/imaging/plugin/hdRpr/domeLight.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include "pxr/base/arch/env.h"
 
 #ifdef BUILD_AS_HOUDINI_PLUGIN
+#include <UT/UT_HDKVersion.h>
 #include <HOM/HOM_Module.h>
 #include <HOM/HOM_ui.h>
 #include <HOM/HOM_text.h>
@@ -64,15 +65,25 @@ static float computeLightIntensity(float intensity, float exposure) {
 
 #ifdef BUILD_AS_HOUDINI_PLUGIN
 
-HOM_Node* FindNodeById(HOM_Node* node, const std::string& id) {
+#if HDK_API_VERSION >= 20000000
+#define HOM_NODE HOM_OpNode
+#else
+#define HOM_NODE HOM_Node
+#endif
+
+HOM_NODE* FindNodeById(HOM_Node* node, const std::string& id) {
     auto schildren = node->children();
     for (HOM_ElemPtr<HOM_Node>& sc : schildren) {
-        HOM_Parm* p = sc.myPointer->parm("primpath");
+        HOM_NODE* nd = dynamic_cast<HOM_NODE*>(sc.myPointer);
+        if (!nd) {
+            continue;
+        }
+        HOM_Parm* p = nd->parm("primpath");
         if (p && p->evalAsString() == id) {
-            return sc.myPointer;
+            return nd;
         }
 
-        HOM_Node* foundInSubnodes = FindNodeById(sc.myPointer, id);
+        HOM_NODE* foundInSubnodes = FindNodeById(sc.myPointer, id);
         if (foundInSubnodes) {
             return foundInSubnodes;
         }
@@ -80,12 +91,12 @@ HOM_Node* FindNodeById(HOM_Node* node, const std::string& id) {
     return nullptr;
 }
 
-HOM_Node* FindNodeById(HOM_Module& hou, const std::string& id) {
+HOM_NODE* FindNodeById(HOM_Module& hou, const std::string& id) {
     HOM_Node* sceneNode = hou.node("/stage");
     return FindNodeById(sceneNode, id);
 }
 
-void CreateSceneBackgroundOverrideParms(HOM_Module& hou, HOM_Node* node) {
+void CreateSceneBackgroundOverrideParms(HOM_Module& hou, HOM_NODE* node) {
     HOM_StdMapStringString enableTags;
     enableTags.insert(std::pair<std::string, std::string>("usdvaluetype", "bool"));
     HOM_StdMapStringString colorTags;
@@ -111,7 +122,7 @@ void CreateSceneBackgroundOverrideParms(HOM_Module& hou, HOM_Node* node) {
     node->setParmTemplateGroup(*group);
 }
 
-void SetSceneBackgroundOverride(HOM_Module& hou, HOM_Node* node, HdRprApi::BackgroundOverride & override) {
+void SetSceneBackgroundOverride(HOM_Module& hou, HOM_NODE* node, HdRprApi::BackgroundOverride & override) {
     if (!node) {
         return;
     }
@@ -173,7 +184,7 @@ HdRprApi::BackgroundOverride BackgroundOverrideSettings(HdSceneDelegate* sceneDe
                 result.color = GfVec3f(1.0f);
             }
         }
-        HOM_Node* node = FindNodeById(hou, nodeId.GetAsString());
+        HOM_NODE* node = FindNodeById(hou, nodeId.GetAsString());
         if (node) {
             SetSceneBackgroundOverride(hou, node, result);
         }
@@ -191,7 +202,7 @@ void CreateOverrideEnableParmIfNeeded(const SdfPath& nodeId) {
         return;
     }
 
-    HOM_Node* node = FindNodeById(hou, nodeId.GetAsString());
+    HOM_NODE* node = FindNodeById(hou, nodeId.GetAsString());
     if (node) {
         HOM_text& text = hou.text();
         HOM_Parm* enableParm = node->parm(text.encode("rpr:backgroundOverride:enable").c_str());


### PR DESCRIPTION
### PURPOSE

This PR fixes compile issues that occur during build with version 20 of the Houdini engine. Additionally, a small note about Python version with HFS environment variable was put to make it easier for people to adjust to the build environment.

### EFFECT OF CHANGE

Makes it possible to use the plugin with version 20.

### TECHNICAL STEPS

In domeLight.cpp, a compile-time check occurs with `HDK_API_VERSION >= 20000000` to choose the correct type. This pattern is also visible in VOP_RPRMaterial.(h|cpp), where HDK_API_VERSION helps to distinguish. But in case the plugin source does not care about version compatibility, I think this code can be made more concise by not checking for version.

### NOTES FOR REVIEWERS

The build was confirmed working with an Indie installation of Houdini version 20.

Please let me know if there's a documented minimum supported Houdini or if it is commit based (for example, latest commit works on 19, merge will be only 20+ etc.), and I can simplify accordingly if that's a viable path.

Thank you!