### PR TITLE
Gitignore alternative build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-build/*
+build*/*
 pxr/imaging/plugin/hdRpr/python/__pycache__/
 .vscode


### PR DESCRIPTION
It is convenient to have multiple top-level build directories distinguished by suffix, like `build-20`, `build-19`, etc. for developer experience