### PR TITLE
Fix build error with strings

### DIFF
--- a/pxr/imaging/rprUsd/config.h
+++ b/pxr/imaging/rprUsd/config.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <mutex>
 #include <memory>
+#include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
 


### PR DESCRIPTION
Building RadeonProRenderUSD on Ubuntu 24.04 using CMake 3.28, GCC 13, Houdini 20.5.417, OpenMP, and other dependencies with RelWithDebInfo configuration.

### PURPOSE

To fix the following error:

```bash
.../RadeonProRenderUSD/pxr/imaging/rprUsd/config.h:63:17: error: field ‘m_filepath’ has incomplete type ‘std::string’ {aka ‘std::basic_string<char>’}
   63 |     std::string m_filepath;
      |                 ^~~~~~~~~~
In file included from /usr/include/c++/13/iosfwd:41,
                 from /usr/include/c++/13/bits/shared_ptr.h:52,
                 from /usr/include/c++/13/memory:80,
                 from 
```

### EFFECT OF CHANGE

Fixes the build error.

### TECHNICAL STEPS

Includes `<string>`.

### NOTES FOR REVIEWERS

Thank you!
